### PR TITLE
Adjust zstd parameters to better match zstd's cli levels and parameters

### DIFF
--- a/_lzbench/compressors.cpp
+++ b/_lzbench/compressors.cpp
@@ -1624,14 +1624,18 @@ int64_t lzbench_zstd_compress(char *inbuf, size_t insize, char *outbuf, size_t o
     if (!cctx) return 0;
 
     ZSTD_parameters params;
-    memset(&params, 0, sizeof(params));
-    params.cParams = ZSTD_getCParams(level, insize, 0);
+    params = ZSTD_getParams(level, insize, 0);
     params.fParams.contentSizeFlag = 1;
     if (windowLog)
     {
         params.cParams.windowLog = windowLog;
-        params.cParams.chainLog = windowLog + ((params.cParams.strategy == ZSTD_btlazy2) || (params.cParams.strategy == ZSTD_btopt));
     }
+    else
+    {
+        params.cParams.windowLog = MIN(23, params.cParams.windowLog);
+    }
+    params.cParams.chainLog = params.cParams.windowLog + ((params.cParams.strategy == ZSTD_btlazy2) || (params.cParams.strategy == ZSTD_btopt));
+    params.cParams = ZSTD_adjustCParams(params.cParams, insize, 0);
 
     res = ZSTD_compressBegin_advanced(cctx, NULL, 0, params, insize);
     if (ZSTD_isError(res)) return res;

--- a/_lzbench/lzbench.h
+++ b/_lzbench/lzbench.h
@@ -169,8 +169,7 @@ static const compressor_desc_t comp_desc[LZBENCH_COMPRESSOR_COUNT] =
     { "zlib",     "1.2.8",       1,   9,   0,       0, lzbench_zlib_compress,     lzbench_zlib_decompress,     NULL,                 NULL },
     { "zling",    "2016-01-10",  0,   4,   0,       0, lzbench_zling_compress,    lzbench_zling_decompress,    NULL,                 NULL },
     { "zstd",     "0.8.0",       1,  22,   0,       0, lzbench_zstd_compress,     lzbench_zstd_decompress,     NULL,                 NULL },
-    { "zstd22",   "0.8.0",       1,  22,  22,       0, lzbench_zstd_compress,     lzbench_zstd_decompress,     NULL,                 NULL },
-    { "zstd24",   "0.8.0",       1,  22,  24,       0, lzbench_zstd_compress,     lzbench_zstd_decompress,     NULL,                 NULL },
+    { "zstd_ult", "0.8.0",       20, 22,  27,       0, lzbench_zstd_compress,     lzbench_zstd_decompress,     NULL,                 NULL },
 };
 
 


### PR DESCRIPTION
This will effectively change the higher levels to match the command line tool which limits wlog to 23 (in zstd's fileio.c).  It should make performance more similar to what the command line obtains at the highest compression levels.

Open to suggestions on how to do this; the previous zstd22/zstd24 options don't quite seem to be the same, and being closer to the command line tool seems ideal.  I believe that zstd now matches the command line at all levels and zstd_ult matches the command line at levels 20-22 when --ultra is specified.

Also tweak some if the initialization functions to fit what (I believe) is the current API approach.