### PR TITLE
Touch pages in buffer allocations prior to running first algorithm to…

### DIFF
--- a/_lzbench/lzbench.h
+++ b/_lzbench/lzbench.h
@@ -12,6 +12,7 @@
 #define PROGNAME "lzbench"
 #define PROGVERSION "1.5"
 #define PAD_SIZE (16*1024)
+#define MIN_PAGE_SIZE 4096  // smallest page size we expect, if it's wrong the first algorithm might be a bit slower
 #define DEFAULT_LOOP_TIME (100*1000000)  // 1/10 of a second
 #define GET_COMPRESS_BOUND(insize) (insize + insize/6 + PAD_SIZE)  // for pithy
 #define LZBENCH_PRINT(level, fmt, ...) if (params->verbose >= level) printf(fmt, __VA_ARGS__)


### PR DESCRIPTION
This is a straightforward fix for issue #29 - basically the idea is to touch every 4096th byte after `malloc` or `calloc` such that the buffer is paged in, all PTEs set up, etc. On some architectures, the page size may be larger than 4096, but this works fine since it will still touch every page in that case (any "extra" touches are harmless).