### PR TITLE
Implement support for CUDA and nvcomp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ ifeq (1,$(filter 1,$(shell [ "$(COMPILER)" = "gcc" ] && expr $(GCC_VERSION) \< 6
   DONT_BUILD_ZLING ?= 1
 endif
 
-
 # detect Windows
 ifneq (,$(filter Windows%,$(OS)))
 	ifeq ($(COMPILER),clang)
@@ -279,7 +278,31 @@ ifeq "$(BENCH_HAS_NAKAMICHI)" "1"
     MISC_FILES += nakamichi/Nakamichi_Okamigan.o
 endif
 
+CUDA_BASE ?= /usr/local/cuda
+LIBCUDART=$(wildcard $(CUDA_BASE)/lib64/libcudart.so)
 
+ifneq "$(LIBCUDART)" ""
+    DEFINES += -DBENCH_HAS_CUDA -I$(CUDA_BASE)/include
+    LDFLAGS += -L$(CUDA_BASE)/lib64 -lcudart -Wl,-rpath=$(CUDA_BASE)/lib64
+    CUDA_COMPILER = nvcc
+    CUDA_CC = $(CUDA_BASE)/bin/nvcc --compiler-bindir $(CXX)
+    CUDA_ARCH = 50 60 70 80
+    CUDA_CFLAGS = -x cu -std=c++14 -O3 $(foreach ARCH, $(CUDA_ARCH), --generate-code=arch=compute_$(ARCH),code=[compute_$(ARCH),sm_$(ARCH)]) --expt-extended-lambda -forward-unknown-to-host-compiler -Wno-deprecated-gpu-targets
+else
+    CUDA_BASE =
+    LIBCUDART =
+endif
+
+ifneq "$(LIBCUDART)" ""
+ifneq "$(DONT_BUILD_NVCOMP)" "1"
+    DEFINES += -DBENCH_HAS_NVCOMP
+    NVCOMP_CPP_SRC = $(wildcard nvcomp/*.cpp)
+    NVCOMP_CPP_OBJ = $(NVCOMP_CPP_SRC:%=%.o)
+    NVCOMP_CU_SRC  = $(wildcard nvcomp/*.cu)
+    NVCOMP_CU_OBJ  = $(NVCOMP_CU_SRC:%=%.o)
+    NVCOMP_FILES   = $(NVCOMP_CU_OBJ) $(NVCOMP_CPP_OBJ)
+endif
+endif
 
 all: lzbench
 
@@ -310,10 +333,21 @@ nakamichi/Nakamichi_Okamigan.o: nakamichi/Nakamichi_Okamigan.c
 	@$(MKDIR) $(dir $@)
 	$(CC) $(CFLAGS) -mavx $< -c -o $@
 
+$(NVCOMP_CU_OBJ): %.cu.o: %.cu
+	@$(MKDIR) $(dir $@)
+	$(CUDA_CC) $(CUDA_CFLAGS) $(CFLAGS) -c $< -o $@
+
+$(NVCOMP_CPP_OBJ): %.cpp.o: %.cpp
+	@$(MKDIR) $(dir $@)
+	$(CXX) $(CFLAGS) -c $< -o $@
+
+# disable the implicit rule for making a binary out of a single object file
+%: %.o
+
 
 _lzbench/lzbench.o: _lzbench/lzbench.cpp _lzbench/lzbench.h
 
-lzbench: $(BZIP2_FILES) $(DENSITY_FILES) $(FASTLZMA2_OBJ) $(ZSTD_FILES) $(GLZA_FILES) $(LZSSE_FILES) $(LZFSE_FILES) $(XPACK_FILES) $(GIPFELI_FILES) $(XZ_FILES) $(LIBLZG_FILES) $(BRIEFLZ_FILES) $(LZF_FILES) $(LZRW_FILES) $(BROTLI_FILES) $(CSC_FILES) $(LZMA_FILES) $(ZLING_FILES) $(QUICKLZ_FILES) $(SNAPPY_FILES) $(ZLIB_FILES) $(LZHAM_FILES) $(LZO_FILES) $(UCL_FILES) $(LZMAT_FILES) $(LZ4_FILES) $(LIBDEFLATE_FILES) $(MISC_FILES) $(LZBENCH_FILES)
+lzbench: $(BZIP2_FILES) $(DENSITY_FILES) $(FASTLZMA2_OBJ) $(ZSTD_FILES) $(GLZA_FILES) $(LZSSE_FILES) $(LZFSE_FILES) $(XPACK_FILES) $(GIPFELI_FILES) $(XZ_FILES) $(LIBLZG_FILES) $(BRIEFLZ_FILES) $(LZF_FILES) $(LZRW_FILES) $(BROTLI_FILES) $(CSC_FILES) $(LZMA_FILES) $(ZLING_FILES) $(QUICKLZ_FILES) $(SNAPPY_FILES) $(ZLIB_FILES) $(LZHAM_FILES) $(LZO_FILES) $(UCL_FILES) $(LZMAT_FILES) $(LZ4_FILES) $(LIBDEFLATE_FILES) $(MISC_FILES) $(NVCOMP_FILES) $(LZBENCH_FILES)
 	$(CXX) $^ -o $@ $(LDFLAGS)
 	@echo Linked GCC_VERSION=$(GCC_VERSION) CLANG_VERSION=$(CLANG_VERSION) COMPILER=$(COMPILER)
 
@@ -330,4 +364,4 @@ lzbench: $(BZIP2_FILES) $(DENSITY_FILES) $(FASTLZMA2_OBJ) $(ZSTD_FILES) $(GLZA_F
 	$(CXX) $(CFLAGS) $< -c -o $@
 
 clean:
-	rm -rf lzbench lzbench.exe *.o _lzbench/*.o bzip2/*.o fast-lzma2/*.o slz/*.o zstd/lib/*.o zstd/lib/*.a zstd/lib/common/*.o zstd/lib/compress/*.o zstd/lib/decompress/*.o zstd/lib/dictBuilder/*.o lzsse/lzsse2/*.o lzsse/lzsse4/*.o lzsse/lzsse8/*.o lzfse/*.o xpack/lib/*.o blosclz/*.o gipfeli/*.o xz/*.o xz/common/*.o xz/check/*.o xz/lzma/*.o xz/lz/*.o xz/rangecoder/*.o liblzg/*.o lzlib/*.o brieflz/*.o brotli/common/*.o brotli/enc/*.o brotli/dec/*.o libcsc/*.o wflz/*.o lzjb/*.o lzma/*.o density/buffers/*.o density/algorithms/*.o density/algorithms/cheetah/core/*.o density/algorithms/*.o density/algorithms/lion/forms/*.o density/algorithms/lion/core/*.o density/algorithms/chameleon/core/*.o density/*.o density/structure/*.o pithy/*.o glza/*.o libzling/*.o yappy/*.o shrinker/*.o fastlz/*.o ucl/*.o zlib/*.o lzham/*.o lzmat/*.o lizard/*.o lz4/*.o crush/*.o lzf/*.o lzrw/*.o lzo/*.o snappy/*.o quicklz/*.o tornado/*.o libdeflate/*.o libdeflate/x86/*.o libdeflate/arm/*.o nakamichi/*.o
+	rm -rf lzbench lzbench.exe *.o _lzbench/*.o bzip2/*.o fast-lzma2/*.o slz/*.o zstd/lib/*.o zstd/lib/*.a zstd/lib/common/*.o zstd/lib/compress/*.o zstd/lib/decompress/*.o zstd/lib/dictBuilder/*.o lzsse/lzsse2/*.o lzsse/lzsse4/*.o lzsse/lzsse8/*.o lzfse/*.o xpack/lib/*.o blosclz/*.o gipfeli/*.o xz/*.o xz/common/*.o xz/check/*.o xz/lzma/*.o xz/lz/*.o xz/rangecoder/*.o liblzg/*.o lzlib/*.o brieflz/*.o brotli/common/*.o brotli/enc/*.o brotli/dec/*.o libcsc/*.o wflz/*.o lzjb/*.o lzma/*.o density/buffers/*.o density/algorithms/*.o density/algorithms/cheetah/core/*.o density/algorithms/*.o density/algorithms/lion/forms/*.o density/algorithms/lion/core/*.o density/algorithms/chameleon/core/*.o density/*.o density/structure/*.o pithy/*.o glza/*.o libzling/*.o yappy/*.o shrinker/*.o fastlz/*.o ucl/*.o zlib/*.o lzham/*.o lzmat/*.o lizard/*.o lz4/*.o crush/*.o lzf/*.o lzrw/*.o lzo/*.o snappy/*.o quicklz/*.o tornado/*.o libdeflate/*.o libdeflate/x86/*.o libdeflate/arm/*.o nakamichi/*.o nvcomp/*.o

--- a/README.md
+++ b/README.md
@@ -122,6 +122,18 @@ see the [CompFuzz Results](https://github.com/nemequ/compfuzz/wiki/Results) page
  - [zstd 1.4.8](https://github.com/facebook/zstd)
 
 
+CUDA support
+-------------------------
+
+If CUDA is available, lzbench supports additional compressors:
+  - [cudaMemcpy](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY.html#group__CUDART__MEMORY_1gc263dbe6574220cc776b45438fc351e8) - similar to the reference `memcpy` benchmark, using GPU memory
+  - [nvcomp 1.2.2](https://github.com/NVIDIA/nvcomp) LZ4 GPU-only compressor
+
+The directory where the CUDA compiler and libraries are available can be passed to `make` via the `CUDA_BASE` variable, *e.g.*:
+```
+make CUDA_BASE=/usr/local/cuda
+```
+
 Benchmarks
 -------------------------
 

--- a/_lzbench/compressors.h
+++ b/_lzbench/compressors.h
@@ -505,5 +505,26 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 	#define lzbench_nakamichi_decompress NULL
 #endif
 
+#ifdef BENCH_HAS_CUDA
+        char* lzbench_cuda_init(size_t insize, size_t, size_t);
+        void lzbench_cuda_deinit(char* workmem);
+        int64_t lzbench_cuda_memcpy(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char* workmem);
+#else
+        #define lzbench_cuda_init NULL
+        #define lzbench_cuda_deinit NULL
+        #define lzbench_cuda_memcpy NULL
+#endif
+
+#ifdef BENCH_HAS_NVCOMP
+        char* lzbench_nvcomp_init(size_t insize, size_t level, size_t);
+        void lzbench_nvcomp_deinit(char* workmem);
+        int64_t lzbench_nvcomp_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem);
+        int64_t lzbench_nvcomp_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char* workmem);
+#else
+        #define lzbench_nvcomp_init NULL
+        #define lzbench_nvcomp_deinit NULL
+        #define lzbench_nvcomp_compress NULL
+        #define lzbench_nvcomp_decompress NULL
+#endif
 
 #endif // LZBENCH_COMPRESSORS_H

--- a/_lzbench/lzbench.cpp
+++ b/_lzbench/lzbench.cpp
@@ -869,6 +869,7 @@ int main( int argc, char** argv)
             printf("fast - alias for compressors with compression speed over 100 MB/s (default)\n");
             printf("opt - compressors with optimal parsing (slow compression, fast decompression)\n");
             printf("lzo / ucl - aliases for all levels of given compressors\n");
+            printf("cuda - alias for all CUDA-based compressors\n");
             for (int i=1; i<LZBENCH_COMPRESSOR_COUNT; i++)
             {
                 if (comp_desc[i].compress)

--- a/_lzbench/lzbench.h
+++ b/_lzbench/lzbench.h
@@ -137,16 +137,16 @@ typedef struct
 
 
 
-#define LZBENCH_COMPRESSOR_COUNT 71
+#define LZBENCH_COMPRESSOR_COUNT 73
 
 static const compressor_desc_t comp_desc[LZBENCH_COMPRESSOR_COUNT] =
 {
     { "memcpy",     "",            0,   0,    0,       0, lzbench_return_0,            lzbench_memcpy,                NULL,                    NULL },
     { "blosclz",    "2.0.0",       1,   9,    0, 64*1024, lzbench_blosclz_compress,    lzbench_blosclz_decompress,    NULL,                    NULL },
     { "brieflz",    "1.3.0",       1,   9,    0,       0, lzbench_brieflz_compress,    lzbench_brieflz_decompress,    lzbench_brieflz_init,    lzbench_brieflz_deinit },
-    { "brotli",     "1.0.9",  0,  11,    0,       0, lzbench_brotli_compress,     lzbench_brotli_decompress,     NULL,                    NULL },
-    { "brotli22",   "1.0.9",  0,  11,   22,       0, lzbench_brotli_compress,     lzbench_brotli_decompress,     NULL,                    NULL },
-    { "brotli24",   "1.0.9",  0,  11,   24,       0, lzbench_brotli_compress,     lzbench_brotli_decompress,     NULL,                    NULL },
+    { "brotli",     "1.0.9",       0,  11,    0,       0, lzbench_brotli_compress,     lzbench_brotli_decompress,     NULL,                    NULL },
+    { "brotli22",   "1.0.9",       0,  11,   22,       0, lzbench_brotli_compress,     lzbench_brotli_decompress,     NULL,                    NULL },
+    { "brotli24",   "1.0.9",       0,  11,   24,       0, lzbench_brotli_compress,     lzbench_brotli_decompress,     NULL,                    NULL },
     { "bzip2",      "1.0.8",       1,   9,    0,       0, lzbench_bzip2_compress,      lzbench_bzip2_decompress,      NULL,                    NULL },
     { "crush",      "1.0",         0,   2,    0,       0, lzbench_crush_compress,      lzbench_crush_decompress,      NULL,                    NULL },
     { "csc",        "2016-10-13",  1,   5,    0,       0, lzbench_csc_compress,        lzbench_csc_decompress,        NULL,                    NULL },
@@ -212,11 +212,13 @@ static const compressor_desc_t comp_desc[LZBENCH_COMPRESSOR_COUNT] =
     { "zstd22LDM",  "1.4.8",       1,  22,   22,       0, lzbench_zstd_LDM_compress,   lzbench_zstd_decompress,       lzbench_zstd_LDM_init,   lzbench_zstd_deinit },
     { "zstd24LDM",  "1.4.8",       1,  22,   24,       0, lzbench_zstd_LDM_compress,   lzbench_zstd_decompress,       lzbench_zstd_LDM_init,   lzbench_zstd_deinit },
     { "nakamichi",  "okamigan",    0,   0,    0,       0, lzbench_nakamichi_compress,  lzbench_nakamichi_decompress,  NULL,                    NULL },
+    { "cudaMemcpy", "",            0,   0,    0,       0, lzbench_return_0,            lzbench_cuda_memcpy,           lzbench_cuda_init,       lzbench_cuda_deinit },
+    { "nvcomp_lz4", "1.2.2",       0,   5,    0,       0, lzbench_nvcomp_compress,     lzbench_nvcomp_decompress,     lzbench_nvcomp_init,     lzbench_nvcomp_deinit },
 };
 
 
 
-#define LZBENCH_ALIASES_COUNT 12
+#define LZBENCH_ALIASES_COUNT 13
 
 static const alias_desc_t alias_desc[LZBENCH_ALIASES_COUNT] =
 {
@@ -248,6 +250,7 @@ static const alias_desc_t alias_desc[LZBENCH_ALIASES_COUNT] =
     { "lzo1y", "lzo1y,1,999" },
     { "lzo",   "lzo1/lzo1a/lzo1b/lzo1c/lzo1f/lzo1x/lzo1y/lzo1z/lzo2a" },
     { "ucl",   "ucl_nrv2b/ucl_nrv2d/ucl_nrv2e" },
+    { "cuda",  "cudaMemcpy/nvcomp_lz4,0,1,3,5" },
 };
 
 #endif

--- a/nvcomp/BatchedLZ4Metadata.cpp
+++ b/nvcomp/BatchedLZ4Metadata.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "BatchedLZ4Metadata.h"
+
+namespace nvcomp
+{
+
+BatchedLZ4Metadata::BatchedLZ4Metadata() :
+    Metadata(NVCOMP_TYPE_UCHAR, 0, 0, LZ4Metadata::COMPRESSION_ID),
+    m_items()
+{
+}
+
+void BatchedLZ4Metadata::add(std::unique_ptr<LZ4Metadata> metadata)
+{
+  if (m_items.size() == 0) {
+    // this is a workaround for the compression scheme
+    // agnostic API, so that a single metadata returns the correct
+    // values. The summation is that the value are sane for batched inputs,
+    // while currently unused
+    setUncompressedSize(
+        getUncompressedSize() + metadata->getUncompressedSize());
+    setCompressedSize(getCompressedSize() + metadata->getCompressedSize());
+  }
+
+  m_items.emplace_back(std::move(metadata));
+}
+
+size_t BatchedLZ4Metadata::size() const
+{
+  return m_items.size();
+}
+
+} // namespace nvcomp

--- a/nvcomp/BatchedLZ4Metadata.h
+++ b/nvcomp/BatchedLZ4Metadata.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NVCOMP_BATCHEDLZ4METADATA_H
+#define NVCOMP_BATCHEDLZ4METADATA_H
+
+#include "LZ4Metadata.h"
+
+#include <memory>
+#include <vector>
+
+namespace nvcomp
+{
+
+class BatchedLZ4Metadata : public Metadata
+{
+public:
+  BatchedLZ4Metadata();
+
+  LZ4Metadata* operator[](const size_t index)
+  {
+    return m_items[index].get();
+  }
+
+  const LZ4Metadata* operator[](const size_t index) const
+  {
+    return m_items[index].get();
+  }
+
+  void add(std::unique_ptr<LZ4Metadata> metadata);
+
+  size_t size() const;
+
+private:
+  std::vector<std::unique_ptr<LZ4Metadata>> m_items;
+};
+
+} // namespace nvcomp
+
+#endif

--- a/nvcomp/BitPackGPU.cu
+++ b/nvcomp/BitPackGPU.cu
@@ -1,0 +1,593 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "BitPackGPU.h"
+#include "unpack.h"
+#include "common.h"
+#include "CascadedCommon.h"
+
+#include <algorithm>
+#include <cassert>
+#include <climits>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+/******************************************************************************
+ * DEFINES ********************************************************************
+ *****************************************************************************/
+
+#define NVCOMP_TYPE_SWITCH(type_var, func, ...)                                \
+  do {                                                                         \
+    switch (type_var) {                                                        \
+    case NVCOMP_TYPE_CHAR:                                                     \
+      func<char, uint32_t, char>(__VA_ARGS__);                                 \
+      break;                                                                   \
+    case NVCOMP_TYPE_UCHAR:                                                    \
+      func<unsigned char, uint32_t, unsigned char>(__VA_ARGS__);               \
+      break;                                                                   \
+    case NVCOMP_TYPE_SHORT:                                                    \
+      func<short, uint32_t, short>(__VA_ARGS__);                               \
+      break;                                                                   \
+    case NVCOMP_TYPE_USHORT:                                                   \
+      func<unsigned short, uint32_t, unsigned short>(__VA_ARGS__);             \
+      break;                                                                   \
+    case NVCOMP_TYPE_INT:                                                      \
+      func<int, uint32_t, int>(__VA_ARGS__);                                   \
+      break;                                                                   \
+    case NVCOMP_TYPE_UINT:                                                     \
+      func<unsigned int, uint32_t, unsigned int>(__VA_ARGS__);                 \
+      break;                                                                   \
+    case NVCOMP_TYPE_LONGLONG:                                                 \
+      func<long long, uint64_t, long long>(__VA_ARGS__);                       \
+      break;                                                                   \
+    case NVCOMP_TYPE_ULONGLONG:                                                \
+      func<unsigned long long, uint64_t, unsigned long long>(__VA_ARGS__);     \
+      break;                                                                   \
+    default:                                                                   \
+      throw std::runtime_error("Unknown type: " + std::to_string(type_var));   \
+    }                                                                          \
+  } while (0)
+
+namespace nvcomp
+{
+
+/******************************************************************************
+ * CONSTANTS ******************************************************************
+ *****************************************************************************/
+
+namespace
+{
+
+constexpr int const BLOCK_SIZE = 256;
+
+// only used for min/max
+constexpr int const BLOCK_WIDTH = 4096;
+
+} // namespace
+
+/******************************************************************************
+ * DEVICE FUNCTIONS ***********************************************************
+ *****************************************************************************/
+
+namespace
+{
+
+__device__ int clamp(size_t const val, int const max)
+{
+  return static_cast<int>(min(static_cast<size_t>(max), val));
+}
+
+template <typename T>
+__device__ void readMinAndMax(
+    T const* const inMin,
+    T const* const inMax,
+    T* const minBuffer,
+    T* const maxBuffer,
+    int const blockOffset,
+    int const blockEnd)
+{
+  static_assert(
+      BLOCK_SIZE <= BLOCK_WIDTH,
+      "BLOCK_SIZE must be less than or equal to BLOCK_WIDTH");
+
+  if (threadIdx.x < blockEnd) {
+    T localMin = inMin[blockOffset + threadIdx.x];
+    T localMax = inMax[blockOffset + threadIdx.x];
+    for (int i = threadIdx.x + BLOCK_SIZE; i < BLOCK_WIDTH && i < blockEnd;
+         i += BLOCK_SIZE) {
+      int const readIdx = blockOffset + i;
+      localMin = min(inMin[readIdx], localMin);
+      localMax = max(inMax[readIdx], localMax);
+    }
+    minBuffer[threadIdx.x] = localMin;
+    maxBuffer[threadIdx.x] = localMax;
+  }
+}
+
+template <typename T>
+__device__ void
+reduceMinAndMax(T* const minBuffer, T* const maxBuffer, int const blockEnd)
+{
+  // cooperatively compute min and max
+  for (int d = BLOCK_SIZE / 2; d > 0; d >>= 1) {
+    if (threadIdx.x < BLOCK_SIZE / 2) {
+      int const idx = threadIdx.x;
+      if (idx < d && idx + d < blockEnd) {
+        minBuffer[idx] = min(minBuffer[idx], minBuffer[d + idx]);
+      }
+    } else {
+      int const idx = threadIdx.x - (BLOCK_SIZE / 2);
+      if (idx < d && idx + d < blockEnd) {
+        maxBuffer[idx] = max(maxBuffer[idx], maxBuffer[d + idx]);
+      }
+    }
+    __syncthreads();
+  }
+}
+
+} // namespace
+
+/******************************************************************************
+ * KERNELS ********************************************************************
+ *****************************************************************************/
+
+namespace
+{
+
+template <typename LIMIT, typename INPUT>
+__global__ void bitPackConfigScanKernel(
+    LIMIT* const minValue,
+    LIMIT* const maxValue,
+    INPUT const* const in,
+    const size_t* const numDevice)
+{
+  static_assert(BLOCK_SIZE % 64 == 0, "BLOCK_SIZE must a multiple of 64");
+
+  assert(BLOCK_SIZE == blockDim.x);
+
+  const size_t num = *numDevice;
+  const int numBlocks = roundUpDiv(num, BLOCK_SIZE);
+
+  assert(num > 0);
+  assert(threadIdx.x < BLOCK_SIZE);
+
+  if (blockIdx.x < numBlocks) {
+    // each block processes it's chunks, updates min/max
+    __shared__ LIMIT minBuffer[BLOCK_SIZE];
+    __shared__ LIMIT maxBuffer[BLOCK_SIZE];
+
+    LIMIT localMin = 0;
+    LIMIT localMax = 0;
+
+    int lastThread = 0;
+    for (int block = blockIdx.x; block < numBlocks; block += gridDim.x) {
+
+      int const blockOffset = BLOCK_SIZE * block;
+      int const blockEnd = min(static_cast<int>(num) - blockOffset, BLOCK_SIZE);
+
+      lastThread = max(lastThread, blockEnd);
+
+      if (threadIdx.x < blockEnd) {
+        LIMIT const val = in[blockOffset + threadIdx.x];
+        if (block == blockIdx.x) {
+          // first iteration just set values
+          localMax = val;
+          localMin = val;
+        } else {
+          localMin = min(val, localMin);
+          localMax = max(val, localMax);
+        }
+      }
+    }
+
+    minBuffer[threadIdx.x] = localMin;
+    maxBuffer[threadIdx.x] = localMax;
+
+    __syncthreads();
+
+    // cooperatively compute min and max
+    reduceMinAndMax(minBuffer, maxBuffer, lastThread);
+
+    if (threadIdx.x == 0) {
+      minValue[blockIdx.x] = minBuffer[0];
+      maxValue[blockIdx.x] = maxBuffer[0];
+    }
+  }
+}
+
+template <typename LIMIT, typename INPUT>
+__global__ void bitPackConfigFinalizeKernel(
+    LIMIT const* const inMin,
+    LIMIT const* const inMax,
+    unsigned char* const* const numBitsPtr,
+    INPUT* const* const outMinValPtr,
+    const size_t* const numDevice)
+{
+  static_assert(
+      BLOCK_SIZE <= BLOCK_WIDTH,
+      "BLOCK_SIZE must be less than or equal to BLOCK_WIDTH");
+  static_assert(
+      BLOCK_WIDTH % BLOCK_SIZE == 0,
+      "BLOCK_WIDTH must be a multiple of BLOCK_SIZE");
+  static_assert(BLOCK_SIZE % 64 == 0, "BLOCK_SIZE must a multiple of 64");
+
+  assert(blockIdx.x == 0);
+
+  const size_t num = min(
+      roundUpDiv(*numDevice, BLOCK_SIZE), static_cast<size_t>(BLOCK_WIDTH));
+
+  assert(num > 0);
+
+  // each block processes it's chunk, updates min/max, and the calculates
+  // the bitwidth based on the last update
+  __shared__ LIMIT minBuffer[BLOCK_SIZE];
+  __shared__ LIMIT maxBuffer[BLOCK_SIZE];
+
+  // load data
+  readMinAndMax(inMin, inMax, minBuffer, maxBuffer, 0, num);
+
+  __syncthreads();
+
+  // cooperatively compute min and max
+  reduceMinAndMax(minBuffer, maxBuffer, min(BLOCK_SIZE, (int)num));
+
+  if (threadIdx.x == 0) {
+    **outMinValPtr = static_cast<INPUT>(minBuffer[0]);
+    // we need to update the number of bits
+    if (sizeof(LIMIT) > sizeof(int)) {
+      const long long int range = static_cast<uint64_t>(maxBuffer[0]) - static_cast<uint64_t>(minBuffer[0]);
+      // need 64 bit clz
+      **numBitsPtr = sizeof(long long int) * 8
+                     - __clzll(range);
+    } else {
+      const int range = static_cast<uint32_t>(maxBuffer[0]) - static_cast<uint32_t>(minBuffer[0]);
+      // can use 32 bit clz
+      **numBitsPtr = sizeof(int) * 8 - __clz(range);
+    }
+  }
+}
+
+template <typename INPUT, typename OUTPUT>
+__global__ void bitPackKernel(
+    unsigned char const* const* const numBitsPtr,
+    INPUT const* const* const valueOffsetPtr,
+    OUTPUT* const* const outPtr,
+    INPUT const* const in,
+    const size_t* const numDevice)
+{
+  using UINPUT = typename std::make_unsigned<INPUT>::type;
+
+  const size_t num = *numDevice;
+
+  const int numBlocks = roundUpDiv(num, BLOCK_SIZE);
+
+  OUTPUT* const out = *outPtr;
+  int const numBits = **numBitsPtr;
+  INPUT const valueOffset = **valueOffsetPtr;
+
+  __shared__ UINPUT inBuffer[BLOCK_SIZE];
+
+  for (int blockId = blockIdx.x; blockId < numBlocks; blockId += gridDim.x) {
+    // The kernel works by assigning an output index to each thread.
+    // The kernel then iterates over chunks of input, filling the bits
+    // for each thread.
+    // And then writing the stored bits to the output.
+    int const outputIdx = threadIdx.x + blockId * BLOCK_SIZE;
+    assert(outputIdx >= 0);
+    assert(**numBitsPtr <= sizeof(INPUT) * 8U);
+
+    size_t const bitStart = outputIdx * sizeof(*out) * 8U;
+    size_t const bitEnd = bitStart + (sizeof(*out) * 8U);
+
+    int const startIdx = clamp(bitStart / static_cast<size_t>(numBits), num);
+    int const endIdx = clamp(roundUpDiv(bitEnd, numBits), num);
+    assert(startIdx >= 0);
+
+    size_t const blockStartBit = blockId * BLOCK_SIZE * sizeof(*out) * 8U;
+    size_t const blockEndBit = (blockId + 1) * BLOCK_SIZE * sizeof(*out) * 8U;
+    assert(blockStartBit < blockEndBit);
+
+    int const blockStartIdx = clamp(
+        roundDownTo(blockStartBit / static_cast<size_t>(numBits), BLOCK_SIZE),
+        num);
+    int const blockEndIdx
+        = clamp(roundUpTo(roundUpDiv(blockEndBit, numBits), BLOCK_SIZE), num);
+    assert(blockStartIdx >= 0);
+    assert(blockStartIdx <= blockEndIdx);
+
+    OUTPUT val = 0;
+    for (int bufferStart = blockStartIdx; bufferStart < blockEndIdx;
+         bufferStart += BLOCK_SIZE) {
+      __syncthreads();
+
+      // fill input buffer
+      int const inputIdx = bufferStart + threadIdx.x;
+      if (inputIdx < num) {
+        inBuffer[threadIdx.x] = in[inputIdx] - valueOffset;
+      }
+
+      __syncthreads();
+
+      int const currentStartIdx = max(startIdx, bufferStart);
+      int const currentEndIdx = min(endIdx, bufferStart + BLOCK_SIZE);
+
+      for (int idx = currentStartIdx; idx < currentEndIdx; ++idx) {
+        int const localIdx = idx - bufferStart;
+
+        // keep only bits we're interested in
+        OUTPUT bits = static_cast<OUTPUT>(inBuffer[localIdx]);
+        int const offset = static_cast<int>(
+            static_cast<ssize_t>(idx * numBits)
+            - static_cast<ssize_t>(bitStart));
+        assert(std::abs(offset) < sizeof(bits) * 8U);
+
+        if (offset > 0) {
+          bits <<= offset;
+        } else {
+          bits >>= -offset;
+        }
+
+        // update b
+        val |= bits;
+      }
+    }
+
+    if (startIdx < num) {
+      out[outputIdx] = val;
+    }
+  }
+}
+
+} // namespace
+
+/******************************************************************************
+ * HELPER FUNCTIONS ***********************************************************
+ *****************************************************************************/
+
+namespace
+{
+
+/**
+ * @brief Get the maximum number of scratch space items that will be needed to
+ * to perform reduction on the input.
+ *
+ * @param num The number of items in the input.
+ *
+ * @return The number of elements required.
+ */
+size_t getReduceScratchSpaceSize(size_t const num)
+{
+  // in the first round, each block will write one value, and then the next
+  // round will launch and write one value per block. After that the spaces
+  // will be re-used
+  size_t const base
+      = std::min(BLOCK_WIDTH, static_cast<int>(roundUpDiv(num, BLOCK_SIZE)))
+        * sizeof(uint64_t);
+
+  return base;
+}
+
+/**
+ * @brief Launch of all of the kernels necessary for the configuration step of
+ * bit packing.
+ *
+ * @tparam LIMIT The type used for min/max values.
+ * @tparam INPUT The type being reduced.
+ * @param minValueScratch Space used by the kernels to reduce the minimum
+ * values. Must be at least the size returned by `getReduceScratchSpaceSize()`.
+ * @param maxValueScratch Space used by the kernels to reduce the maximum
+ * values. Must be at least the size returned by `getReduceScratchSpaceSize()`.
+ * @param minValOutPtr The place to put the actual minimum value of the entire
+ * series (output).
+ * @param numBitsPtr The number of bits to compact to (output).
+ * @param in The input to be compressed.
+ * @param numDevice The number of elements on the device.
+ * @param maxNum The maximum number of elements in the input.
+ * @param stream The GPU stream to launch on.
+ */
+template <typename LIMIT, typename INPUT>
+void bitPackConfigLaunch(
+    LIMIT* const minValueScratch,
+    LIMIT* const maxValueScratch,
+    INPUT* const* const minValOutPtr,
+    unsigned char* const* const numBitsPtr,
+    INPUT const* const in,
+    const size_t* const numDevice,
+    size_t const maxNum,
+    cudaStream_t stream)
+{
+  const dim3 grid(
+      min(BLOCK_WIDTH, static_cast<int>(roundUpDiv(maxNum, BLOCK_SIZE))));
+  const dim3 block(BLOCK_SIZE);
+
+  cudaError_t err;
+
+  // make sure the result will fit in a single block for the finalize kernel
+  bitPackConfigScanKernel<<<grid, block, 0, stream>>>(
+      minValueScratch, maxValueScratch, in, numDevice);
+  err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        "Failed to launch bitPackConfigScanKernel "
+        "kernel: "
+        + std::to_string(err));
+  }
+
+  // determine numBits and convert min value
+  bitPackConfigFinalizeKernel<<<dim3(1), block, 0, stream>>>(
+      minValueScratch, maxValueScratch, numBitsPtr, minValOutPtr, numDevice);
+  err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        "Failed to launch bitPackConfigFinalizeKernel "
+        "kernel: "
+        + std::to_string(err));
+  }
+}
+
+template <typename INPUT, typename OUTPUT>
+void bitPackLaunch(
+    INPUT const* const* const minValueDevicePtr,
+    unsigned char const* const* const numBitsDevicePtr,
+    OUTPUT* const* const outPtr,
+    INPUT const* const in,
+    const size_t* const numDevice,
+    const size_t maxNum,
+    cudaStream_t stream)
+{
+  static_assert(
+      BLOCK_SIZE % (sizeof(OUTPUT) * 8U) == 0,
+      "Block size must be a multiple of output word size.");
+
+  dim3 const grid(
+      std::min(4096, static_cast<int>(roundUpDiv(maxNum, BLOCK_SIZE))));
+  dim3 const block(BLOCK_SIZE);
+
+  bitPackKernel<<<grid, block, 0, stream>>>(
+      numBitsDevicePtr, minValueDevicePtr, outPtr, in, numDevice);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        "Failed to launch bitPackKernel kernel: " + std::to_string(err));
+  }
+}
+
+template <typename IN, typename OUT, typename LIMIT>
+void bitPackFixedBitAndMinInternal(
+    void const* const* const minValueDevicePtr,
+    unsigned char const* const* const numBitsDevicePtr,
+    void* const /* workspace */,
+    void* const* const outPtr,
+    void const* const in,
+    const size_t* const numDevice,
+    size_t const maxNum,
+    cudaStream_t stream)
+{
+  OUT* const* const outputTypedPtr = reinterpret_cast<OUT* const*>(outPtr);
+  IN const* const inputTyped = static_cast<IN const*>(in);
+
+  bitPackLaunch(
+      reinterpret_cast<const IN* const*>(minValueDevicePtr),
+      numBitsDevicePtr,
+      outputTypedPtr,
+      inputTyped,
+      numDevice,
+      maxNum,
+      stream);
+}
+
+template <typename IN, typename OUT, typename LIMIT>
+void bitPackInternal(
+    void* const workspace,
+    void* const* const outPtr,
+    void const* const in,
+    const size_t* const numDevice,
+    size_t const maxNum,
+    void* const* const minValueDevicePtr,
+    unsigned char* const* const numBitsDevicePtr,
+    cudaStream_t stream)
+{
+  // cast voids to known types
+  LIMIT* const maxValueTyped = static_cast<LIMIT*>(workspace);
+  LIMIT* const minValueTyped
+      = maxValueTyped + getReduceScratchSpaceSize(maxNum);
+  IN const* const inputTyped = static_cast<IN const*>(in);
+
+  // determine min, and bit width
+  bitPackConfigLaunch(
+      minValueTyped,
+      maxValueTyped,
+      reinterpret_cast<IN* const*>(minValueDevicePtr),
+      numBitsDevicePtr,
+      inputTyped,
+      numDevice,
+      maxNum,
+      stream);
+
+  bitPackFixedBitAndMinInternal<IN, OUT, LIMIT>(
+      minValueDevicePtr,
+      numBitsDevicePtr,
+      workspace,
+      outPtr,
+      in,
+      numDevice,
+      maxNum,
+      stream);
+}
+
+} // namespace
+
+/******************************************************************************
+ * PUBLIC STATIC METHODS ******************************************************
+ *****************************************************************************/
+
+void BitPackGPU::compress(
+    void* const workspace,
+    const size_t workspaceSize,
+    const nvcompType_t inType,
+    void* const* const outPtr,
+    const void* const in,
+    const size_t* const numPtr,
+    const size_t maxNum,
+    void* const* const minValueDevicePtr,
+    unsigned char* const* const numBitsDevicePtr,
+    cudaStream_t stream)
+{
+  const size_t reqWorkSize = requiredWorkspaceSize(maxNum, inType);
+  if (workspaceSize < reqWorkSize) {
+    throw std::runtime_error(
+        "Insufficient workspace size: " + std::to_string(workspaceSize)
+        + ", need " + std::to_string(reqWorkSize));
+  }
+
+  NVCOMP_TYPE_SWITCH(
+      inType,
+      bitPackInternal,
+      workspace,
+      outPtr,
+      in,
+      numPtr,
+      maxNum,
+      minValueDevicePtr,
+      numBitsDevicePtr,
+      stream);
+}
+
+size_t
+BitPackGPU::requiredWorkspaceSize(size_t const num, const nvcompType_t type)
+{
+  // we need a space for min values, and a space for maximum values
+  size_t const bytes
+      = sizeOfnvcompType(type) * getReduceScratchSpaceSize(num) * 2;
+
+  return bytes;
+}
+
+} // namespace nvcomp

--- a/nvcomp/BitPackGPU.h
+++ b/nvcomp/BitPackGPU.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "cascaded.h"
+#include "cuda_runtime.h"
+
+#include <cstddef>
+
+namespace nvcomp
+{
+
+class BitPackGPU
+{
+public:
+  /**
+   * @brief Pack a series of values into uniform width bits. That is, reduce
+   * each value to `numBits` bits, and compress together so that only
+   * `numBits`*`num` total bits are used for output.
+   *
+   * @param workspace The workspace used internally by kernels.
+   * @param workspaceSize The size of the workspace in bytes. If it is too
+   * small to use, an exception will be thrown.
+   * @param inType The type of the input elements.
+   * @param out The output memory location on the GPU. It should equal to the
+   * length of the input vector.
+   * @param in The input memory location on the GPU.
+   * @param numDevice The number of values to pack on the device.
+   * @param maxNum The maximum number of values to pack.
+   * @param minValueDevicePtr The minimum value found while packing (OUTPUT).
+   * When unpacking, it must be added to the packed bits in order retrieve
+   * the original number. The value must reside in device memory.
+   * @param numBitsDevicePtr The number of bits used to represent the numbers
+   * (OUTPUT). The value must reside in device memory
+   * @param stream The stream to execute the kernel on.
+   */
+  static void compress(
+      void* workspace,
+      size_t workspaceSize,
+      nvcompType_t inType,
+      void* const* outPtr,
+      const void* in,
+      const size_t* numDevice,
+      size_t maxNum,
+      void* const* const minValueDevicePtr,
+      unsigned char* const* const numBitsDevicePtr,
+      cudaStream_t stream);
+
+  /**
+   * @brief Get the required size of the workspace in bytes.
+   *
+   * @param num The number of elements to compress.
+   * @param type The type of elements.
+   *
+   * @return The size in bytes of the required workspace.
+   */
+  static size_t requiredWorkspaceSize(size_t num, nvcompType_t type);
+};
+
+} // namespace nvcomp

--- a/nvcomp/CascadedCommon.h
+++ b/nvcomp/CascadedCommon.h
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2018-2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CascadedMetadata.h"
+
+#include <cassert>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace nvcomp
+{
+
+// Opaque structures
+typedef int nvcompHandle_t;
+typedef int nvcompConfig_t;
+struct nvcompIntConfig_t;
+
+/* Simple compress handle */
+struct nvcompCompressHandle_t
+{
+  int numRLEs = 0;
+  int numDeltas = 0;
+  int bitPacking = 0;
+  int sysmem = 0; // where the compressed data resides
+  int duplicate = 1;
+
+  nvcompType_t dataInType;
+  nvcompType_t dataRunType;
+  size_t comp_size = 0;
+  size_t all_comp_size = 0;
+};
+
+typedef int nvcompConfig_t;
+
+nvcompIntConfig_t* createConfig(const CascadedMetadata* metadata);
+
+void destroyConfig(nvcompIntConfig_t* config);
+
+/* Adds an RLE stage (A,B,C):(1,2,3) -> (A,B,B,C,C,C). Takes two inputs and
+ * produces one output.
+ *
+ * Input.  valsId is the buffer id of the input values, runsId is the buffer id
+ * of the input runs. If the id < numInputs specified in nvcompDecompressLaunch
+ * then the data is taken from user-provided inputHdrs/inputData in
+ * nvcompDecompressLaunch. In this case the type and packing options must be
+ * specified. If valPacking=0 then the input data is treated as of valType
+ * type. If valPacking=1 then each value is stored as an unsigned integer of
+ * numBits bits and represents an offset to minValue of inputType type. If
+ * the id >= numInputs then the data is taken from the output of one of the
+ * previous decompression layers.
+ *
+ * Output.  outputId should be equal or larger than numInputs. If the output id
+ * is the same as outputId in 'config' then this is the
+ * final decompression stage. maxOutputSize specifies the maximum decompressed
+ * chunk size (number of elements) for this stage. */
+nvcompError_t nvcompConfigAddRLE_BP(
+    nvcompIntConfig_t* const config,
+    int outputId,
+    size_t maxOutputSize,
+    int valId,
+    nvcompType_t valType,
+    int valPacking,
+    int runId,
+    nvcompType_t runType,
+    int runPacking);
+
+/* Adds a Delta stage (A,B,C) -> (A,A+B,A+B+C). Takes one input and produces
+ * one output.
+ *
+ * Input.  valsId is the buffer id of the input values, runsId is the buffer id
+ * of the input runs. If the id < numInputs specified in nvcompDecompressLaunch
+ * then the data is taken from user-provided inputHdrs/inputData in
+ * nvcompDecompressLaunch. In this case the type and packing options must be
+ * specified. If valPacking=0 then the input data is treated as of valType
+ * type. If valPacking=1 then each value is stored as an unsigned integer of
+ * numBits bits and represents an offset to minValue of inputType type. If
+ * the id >= numInputs then the data is taken from the output of one of the
+ * previous decompression layers.
+ *
+ * Output.  outputId should be equal or larger than numInputs. If the output id
+ * is the same as outputId specified in 'config' then this is the
+ * final decompression stage. maxOutputSize specifies the maximum decompressed
+ * chunk size (number of elements) for this stage. */
+nvcompError_t nvcompConfigAddDelta_BP(
+    nvcompIntConfig_t* const config,
+    int outputId,
+    size_t maxOutputSize,
+    int valId,
+    nvcompType_t valType,
+    int valPacking);
+
+/* Adds an RLE stage (A,B,C):(1,2,3) -> (A,B,B,C,C,C). Takes two inputs and
+ * produces one output.
+ *
+ * Input.  valsId is the buffer id of the input values, runsId is the buffer id
+ * of the input runs. If the id < numInputs specified in nvcompDecompressLaunch
+ * then the data is taken from user-provided inputHdrs/inputData in
+ * nvcompDecompressLaunch. In this case the type option must be specified. If
+ * the id >= numInputs then the data is taken from the output of one of the
+ * previous decompression layers.
+ *
+ * Output.  outputId should be equal or larger than numInputs. If the output id
+ * is the same as outputId specified in 'config' then this is the
+ * final decompression stage. maxOutputSize specifies the maximum decompressed
+ * chunk size (number of elements) for this stage. */
+nvcompError_t nvcompConfigAddRLE(
+    nvcompIntConfig_t* const config,
+    int outputId,
+    size_t maxOutputSize,
+    int valId,
+    nvcompType_t valType,
+    int runId,
+    nvcompType_t runType);
+
+/* Adds a Delta stage (A,B,C) -> (A,A+B,A+B+C). Takes one input and produces
+ * one output.
+ *
+ * Input.  valsId is the buffer id of the input values, runsId is the buffer id
+ * of the input runs. If the id < numInputs specified in nvcompDecompressLaunch
+ * then the data is taken from user-provided inputHdrs/inputData in
+ * nvcompDecompressLaunch. In this case the type option must be specified. If
+ * the id >= numInputs then the data is taken from the output of one of the
+ * previous decompression layers.
+ *
+ * Output.  outputId should be equal or larger than numInputs. If the output id
+ * is the same as outputId specified in 'config' then this is the
+ * final decompression stage. maxOutputSize specifies the maximum decompressed
+ * chunk size (number of elements) for this stage. */
+nvcompError_t nvcompConfigAddDelta(
+    nvcompIntConfig_t* const config,
+    int outputId,
+    size_t maxOutputSize,
+    int valId,
+    nvcompType_t valType);
+/* Adds a Byte-packing stage. Takes one input and produces one output.
+ *
+ * Input.  valsId is the buffer id of the input values. If the id < numInputs
+ * specified in nvcompDecompressLaunch then the data is taken from user-provided
+ * inputHdrs/inputData in nvcompDecompressLaunch. In this case the type option
+ * must be specified. Each value is stored as an unsigned integer of
+ * numBits bits and represents an offset to minValue of inputType type. If
+ * the id >= numInputs then the data is taken from the output of one of the
+ * previous decompression layers.
+ *
+ * Output.  outputId should be equal or larger than numInputs. If the output id
+ * is the same as outputId specified in 'config' then this is the
+ * final decompression stage. maxOutputSize specifies the maximum decompressed
+ * chunk size (number of elements) for this stage. */
+nvcompError_t nvcompConfigAddBP(
+    nvcompIntConfig_t* const config,
+    int outputId,
+    size_t maxOutputSize,
+    int valId,
+    nvcompType_t valType);
+
+/* Creates a decompression handle assigned to the specified cascaded scheme
+ * described by the config.  Assumes that the workspaceStorage is pre-allocated
+ * and accessible by the GPU, otherwise flags an error.
+ * Multiple handles can be created but each handle takes resources.
+ * */
+nvcompError_t nvcompCreateHandleAsync(
+    nvcompHandle_t* handle,
+    nvcompIntConfig_t* const config,
+    void* workspaceStorage,
+    size_t workspaceBytes,
+    cudaStream_t stream);
+
+/* Reconfigures the workspace. This will try to adjust the allocation policy to
+ * fit the specified memory budget of workspaceBytes. On success the handle
+ * will release the previous temporary storage and use the new memory space,
+ * otherwise cudaErrorNotSupported will be returned and no changes to the
+ * workspace will be made. */
+nvcompError_t nvcompSetWorkspace(
+    nvcompHandle_t handle, void* workspaceStorage, size_t workspaceBytes);
+
+/* Gets the current workspace size in bytes. */
+nvcompError_t
+nvcompGetWorkspaceSize(nvcompHandle_t handle, size_t* workspaceBytes);
+
+/* Changes the stream used by the handle. */
+nvcompError_t nvcompSetStream(nvcompHandle_t handle, cudaStream_t streamId);
+
+/* Gets the current stream assigned to the handle. */
+nvcompError_t nvcompGetStream(nvcompHandle_t handle, cudaStream_t* streamId);
+
+/* Sets the output length of a particular node. This is helpful when the node is
+ * the output node of a RLE layer in a multi-GPU system. With this method, the
+ * cudaStreamSynchronize() in nvcompDecompressLaunch() can be eliminated which
+ * preserves the concurrency. */
+nvcompError_t
+nvcompSetNodeLength(nvcompHandle_t handle, int nodeId, size_t output_length);
+
+/* Usage.  Submits a decompression task to the GPU asynchronously and returns
+ * the task ID. In practice this would pipeline memory copies and kernels into
+ * the assigned CUDA stream(s). The function uses no additional memory and is
+ * very lightweight. The main usage pattern is to subdivide your data into
+ * relatively large chunks and submit one decompression task per chunk. We must
+ * support non-pinned data and this might require implementing a staging
+ * pipeline inside the library. We do not want to expose CUDA streams or events
+ * to the user externally since we might be able to do some efficient
+ * scheduling internally by querying the status of streams or using some other
+ * custom heuristics. However, the user is free to record events before and
+ * after the decompress launch function to create more complex dependencies.
+ *
+ * Input.  The input headers and data arrays are processed according to the
+ * compression DAG specified by the handle's config. Each inputHdrs/inputData
+ * pair represent some input data such as RLE values, RLE runs, dictionary
+ * values, or any other input depending on the configuration plan.
+ * The corresponding inputData buffer should contain length
+ * number of elements of type valType. If valPacking=1 then
+ * nvcompPackedHeader_t<valType> should be used. The corresponding inputData
+ * buffer should contain length number of elements of numBits bits each, the
+ * values will be treated as unsigned offsets to the shared minValue of type
+ * valType.  Both inputHdrs and inputData must be accessible by the GPU, and
+ * hostHdrs is a copy of inputHdrs that is accessible to the CPU.
+ * numOutputElements The number of elements that will be output.
+ *
+ * Output.  Decompressed data will be stored in outputData and the final number
+ * of uncompressed elements will be written to outputSize. Note that the type
+ * of output values is specified in 'config'. */
+nvcompError_t nvcompDecompressLaunch(
+    nvcompHandle_t handle,
+    size_t numUncompressedElements,
+    void* outputData,
+    size_t outputSize,
+    const void** inputData,
+    const void** hostHdrs);
+
+/* Releases all memory associated with the decompression handle. */
+nvcompError_t nvcompDestroyHandle(nvcompHandle_t handle);
+
+inline nvcompType_t selectRunsType(const size_t length)
+{
+  if (length <= std::numeric_limits<uint8_t>::max()) {
+    return NVCOMP_TYPE_UCHAR;
+  } else if (length <= std::numeric_limits<uint16_t>::max()) {
+    return NVCOMP_TYPE_USHORT;
+  } else if (length <= std::numeric_limits<uint32_t>::max()) {
+    return NVCOMP_TYPE_UINT;
+  } else {
+    return NVCOMP_TYPE_ULONGLONG;
+  }
+}
+
+} // namespace nvcomp

--- a/nvcomp/CascadedCompressionGPU.cu
+++ b/nvcomp/CascadedCompressionGPU.cu
@@ -1,0 +1,850 @@
+/*
+ * Copyright (c) Copyright-2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "CascadedCompressionGPU.h"
+
+#include "BitPackGPU.h"
+#include "CascadedMetadata.h"
+#include "CascadedMetadataOnGPU.h"
+#include "Check.h"
+#include "CudaUtils.h"
+#include "DeltaGPU.h"
+#include "RunLengthEncodeGPU.h"
+#include "TempSpaceBroker.h"
+#include "nvcomp.h"
+#include "nvcomp.hpp"
+#include "type_macros.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+namespace nvcomp
+{
+
+/******************************************************************************
+ * KERNELS ********************************************************************
+ *****************************************************************************/
+
+namespace
+{
+
+template <typename T>
+__global__ void dereferenceDevice(T* const outValue, T* const* const ref)
+{
+  assert(threadIdx.x == 0);
+  assert(blockIdx.x == 0);
+
+  *outValue = **ref;
+}
+
+template <typename T>
+__global__ void configureBitPackHeader(
+    CascadedMetadata::Header* const header,
+    T** const minValueDevicePtr,
+    unsigned char** const numBitsDevicePtr)
+{
+  // setup the header and pointers into it
+  assert(blockIdx.x == 0);
+  assert(threadIdx.x == 0);
+
+  *minValueDevicePtr = CascadedMetadata::getMinValueLocation<T>(header);
+  *numBitsDevicePtr = &header->numBits;
+}
+
+/**
+ * @brief Asynchronously perform a device to device copy, where the destination
+ * address and number of elements to copy are stored on the device.
+ *
+ * @tparam T The type of element to copy.
+ * @tparam BLOCK_SIZE The size of each thread block.
+ * @param destDPtr The pointer to the destination address to copy elements to,
+ * stored on the device.
+ * @param src The source address to copy elements from.
+ * @param numElementsDPtr The number of elements to copy, stored on the device.
+ */
+template <typename T, int BLOCK_SIZE>
+__global__ void deferredCopy(
+    T** const destDPtr, const T* const src, const size_t* const numElementsDPtr)
+{
+  assert(blockDim.x == BLOCK_SIZE);
+
+  T* const dest = *destDPtr;
+
+  const size_t num = *numElementsDPtr;
+
+  for (int idx = blockIdx.x * BLOCK_SIZE + threadIdx.x; idx < num;
+       idx += gridDim.x * BLOCK_SIZE) {
+    dest[idx] = src[idx];
+  }
+}
+
+/**
+ * @brief Asynchronously perform a device to device copy, where the number of
+ * elements to copy is stored on the device.
+ *
+ * @tparam T The type of element to copy.
+ * @tparam BLOCK_SIZE The size of each thread block to use.
+ * @param dest The destination address to copy to.
+ * @param src The source address to copy from.
+ * @param numElementsDPtr The number of elements to copy, stored on the device.
+ */
+template <typename T, int BLOCK_SIZE>
+__global__ void deferredCopy(
+    T* const dest, const T* const src, const size_t* const numElementsDPtr)
+{
+  assert(blockDim.x == BLOCK_SIZE);
+
+  const size_t num = *numElementsDPtr;
+
+  for (int idx = blockIdx.x * BLOCK_SIZE + threadIdx.x; idx < num;
+       idx += gridDim.x * BLOCK_SIZE) {
+    dest[idx] = src[idx];
+  }
+}
+
+template <typename T>
+__global__ void
+offsetPointerAsync(T* const src, T** const dst, const size_t* const offset)
+{
+  assert(threadIdx.x == 0);
+  assert(blockIdx.x == 0);
+
+  *dst = src + *offset;
+}
+
+__global__ void offsetAndAlignPointerAsync(
+    void* const src, void** const dst, size_t* const offset)
+{
+  assert(threadIdx.x == 0);
+  assert(blockIdx.x == 0);
+
+  // update the offset if we need to
+  const size_t unalignedOffset = *offset;
+  const size_t alignedOffset = roundUpTo(unalignedOffset, sizeof(size_t));
+  if (alignedOffset != unalignedOffset) {
+    *offset = alignedOffset;
+  }
+
+  *dst = static_cast<char*>(src) + alignedOffset;
+}
+
+template <typename VALUE, typename RUN>
+__global__ void configTempSpacePointers(
+    VALUE* const vals,
+    VALUE** const valsPtr,
+    RUN* const runs,
+    RUN** const runsPtr,
+    VALUE* const delta,
+    VALUE** const deltaPtr)
+{
+  assert(threadIdx.x == 0);
+  assert(blockIdx.x == 0);
+
+  *valsPtr = vals;
+  *runsPtr = runs;
+  *deltaPtr = delta;
+}
+
+template <typename T>
+__global__ void increaseOffsetByBitPacking(
+    size_t* const offsetDevice, const CascadedMetadata::Header* const header)
+{
+  assert(threadIdx.x == 0);
+  assert(blockIdx.x == 0);
+
+  const size_t temp_size = roundUpTo(
+      roundUpDiv(header->length * header->numBits, 8ULL), sizeof(T));
+
+  *offsetDevice += temp_size;
+}
+
+template <typename T>
+__global__ void increaseOffsetByRaw(
+    size_t* const offsetDevice, const CascadedMetadata::Header* const header)
+{
+  assert(threadIdx.x == 0);
+  assert(blockIdx.x == 0);
+
+  const size_t temp_size = header->length * sizeof(T);
+
+  *offsetDevice += temp_size;
+}
+
+/**
+ * @brief This kernel allows copying to the device from a stack variable
+ * asynchronously.
+ *
+ * @tparam T The type of variable to copy.
+ * @param hostValue The value to copy.
+ * @param deviceValue The location to copy to.
+ */
+template <typename T>
+__global__ void asyncPODCopyKernel(const T hostValue, T* const deviceValue)
+{
+  static_assert(std::is_pod<T>::value, "Must be a POD to do async copy.");
+
+  assert(threadIdx.x == 0);
+  assert(blockIdx.x == 0);
+
+  *deviceValue = hostValue;
+}
+
+} // namespace
+
+/******************************************************************************
+ * HELPER FUNCTIONS ***********************************************************
+ *****************************************************************************/
+
+namespace
+{
+
+void checkAlignmentOf(void* const ptr, const size_t alignment)
+{
+  void* aligned_ptr = ptr;
+  size_t space = alignment;
+  if (std::align(alignment, alignment, aligned_ptr, space) == nullptr
+      || ptr != aligned_ptr) {
+    std::ostringstream oss;
+    oss << ptr;
+    throw std::runtime_error(
+        "Incorrectly aligned buffer: " + oss.str() + ", should be aligned to "
+        + std::to_string(alignment));
+  }
+}
+
+/**
+ * @brief This copies the input to the device from a stack variable
+ * asynchronously. While this is inefficient, it is better than synchronizing or
+ * pinning the variable.
+ *
+ * @tparam T The type of variable to copy.
+ * @param hostValue The value to copy.
+ * @param deviceValue The location to copy to.
+ */
+template <typename T>
+void asyncPODCopy(const T& value, T* const destination, cudaStream_t stream)
+{
+  asyncPODCopyKernel<<<dim3(1), dim3(1), 0, stream>>>(value, destination);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        "Failed to launch asyncPODCopyKernel "
+        "kernel: "
+        + std::to_string(err));
+  }
+}
+
+/**
+ * @brief Bit pack or copy the elements to an output address.
+ *
+ * @tparam T The type of element to pack/copy.
+ * @param headerDPtr The header, stored on the device.
+ * @param temp_ptr The temporary workspace allocated (on the device).
+ * @param temp_bytes The size of the temporary workspace.
+ * @param outputDPtr The pointer to the location to output the elements to (on
+ * the device), stored on the device.
+ * @param input The input elements (on the device).
+ * @param numElementsDPtr The pointer to the number of elements, stored on the
+ * device.
+ * @param maxNum The maximum number of elements.
+ * @param offsetDPtr The current offset output, to be increased by
+ * the number of bytes written by this function.
+ * @param bitPacking Whether or not to perform bitpacking on this data.
+ * @param stream The stream to asynchronously perform work on.
+ */
+template <typename T>
+void packToOutput(
+    CascadedMetadata::Header* const headerDPtr,
+    void* const temp_ptr,
+    const size_t temp_bytes,
+    void** const outputDPtr,
+    const T* const input,
+    const size_t* const numElementsDPtr,
+    const size_t maxNum,
+    size_t* const offsetDPtr,
+    const bool bitPacking,
+    cudaStream_t stream)
+{
+  CudaUtils::copy_async(
+      &(headerDPtr->length), numElementsDPtr, 1, DEVICE_TO_DEVICE, stream);
+
+  if (bitPacking) {
+    TempSpaceBroker tempSpace(temp_ptr, temp_bytes);
+
+    void** bitPackOutputPtr;
+    void** minValueDevicePtr;
+    unsigned char** numBitsDevicePtr;
+    tempSpace.reserve(&bitPackOutputPtr, 1);
+    tempSpace.reserve(&minValueDevicePtr, 1);
+    tempSpace.reserve(&numBitsDevicePtr, 1);
+
+    configureBitPackHeader<<<1, 1, 0, stream>>>(
+        headerDPtr, reinterpret_cast<T**>(minValueDevicePtr), numBitsDevicePtr);
+
+    void* const packTemp = reinterpret_cast<void*>(numBitsDevicePtr + 1);
+    const size_t packTempSize
+        = temp_bytes
+          - (static_cast<char*>(packTemp) - static_cast<char*>(temp_ptr));
+
+    BitPackGPU::compress(
+        packTemp,
+        packTempSize,
+        getnvcompType<T>(),
+        outputDPtr,
+        input,
+        numElementsDPtr,
+        maxNum,
+        minValueDevicePtr,
+        numBitsDevicePtr,
+        stream);
+
+    increaseOffsetByBitPacking<T><<<1, 1, 0, stream>>>(offsetDPtr, headerDPtr);
+  } else {
+    constexpr const int BLOCK_SIZE = 512;
+
+    const dim3 grid(std::min(1024, roundUpDiv<int, int>(maxNum, BLOCK_SIZE)));
+    const dim3 block(BLOCK_SIZE);
+
+    deferredCopy<T, BLOCK_SIZE><<<grid, block, 0, stream>>>(
+        reinterpret_cast<T**>(outputDPtr), input, numElementsDPtr);
+
+    increaseOffsetByRaw<T><<<1, 1, 0, stream>>>(offsetDPtr, headerDPtr);
+  }
+}
+
+template <typename valT, typename runT>
+void generateTypedOutputUpperBound(
+    const void* const /*in_ptr*/,
+    const size_t in_bytes,
+    const nvcompCascadedFormatOpts* const opts,
+    void* const temp_ptr,
+    const size_t temp_bytes,
+    size_t* const out_bytes)
+{
+  if (temp_bytes > 0) {
+    CHECK_NOT_NULL(temp_ptr);
+
+    // only check if its non-null
+    checkAlignmentOf(temp_ptr, sizeof(size_t));
+  }
+
+  CascadedMetadata metadata(*opts, getnvcompType<valT>(), in_bytes, 0);
+
+  const int numRLEs = metadata.getNumRLEs();
+  const int numDeltas = metadata.getNumDeltas();
+  const bool bitPacking = metadata.useBitPacking();
+
+  // assume single chunk for now
+  // TODO: implement a multi-chunk version
+  const size_t outputSize = in_bytes / sizeof(valT);
+  assert(outputSize * sizeof(valT) == in_bytes);
+  int vals_id = 0;
+
+  // initialize config
+  nvcompType_t type = getnvcompType<valT>();
+  nvcompIntConfig_t* config = createConfig(&metadata);
+
+  // First past - set layers assume nothing actual compresses.
+  // TODO: This will be a
+  // gross over estimation of the output size, but the better option would
+  // be to probably just assume 1:1 output/input, and error out during
+  // compression if we fail to achieve that (maybe just set RLE, Delta, and BP
+  // to 0, and do a memcpy, so that user's wont have to handle the error case
+  // in their code).
+
+  // A step can be RLE+Delta, RLE, or Delta, with final outputs conditionally
+  // having bit packing applied
+  const int numSteps = std::max(numRLEs, numDeltas);
+  for (int r = numSteps - 1; r >= 0; r--) {
+    const int inputId = vals_id;
+    if (numSteps - r - 1 < numRLEs) {
+      const int runId = ++vals_id;
+      const int valId = ++vals_id;
+
+      nvcompConfigAddRLE_BP(
+          config,
+          inputId,
+          outputSize,
+          valId,
+          type,
+          bitPacking,
+          runId,
+          type,
+          bitPacking);
+
+      // store vals (apply delta if necessary)
+      if (numRLEs - 1 - r < numDeltas) {
+        const int deltaId = ++vals_id;
+        if (r == 0) {
+          nvcompConfigAddDelta_BP(
+              config, valId, outputSize, deltaId, type, bitPacking);
+        } else {
+          nvcompConfigAddDelta_BP(
+              config,
+              deltaId,
+              outputSize,
+              valId,
+              type,
+              0); // no bitpacking when delta is used as an intermediate step
+        }
+      }
+    } else {
+      // RLE-less step
+      const int deltaId = ++vals_id;
+
+      if (r == 0) {
+        nvcompConfigAddDelta_BP(
+            config, inputId, outputSize, deltaId, type, bitPacking);
+      } else {
+        nvcompConfigAddDelta_BP(
+            config,
+            deltaId,
+            outputSize,
+            inputId,
+            type,
+            0); // no bitpacking when delta is used as an intermediate step
+      }
+    }
+  }
+
+  destroyConfig(config);
+
+  // we will abort compression if we can't fit into out_bytes.
+  const size_t serializedMetadataSize
+      = CascadedMetadataOnGPU::getSerializedSizeOf(metadata);
+
+  // This may be overkill, as most datatypes we use are aligned to size_t,
+  // which on x86_64 is 8 bytes, where as this will be 16 bytes. In theory a
+  // smart compiler could potentially generate instructions for some of our
+  // structure that at 16-byte aligned.
+  const size_t wordSize = alignof(std::max_align_t);
+
+  // space for metadata, each set of 'runs', one set of 'vals'.
+  *out_bytes = roundUpTo(serializedMetadataSize, wordSize)
+               + roundUpTo(sizeof(runT) * outputSize, wordSize) * numRLEs
+               + roundUpTo(sizeof(valT) * outputSize, wordSize);
+}
+
+template <typename valT, typename runT>
+void compressTypedAsync(
+    const void* const in_ptr,
+    const size_t in_bytes,
+    const nvcompCascadedFormatOpts* const format_opts,
+    void* const temp_ptr,
+    const size_t temp_bytes,
+    void* const out_ptr,
+    size_t* const out_bytes,
+    cudaStream_t stream)
+{
+  const nvcompType_t type = getnvcompType<valT>();
+
+  CascadedMetadata metadata(*format_opts, type, in_bytes, 0);
+
+  const int numRLEs = metadata.getNumRLEs();
+  const int numDeltas = metadata.getNumDeltas();
+  const bool bitPacking = metadata.useBitPacking();
+
+  // assume single chunk for now
+  // TODO: implement a multi-chunk version
+  const size_t maxNum = in_bytes / sizeof(valT);
+  int vals_id = 0;
+
+  TempSpaceBroker tempSpace(temp_ptr, temp_bytes);
+
+  size_t* offsetDevice;
+  tempSpace.reserve(&offsetDevice, 1);
+
+  CascadedMetadataOnGPU metadataOnGPU(out_ptr, *out_bytes);
+
+  metadataOnGPU.copyToGPU(metadata, offsetDevice, stream);
+
+  valT* vals_delta = nullptr;
+  valT* vals_output = nullptr;
+  runT* runs_output = nullptr;
+
+  if (numRLEs > 0 || numDeltas > 0) {
+    tempSpace.reserve(&vals_output, maxNum);
+    if (numRLEs > 0) {
+      tempSpace.reserve(&runs_output, maxNum);
+    }
+    tempSpace.reserve(&vals_delta, maxNum);
+  }
+
+  size_t* numRunsDevice;
+  size_t* outputSizePtr;
+  tempSpace.reserve(&numRunsDevice, 1);
+  tempSpace.reserve(&outputSizePtr, 1);
+
+  runT** runs_output_ptr;
+  valT** vals_output_ptr;
+  valT** vals_delta_ptr;
+  tempSpace.reserve(&runs_output_ptr, 1);
+  tempSpace.reserve(&vals_output_ptr, 1);
+  tempSpace.reserve(&vals_delta_ptr, 1);
+
+  void** bit_out_ptr;
+  tempSpace.reserve(&bit_out_ptr, 1);
+
+  cudaError_t* statusDevice;
+  tempSpace.reserve(&statusDevice, 1);
+
+  configTempSpacePointers<<<1, 1, 0, stream>>>(
+      vals_output,
+      vals_output_ptr,
+      runs_output,
+      runs_output_ptr,
+      vals_delta,
+      vals_delta_ptr);
+
+  // Set first offset to end of metadata
+  metadataOnGPU.saveOffset(vals_id, offsetDevice, stream);
+
+  // Second pass - perform compression and store in the memory allocated above.
+
+  // A step can be RLE+Delta, RLE, or Delta, with final outputs conditionally
+  // having bit packing applied
+  const int numSteps = std::max(numRLEs, numDeltas);
+  for (int r = numSteps - 1; r >= 0; r--) {
+    int nextValId;
+    const bool firstLayer = r == std::max(numRLEs - 1, numDeltas - 1);
+    const valT* const vals_input
+        = firstLayer ? static_cast<const valT*>(in_ptr) : vals_delta;
+
+    if (numSteps - r - 1 < numRLEs) {
+      const int runId = ++vals_id;
+      const int valId = ++vals_id;
+
+      // rle always first
+      if (firstLayer) {
+        RunLengthEncodeGPU::compress(
+            tempSpace.next(),
+            tempSpace.spaceLeft(),
+            getnvcompType<valT>(),
+            vals_output,
+            getnvcompType<runT>(),
+            runs_output,
+            numRunsDevice,
+            vals_input,
+            maxNum,
+            stream);
+      } else {
+        RunLengthEncodeGPU::compressDownstream(
+            tempSpace.next(),
+            tempSpace.spaceLeft(),
+            getnvcompType<valT>(),
+            (void**)vals_output_ptr,
+            getnvcompType<runT>(),
+            (void**)runs_output_ptr,
+            numRunsDevice,
+            vals_input,
+            outputSizePtr,
+            maxNum,
+            stream);
+      }
+
+      // save initial offset
+      CascadedMetadata::Header* const valHdr
+          = metadataOnGPU.getHeaderLocation(valId);
+      CudaUtils::copy_async(
+          &(valHdr->length), numRunsDevice, 1, DEVICE_TO_DEVICE, stream);
+
+      metadataOnGPU.saveOffset(valId, offsetDevice, stream);
+
+      CascadedMetadata::Header* const runHdr
+          = metadataOnGPU.getHeaderLocation(runId);
+      CudaUtils::copy_async(
+          &(runHdr->length), numRunsDevice, 1, DEVICE_TO_DEVICE, stream);
+
+      // store vals (apply delta if necessary)
+      if (numRLEs - 1 - r < numDeltas) {
+        DeltaGPU::compress(
+            tempSpace.next(),
+            tempSpace.spaceLeft(),
+            getnvcompType<valT>(),
+            (void**)vals_delta_ptr,
+            vals_output,
+            numRunsDevice,
+            maxNum,
+            stream);
+
+        const int id = ++vals_id;
+        nextValId = id;
+
+        CascadedMetadata::Header* const hdr
+            = metadataOnGPU.getHeaderLocation(id);
+        CudaUtils::copy_async(
+            &(hdr->length), numRunsDevice, 1, DEVICE_TO_DEVICE, stream);
+
+        metadataOnGPU.saveOffset(id, offsetDevice, stream);
+      } else {
+        constexpr const int COPY_BLOCK_SIZE = 512;
+        const dim3 grid(std::min(
+            4096, static_cast<int>(roundUpDiv(maxNum, COPY_BLOCK_SIZE))));
+        const dim3 block(COPY_BLOCK_SIZE);
+
+        deferredCopy<valT, COPY_BLOCK_SIZE><<<grid, block, 0, stream>>>(
+            vals_delta, vals_output, numRunsDevice);
+
+        nextValId = valId;
+      }
+
+      offsetAndAlignPointerAsync<<<1, 1, 0, stream>>>(
+          out_ptr, bit_out_ptr, offsetDevice);
+
+      metadataOnGPU.saveOffset(runId, offsetDevice, stream);
+
+      // pack runs into bytes
+      packToOutput(
+          metadataOnGPU.getHeaderLocation(runId),
+          tempSpace.next(),
+          tempSpace.spaceLeft(),
+          bit_out_ptr,
+          runs_output,
+          numRunsDevice,
+          maxNum,
+          offsetDevice,
+          bitPacking,
+          stream);
+    } else {
+      if (!firstLayer) {
+        CudaUtils::copy_async(
+            numRunsDevice, outputSizePtr, 1, DEVICE_TO_DEVICE, stream);
+      } else {
+        CudaUtils::copy_async(
+            numRunsDevice, &maxNum, 1, HOST_TO_DEVICE, stream);
+      }
+
+      // No RLE
+      DeltaGPU::compress(
+          tempSpace.next(),
+          tempSpace.spaceLeft(),
+          getnvcompType<valT>(),
+          (void**)vals_output_ptr,
+          vals_input,
+          numRunsDevice,
+          maxNum,
+          stream);
+
+      // we need to copy the delta to final delta buffer
+      {
+        constexpr const int COPY_BLOCK_SIZE = 512;
+        const dim3 grid(std::min(
+            4096, static_cast<int>(roundUpDiv(maxNum, COPY_BLOCK_SIZE))));
+        const dim3 block(COPY_BLOCK_SIZE);
+
+        deferredCopy<valT, COPY_BLOCK_SIZE><<<grid, block, 0, stream>>>(
+            vals_delta, vals_output, numRunsDevice);
+      }
+
+      const int id = ++vals_id;
+      nextValId = id;
+
+      CascadedMetadata::Header* const hdr = metadataOnGPU.getHeaderLocation(id);
+      CudaUtils::copy_async(
+          &(hdr->length), numRunsDevice, 1, DEVICE_TO_DEVICE, stream);
+      metadataOnGPU.saveOffset(id, offsetDevice, stream);
+    }
+    if (r == 0) {
+      offsetAndAlignPointerAsync<<<1, 1, 0, stream>>>(
+          out_ptr, bit_out_ptr, offsetDevice);
+
+      metadataOnGPU.saveOffset(nextValId, offsetDevice, stream);
+
+      // pack runs into bytes
+      packToOutput(
+          metadataOnGPU.getHeaderLocation(nextValId),
+          tempSpace.next(),
+          tempSpace.spaceLeft(),
+          bit_out_ptr,
+          vals_delta,
+          numRunsDevice,
+          maxNum,
+          offsetDevice,
+          bitPacking,
+          stream);
+    } else {
+      // update current RLE size
+      CudaUtils::copy_async(
+          outputSizePtr, numRunsDevice, 1, DEVICE_TO_DEVICE, stream);
+    }
+  }
+
+  // If there are no RLEs or Deltas, we will do a single BP step.
+  if (numRLEs == 0 && numDeltas == 0) {
+    const int nextValId = ++vals_id;
+    const valT* const vals_input = static_cast<const valT*>(in_ptr);
+
+    CudaUtils::copy_async(numRunsDevice, &maxNum, 1, HOST_TO_DEVICE, stream);
+
+    offsetAndAlignPointerAsync<<<1, 1, 0, stream>>>(
+        out_ptr, bit_out_ptr, offsetDevice);
+
+    metadataOnGPU.saveOffset(nextValId, offsetDevice, stream);
+
+    // pack runs into bytes
+    packToOutput(
+        metadataOnGPU.getHeaderLocation(nextValId),
+        tempSpace.next(),
+        tempSpace.spaceLeft(),
+        bit_out_ptr,
+        vals_input,
+        numRunsDevice,
+        maxNum,
+        offsetDevice,
+        bitPacking,
+        stream);
+  }
+
+  // async copy output
+  metadataOnGPU.setCompressedSizeFromGPU(offsetDevice, stream);
+  CudaUtils::copy_async(out_bytes, offsetDevice, 1, DEVICE_TO_HOST, stream);
+}
+
+} // namespace
+
+/******************************************************************************
+ * PUBLIC STATIC METHODS ******************************************************
+ *****************************************************************************/
+
+void nvcompCascadedCompressionGPU::computeWorkspaceSize(
+    const void* /*in_ptr*/,
+    const size_t in_bytes,
+    const nvcompType_t in_type,
+    const nvcompCascadedFormatOpts* const opts,
+    size_t* const temp_bytes)
+{
+  size_t kernelBytes = 0;
+
+  // get at least enough for intermediate gpu values
+  size_t ioBytes = 1024;
+
+  const size_t numIn = in_bytes / sizeOfnvcompType(in_type);
+  const nvcompType_t runType = selectRunsType(numIn);
+
+  if (opts->use_bp) {
+    // max of runs and values
+    kernelBytes = std::max(
+        kernelBytes, BitPackGPU::requiredWorkspaceSize(numIn, in_type));
+    kernelBytes = std::max(
+        kernelBytes, BitPackGPU::requiredWorkspaceSize(numIn, runType));
+  }
+
+  if (opts->num_deltas > 0) {
+    kernelBytes = std::max(
+        kernelBytes, DeltaGPU::requiredWorkspaceSize(numIn, in_type));
+  }
+
+  if (opts->num_RLEs > 0) {
+    kernelBytes = std::max(
+        kernelBytes,
+        RunLengthEncodeGPU::requiredWorkspaceSize(numIn, in_type, runType));
+
+    ioBytes += (2 * in_bytes) + numIn * sizeOfnvcompType(runType);
+  } else if (opts->num_deltas > 0) {
+    ioBytes += 2 * in_bytes;
+  }
+
+  *temp_bytes = kernelBytes + ioBytes;
+}
+
+void nvcompCascadedCompressionGPU::generateOutputUpperBound(
+    const void* const in_ptr,
+    const size_t in_bytes,
+    const nvcompType_t in_type,
+    const nvcompCascadedFormatOpts* const opts,
+    void* const temp_ptr,
+    const size_t temp_bytes,
+    size_t* const out_bytes)
+{
+  CHECK_NOT_NULL(in_ptr);
+  CHECK_NOT_NULL(opts);
+  if (temp_bytes > 0) {
+    CHECK_NOT_NULL(temp_ptr);
+  }
+  CHECK_NOT_NULL(out_bytes);
+
+  const nvcompType_t countType
+      = selectRunsType(in_bytes / sizeOfnvcompType(in_type));
+
+  NVCOMP_TYPE_TWO_SWITCH(
+      in_type,
+      countType,
+      generateTypedOutputUpperBound,
+      in_ptr,
+      in_bytes,
+      opts,
+      temp_ptr,
+      temp_bytes,
+      out_bytes);
+}
+
+void nvcompCascadedCompressionGPU::compressAsync(
+    const void* const in_ptr,
+    const size_t in_bytes,
+    const nvcompType_t in_type,
+    const nvcompCascadedFormatOpts* const cascadedOpts,
+    void* const temp_ptr,
+    const size_t temp_bytes,
+    void* const out_ptr,
+    size_t* const out_bytes,
+    cudaStream_t stream)
+{
+  CHECK_NOT_NULL(in_ptr);
+  CHECK_NOT_NULL(cascadedOpts);
+  CHECK_NOT_NULL(temp_ptr);
+  CHECK_NOT_NULL(out_ptr);
+  CHECK_NOT_NULL(out_bytes);
+
+  checkAlignmentOf(out_ptr, sizeof(size_t));
+  checkAlignmentOf(temp_ptr, sizeof(size_t));
+
+  const nvcompType_t countType
+      = selectRunsType(in_bytes / sizeOfnvcompType(in_type));
+
+  NVCOMP_TYPE_TWO_SWITCH(
+      in_type,
+      countType,
+      compressTypedAsync,
+      in_ptr,
+      in_bytes,
+      cascadedOpts,
+      temp_ptr,
+      temp_bytes,
+      out_ptr,
+      out_bytes,
+      stream);
+}
+
+} // namespace nvcomp

--- a/nvcomp/CascadedCompressionGPU.h
+++ b/nvcomp/CascadedCompressionGPU.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "cascaded.h"
+#include "common.h"
+#include "CascadedCommon.h"
+
+namespace nvcomp
+{
+
+class nvcompCascadedCompressionGPU
+{
+public:
+  /**
+   * @brief Compute the required temporary workspace on the GPU
+   * required for the given compression configuration.
+   *
+   * @param in_ptr The pointer to the input data on the GPU.
+   * @param in_bytes The length in bytes of the input data.
+   * @param in_type The input data type.
+   * @param opts The compression configuration to use.
+   * @param temp_bytes The required minimum size of the temporary workspace
+   * (output).
+   */
+  static void computeWorkspaceSize(
+      const void* in_ptr,
+      size_t in_bytes,
+      nvcompType_t in_type,
+      const nvcompCascadedFormatOpts* opts,
+      size_t* temp_bytes);
+
+  /**
+   * @brief Generate the compression metadata information.
+   *
+   * @param in_ptr The pointer to the input data on the GPU.
+   * @param in_bytes The length in bytes of the input data.
+   * @param in_type The input data type.
+   * @param opts The compression configuration to use.
+   * @param temp_ptr The allocated temporary workspace on the GPU.
+   * @param temp_bytes The size of the allocated temporary workspace on the
+   * GPU.
+   * @param out_bytes The required output space on the GPU in bytes to store
+   * the compressed data (output).
+   */
+  static void generateOutputUpperBound(
+      const void* in_ptr,
+      size_t in_bytes,
+      nvcompType_t in_type,
+      const nvcompCascadedFormatOpts* opts,
+      void* temp_ptr,
+      size_t temp_bytes,
+      size_t* out_bytes);
+
+  /**
+   * @brief Start the compression on the GPU. This will be asynchronous, if
+   * `out_bytes` is pinned memory, otherwise this method block until all work is
+   * done.
+   *
+   * @param in_ptr The pointer to the input data on the GPU.
+   * @param in_bytes The length in bytes of the input data.
+   * @param in_type The input data type.
+   * @param opts The compression configuration to use.
+   * @param temp_ptr The allocated temporary workspace on the GPU.
+   * @param temp_bytes The size of the allocated temporary workspace on the
+   * GPU.
+   * @param metadata The metadata to use for compression and update.
+   * @param out_ptr The location to write the output to.
+   * @param out_bytes The size of the compressed data (output).
+   * @param stream The stream to queue the compression on.
+   */
+  static void compressAsync(
+      const void* in_ptr,
+      size_t in_bytes,
+      nvcompType_t in_type,
+      const nvcompCascadedFormatOpts* opts,
+      void* temp_ptr,
+      const size_t temp_bytes,
+      void* out_ptr,
+      size_t* out_bytes,
+      cudaStream_t stream);
+};
+
+} // namespace nvcomp

--- a/nvcomp/CascadedDecompression.cu
+++ b/nvcomp/CascadedDecompression.cu
@@ -1,0 +1,1632 @@
+/*
+ * Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "CascadedCompressionGPU.h"
+#include "CascadedMetadata.h"
+#include "CascadedMetadataOnGPU.h"
+
+#include "CascadedDecompressionKernels.cuh"
+#include "Check.h"
+#include "CudaUtils.h"
+#include "cascaded.h"
+#include "nvcomp.h"
+#include "nvcomp.hpp"
+#include "type_macros.h"
+#include "unpack.h"
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weffc++"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
+#include <cub/cub.cuh>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+#ifdef USE_RMM
+#include <rmm/rmm.h>
+#endif
+
+#include <cassert>
+#include <iostream>
+#include <list>
+#include <map>
+#include <mutex>
+#include <sstream>
+#include <vector>
+
+// align all temp allocations by 512B
+#define CUDA_MEM_ALIGN(size) (((size) + 0x1FF) & ~0x1FF)
+
+#ifndef RLE_THREAD_BLOCK
+#define RLE_THREAD_BLOCK 128
+#endif
+
+#ifndef RLE_ELEMS_PER_THREAD
+#define RLE_ELEMS_PER_THREAD 4
+#endif
+
+#define RLE_ELEMS_PER_BLOCK (RLE_THREAD_BLOCK * RLE_ELEMS_PER_THREAD)
+
+namespace nvcomp
+{
+
+// internal representations: one kernel per scheme
+enum nvcompScheme_t
+{
+  NVCOMP_SCHEME_BP,
+  NVCOMP_SCHEME_RLE,
+  NVCOMP_SCHEME_DELTA,
+  NVCOMP_SCHEME_RLE_DELTA, // automatically fused RLE+Delta to reduce mem
+                           // traffic
+};
+
+struct nvcompLayer_t;
+
+struct nvcompDataNode_t
+{
+  void* ptr;
+  nvcompType_t type;
+  int packing;
+
+  nvcompLayer_t* parentLayer;
+  size_t length;
+
+  // to enable BP as a separate layer, default -1
+  int pointToId;
+};
+
+struct nvcompLayer_t
+{
+  nvcompScheme_t scheme;
+  size_t maxOutputSize;
+
+  nvcompDataNode_t* vals;
+  nvcompDataNode_t* runs;
+  nvcompDataNode_t* output;
+
+  // TODO: can we get rid of those
+  int valId;
+  int runId;
+  int outputId;
+};
+
+struct nvcompIntConfig_t
+{
+  int outputId = 0;
+  nvcompType_t outputType = NVCOMP_TYPE_INT;
+  size_t maxOutputSize = 0;
+
+  std::list<nvcompLayer_t> layers = {};
+  std::map<int, nvcompDataNode_t> nodes
+      = {}; // TODO: should we make this nvcompData_t instead of int?
+
+  // compute the workspace size
+  size_t getWorkspaceBytes();
+  size_t getWorkspaceBytes(nvcompDataNode_t* node);
+
+  // fuse kernels, etc.
+  void optimizeLayers();
+};
+
+struct nvcompIntTask_t
+{
+  // TODO: add CUDA event assigned to this task
+};
+
+struct nvcompIntHandle_t
+{
+  std::unique_ptr<nvcompIntConfig_t> config = nullptr;
+  cudaStream_t stream = 0;
+
+  // main decomp functions
+  template <typename outputT>
+  nvcompError_t decompCPU(
+      nvcompDataNode_t* node, const void** inputData, const void** h_headers);
+  template <typename outputT, typename runT>
+  nvcompError_t decompGPU(
+      nvcompDataNode_t* node,
+      const void** inputData,
+      const void** h_headers,
+      cudaStream_t stream);
+
+  // workspace memory
+  size_t workspaceBytes = 0;
+  void* workspaceStorage = nullptr;
+
+  // workspace mem management
+  nvcompError_t release();
+  nvcompError_t
+  allocateAsync(); // new function that splits of pre-allocated memory
+
+  // workspace breakdown
+  size_t max_input_len = 0;  // maximum input RLE length
+  size_t max_output_len = 0; // maximum output RLE length
+
+  void* temp_val = nullptr;    // temp RLE val expansions
+  void* temp_run = nullptr;    // temp RLE run expansions
+  void* temp_delta = nullptr;  // temp Delta expansions
+  void* temp_output = nullptr; // temp Delta expansions
+
+  // cub scan memory
+  size_t temp_scan_bytes = 0;
+  void* temp_scan = nullptr;
+
+  // block indices start and offsets
+  size_t max_num_blocks = 0;
+  size_t* start_ind = nullptr;
+  size_t* start_off = nullptr;
+};
+
+template <typename keyT, typename valueT>
+struct SharedMap
+{
+  std::map<keyT, valueT> data = {};
+  std::mutex m = {};
+
+  // find the next available id
+  keyT find_next()
+  {
+    std::lock_guard<std::mutex> guard(m);
+    int id = 0;
+    while (data.find(id) != data.end())
+      id++;
+    return (keyT)id;
+  }
+
+  bool exists(const keyT& key)
+  {
+    std::lock_guard<std::mutex> guard(m);
+    return data.find(key) != data.end();
+  }
+
+  void insert(const keyT& key, const valueT& val)
+  {
+    std::lock_guard<std::mutex> guard(m);
+    if (data.find(key) == data.end())
+      data[key] = val;
+  }
+
+  valueT& operator[](const keyT& key)
+  {
+    std::lock_guard<std::mutex> guard(m);
+    return data[key];
+  }
+
+  void erase(const keyT& key)
+  {
+    std::lock_guard<std::mutex> guard(m);
+    data.erase(key);
+  }
+};
+
+// internal collections
+SharedMap<nvcompConfig_t, nvcompIntConfig_t> configs;
+SharedMap<nvcompHandle_t, nvcompIntHandle_t> handles;
+
+// TODO: can we get rid of these?
+std::mutex config_mutex;
+std::mutex handle_mutex;
+
+namespace
+{
+
+template <typename T>
+void cubDeviceScanTempSpace(size_t& temp_scan_bytes, const size_t max_input_len)
+{
+  void* temp_scan = nullptr;
+  T* temp_run = nullptr;
+
+  cub::DeviceScan::InclusiveSum(
+      temp_scan, temp_scan_bytes, temp_run, temp_run, max_input_len);
+}
+
+void checkCompressSize(const size_t numBytes)
+{
+  const size_t maxBytes = static_cast<size_t>(std::numeric_limits<int>::max());
+  if (numBytes > maxBytes) {
+    throw std::runtime_error(
+        "Cascaded compression can only compress up to a maximum of "
+        + std::to_string(maxBytes) + " bytes at a time (requested "
+        + std::to_string(numBytes) + " bytes).");
+  }
+}
+
+std::unique_ptr<nvcompIntConfig_t> generateConfig(const CascadedMetadata* const metadata)
+{
+  const int numRLEs = metadata->getNumRLEs();
+  const int numDeltas = metadata->getNumDeltas();
+  const bool bitPacking = metadata->useBitPacking();
+
+  int vals_id = 0;
+
+  // initialize config
+  const nvcompType_t type = metadata->getValueType();
+
+  std::unique_ptr<nvcompIntConfig_t> config(new nvcompIntConfig_t);
+  config->outputId = vals_id;
+  config->outputType = type;
+  config->maxOutputSize = metadata->getUncompressedSize();
+
+  const nvcompType_t runType
+      = selectRunsType(metadata->getNumUncompressedElements());
+
+  const size_t maxSegmentSize = metadata->getUncompressedSize();
+
+  config->nodes[0].length = metadata->getNumUncompressedElements();
+
+  // A step can be RLE+Delta, RLE, or Delta, with final outputs conditionally
+  // having bit packing applied
+  const int numSteps = std::max(numRLEs, numDeltas);
+  for (int r = numSteps - 1; r >= 0; r--) {
+    const int inputId = vals_id;
+
+    if (numSteps - r - 1 < numRLEs) {
+      const int runId = ++vals_id;
+      const int valId = ++vals_id;
+
+      // add to config
+      nvcompConfigAddRLE_BP(
+          config.get(),
+          inputId,
+          maxSegmentSize,
+          valId,
+          type,
+          bitPacking,
+          runId,
+          runType,
+          bitPacking);
+      config->nodes[valId].length = metadata->getNumElementsOf(valId);
+      config->nodes[runId].length = metadata->getNumElementsOf(runId);
+
+      // store vals (apply delta if necessary)
+      if (numRLEs - 1 - r < numDeltas) {
+        const int deltaId = ++vals_id;
+
+        if (r == 0) {
+          nvcompConfigAddDelta_BP(
+              config.get(), valId, maxSegmentSize, deltaId, type, bitPacking);
+        } else {
+          nvcompConfigAddDelta_BP(
+              config.get(),
+              valId,
+              maxSegmentSize,
+              deltaId,
+              type,
+              0); // no bitpacking when delta is used as an intermediate step
+        }
+        config->nodes[deltaId].length = metadata->getNumElementsOf(deltaId);
+      }
+    } else {
+      // RLE-less step
+      const int deltaId = ++vals_id;
+
+      if (r == 0) {
+        nvcompConfigAddDelta_BP(
+            config.get(), inputId, maxSegmentSize, deltaId, type, bitPacking);
+      } else {
+        nvcompConfigAddDelta_BP(
+            config.get(),
+            inputId,
+            maxSegmentSize,
+            deltaId,
+            type,
+            0); // no bitpacking when delta is used as an intermediate step
+      }
+      config->nodes[deltaId].length = metadata->getNumElementsOf(deltaId);
+    }
+  }
+
+  // If there are no RLEs or Deltas, we will do a single BP step.
+  if (numRLEs == 0 && numDeltas == 0) {
+    const int inputId = vals_id;
+    const int bpId = ++vals_id;
+    nvcompConfigAddBP(config.get(), inputId, maxSegmentSize, bpId, type);
+
+    config->nodes[bpId].length = metadata->getNumElementsOf(bpId);
+  }
+
+  return config;
+}
+
+template <typename T>
+constexpr bool isFixedWidth()
+{
+  return std::is_same<T, char>::value || std::is_same<T, int8_t>::value
+         || std::is_same<T, uint8_t>::value || std::is_same<T, int16_t>::value
+         || std::is_same<T, uint16_t>::value || std::is_same<T, int32_t>::value
+         || std::is_same<T, uint32_t>::value || std::is_same<T, int64_t>::value
+         || std::is_same<T, uint64_t>::value;
+}
+
+template <typename T>
+size_t writeFixedWidthData(
+    const T* const val,
+    void* const ptr,
+    const size_t offset,
+    const size_t maxSize)
+{
+  assert(isFixedWidth<T>());
+
+  size_t newOffset = offset + sizeof(*val);
+
+  if (ptr) {
+    // only write if we're doing a really output
+    if (newOffset > maxSize) {
+      throw std::runtime_error(
+          "Not enough room to write member, need at least "
+          + std::to_string(newOffset) + " bytes, but given only "
+          + std::to_string(maxSize));
+    }
+
+    memcpy(static_cast<char*>(ptr) + offset, val, sizeof(*val));
+  }
+
+  return newOffset;
+}
+
+template <typename T>
+size_t writeData(
+    const T* const val,
+    void* const ptr,
+    const size_t offset,
+    const size_t maxSize)
+{
+  if (isFixedWidth<T>()) {
+    return writeFixedWidthData(val, ptr, offset, maxSize);
+  } else if (std::is_same<T, bool>::value) {
+    const int8_t typedVal = static_cast<int8_t>(*val);
+    return writeData(&typedVal, ptr, offset, maxSize);
+  } else if (std::is_same<T, int>::value) {
+    // on most systems this will not be used, as int32_t is usually defined as
+    // int
+    const int32_t typedVal = static_cast<int32_t>(*val);
+    return writeData(&typedVal, ptr, offset, maxSize);
+  } else if (std::is_same<T, size_t>::value) {
+    const uint64_t typedVal = static_cast<uint64_t>(*val);
+    return writeData(&typedVal, ptr, offset, maxSize);
+  } else {
+    throw std::runtime_error("Unsupported type for serialization.");
+  }
+}
+
+} // namespace
+
+
+/**************************************************************************************
+ *            Older API definitions below.  New API calls rely on them.
+ **************************************************************************************/
+
+nvcompIntConfig_t * createConfig(const CascadedMetadata* metadata)
+{
+  return generateConfig(metadata).release();
+}
+
+void destroyConfig(nvcompIntConfig_t* config)
+{
+  delete config;
+}
+
+nvcompError_t nvcompConfigAddRLE_BP(
+    nvcompIntConfig_t* const config,
+    int outputId,
+    size_t maxOutputSize,
+    int valId,
+    nvcompType_t valType,
+    int valPacking,
+    int runId,
+    nvcompType_t runType,
+    int runPacking)
+{
+  nvcompIntConfig_t& c = *config;
+
+  // setup input nodes if necessary
+  if (c.nodes.find(valId) == c.nodes.end()) {
+    c.nodes[valId] = {NULL, valType, valPacking, NULL, 0, 0};
+  }
+  if (c.nodes.find(runId) == c.nodes.end()) {
+    c.nodes[runId] = {NULL, runType, runPacking, NULL, 0, 0};
+  }
+
+  // create the output node if necessary
+  if (c.nodes.find(outputId) == c.nodes.end()) {
+    c.nodes[outputId] = {NULL, valType, 0, NULL, 0, 0};
+  }
+
+  nvcompLayer_t layer = {NVCOMP_SCHEME_RLE,
+                         maxOutputSize,
+                         NULL,
+                         NULL,
+                         NULL,
+                         valId,
+                         runId,
+                         outputId};
+  c.layers.push_back(layer);
+  c.nodes[outputId].parentLayer = &c.layers.back();
+
+  return nvcompSuccess;
+}
+
+nvcompError_t nvcompConfigAddDelta_BP(
+    nvcompIntConfig_t* const config,
+    int outputId,
+    size_t maxOutputSize,
+    int valId,
+    nvcompType_t valType,
+    int valPacking)
+{
+  nvcompIntConfig_t& c = *config;
+
+  // setup the input node if necessary
+  if (c.nodes.find(valId) == c.nodes.end()) {
+    c.nodes[valId] = {NULL, valType, valPacking, NULL, 0, 0};
+  }
+
+  // create the output node if necessary
+  if (c.nodes.find(outputId) == c.nodes.end()) {
+    c.nodes[outputId] = {NULL, valType, 0, NULL, 0, 0};
+  }
+
+  nvcompLayer_t layer = {NVCOMP_SCHEME_DELTA,
+                         maxOutputSize,
+                         NULL,
+                         NULL,
+                         NULL,
+                         valId,
+                         -1,
+                         outputId};
+  c.layers.push_back(layer);
+  c.nodes[outputId].parentLayer = &c.layers.back();
+
+  return nvcompSuccess;
+}
+
+nvcompError_t nvcompConfigAddBP(
+    nvcompIntConfig_t* const config,
+    int outputId,
+    size_t maxOutputSize,
+    int valId,
+    nvcompType_t valType)
+{
+  nvcompIntConfig_t& c = *config;
+
+  // setup the input node if necessary
+  if (c.nodes.find(valId) == c.nodes.end()) {
+    c.nodes[valId] = {NULL, valType, 1, NULL, 0, 0};
+  }
+
+  // create the output node if necessary
+  if (c.nodes.find(outputId) == c.nodes.end()) {
+    c.nodes[outputId] = {NULL, valType, 0, NULL, 0, 0};
+  }
+
+  nvcompLayer_t layer = {
+      NVCOMP_SCHEME_BP, maxOutputSize, NULL, NULL, NULL, valId, -1, outputId};
+  c.layers.push_back(layer);
+  c.nodes[outputId].parentLayer = &c.layers.back();
+
+  return nvcompSuccess;
+}
+
+size_t nvcompIntConfig_t::getWorkspaceBytes(nvcompDataNode_t* /*node*/)
+{
+  // TODO: allocate output buffers for each node except the terminal one
+  // currently this is done inside decompGPU which will break concurrency (once
+  // we add streams)
+  return 0;
+}
+
+size_t nvcompIntConfig_t::getWorkspaceBytes()
+{
+  if (nodes.find(outputId) == nodes.end()) {
+    throw std::runtime_error(
+        "getWorkspaceBytes(): could not find output ID amongst nodes: "
+        + std::to_string(outputId) + " with " + std::to_string(nodes.size())
+        + " nodes.");
+  }
+  if (nodes[outputId].parentLayer == NULL) {
+    throw std::runtime_error("getWorkspaceBytes(): the output node is not used "
+                             "by any compression layers.");
+  }
+
+  int numRLEs = 0;
+  int numDeltas = 0;
+
+  size_t max_input_len = 0;
+  for (const nvcompLayer_t& layer : layers) {
+    if (layer.scheme == NVCOMP_SCHEME_RLE
+        || layer.scheme == NVCOMP_SCHEME_RLE_DELTA) {
+      ++numRLEs;
+    }
+    if (layer.scheme == NVCOMP_SCHEME_DELTA
+        || layer.scheme == NVCOMP_SCHEME_RLE_DELTA) {
+      ++numDeltas;
+    }
+
+    const size_t layer_len = nodes[layer.valId].length;
+    if (layer_len > max_input_len) {
+      max_input_len = layer_len;
+    }
+  }
+
+  const size_t max_output_len = maxOutputSize;
+
+  size_t size = 0;
+
+  // temp vals, runs, delta, output
+  if (numRLEs > 0 || numDeltas > 0) {
+    size += CUDA_MEM_ALIGN(max_input_len * sizeOfnvcompType(outputType));
+    if (numRLEs > 0) {
+      size += CUDA_MEM_ALIGN(
+          max_input_len * sizeOfnvcompType(selectRunsType(maxOutputSize)));
+    }
+    size += CUDA_MEM_ALIGN(max_input_len * sizeOfnvcompType(outputType));
+    size += CUDA_MEM_ALIGN(max_input_len * sizeOfnvcompType(outputType));
+  }
+
+  size_t temp_scan_bytes_run = 0;
+  size_t temp_scan_bytes_delta = 0;
+  NVCOMP_TYPE_ONE_SWITCH(
+      selectRunsType(max_output_len),
+      cubDeviceScanTempSpace,
+      temp_scan_bytes_run,
+      max_input_len);
+  NVCOMP_TYPE_ONE_SWITCH(
+      outputType, cubDeviceScanTempSpace, temp_scan_bytes_delta, max_input_len);
+  size_t temp_scan_bytes = std::max(temp_scan_bytes_run, temp_scan_bytes_delta);
+
+  size += CUDA_MEM_ALIGN(temp_scan_bytes);
+
+  size_t max_num_blocks
+      = (max_output_len + RLE_ELEMS_PER_BLOCK - 1) / RLE_ELEMS_PER_BLOCK;
+  size += CUDA_MEM_ALIGN((max_num_blocks + 1) * sizeof(size_t));
+  size += CUDA_MEM_ALIGN((max_num_blocks + 1) * sizeof(size_t));
+
+  return size;
+}
+
+nvcompError_t nvcompIntHandle_t::release()
+{
+  return nvcompSuccess;
+}
+
+// recursively assign memory for all nodes in our DAG
+// ** Assumes worspaceStorage is already allocated with sufficient space **
+nvcompError_t nvcompIntHandle_t::allocateAsync()
+{
+  nvcompIntConfig_t& c = *config;
+
+  nvcompType_t outputType = c.outputType;
+
+  // assign member variables for size
+  max_output_len = c.maxOutputSize;
+  max_input_len = 0;
+  int numRLEs = 0;
+  int numDeltas = 0;
+  for (const nvcompLayer_t& layer : c.layers) {
+    if (layer.scheme == NVCOMP_SCHEME_RLE
+        || layer.scheme == NVCOMP_SCHEME_RLE_DELTA) {
+      ++numRLEs;
+    }
+    if (layer.scheme == NVCOMP_SCHEME_DELTA
+        || layer.scheme == NVCOMP_SCHEME_RLE_DELTA) {
+      ++numDeltas;
+    }
+
+    const size_t layer_len = c.nodes[layer.valId].length;
+    if (layer_len > max_input_len) {
+      max_input_len = layer_len;
+    }
+  }
+
+  unsigned char* ptr = (unsigned char*)workspaceStorage;
+
+  // temporary buffers that can hold RLE expansions and other data, but we will
+  // re-use locations
+  if (numRLEs > 0 || numDeltas > 0) {
+    temp_val = ptr;
+    ptr += CUDA_MEM_ALIGN(max_input_len * sizeOfnvcompType(outputType));
+    if (numRLEs > 0) {
+      temp_run = ptr;
+      ptr += CUDA_MEM_ALIGN(
+          max_input_len * sizeOfnvcompType(selectRunsType(max_output_len)));
+    }
+    temp_delta = ptr;
+    ptr += CUDA_MEM_ALIGN(max_input_len * sizeOfnvcompType(outputType));
+
+    // one additional buffer for delta expansion
+    // TODO: can we get rid of this one?
+    temp_output = ptr;
+    ptr += CUDA_MEM_ALIGN(max_input_len * sizeOfnvcompType(outputType));
+  }
+
+  // allocate temp storage for cub scan using the largest size_t
+  // this temp storage will be reused by delta and runs scans of different types
+  temp_scan = ptr;
+
+  size_t temp_scan_bytes_run = 0;
+  size_t temp_scan_bytes_delta = 0;
+  NVCOMP_TYPE_ONE_SWITCH(
+      selectRunsType(max_output_len),
+      cubDeviceScanTempSpace,
+      temp_scan_bytes_run,
+      max_input_len);
+  NVCOMP_TYPE_ONE_SWITCH(
+      outputType, cubDeviceScanTempSpace, temp_scan_bytes_delta, max_input_len);
+  temp_scan_bytes = std::max(temp_scan_bytes_run, temp_scan_bytes_delta);
+  ptr += CUDA_MEM_ALIGN(temp_scan_bytes);
+
+  // block indices/offsets
+  max_num_blocks
+      = (max_output_len + RLE_ELEMS_PER_BLOCK - 1) / RLE_ELEMS_PER_BLOCK;
+  start_ind = (size_t*)ptr;
+  ptr += CUDA_MEM_ALIGN((max_num_blocks + 1) * sizeof(size_t));
+  start_off = (size_t*)ptr;
+  ptr += CUDA_MEM_ALIGN((max_num_blocks + 1) * sizeof(size_t));
+
+  return nvcompSuccess;
+}
+
+// here we do kernel fusion
+void nvcompIntConfig_t::optimizeLayers()
+{
+  for (auto it = layers.begin(); it != layers.end();) {
+    if (it->scheme == NVCOMP_SCHEME_DELTA) {
+      int valId = it->valId;
+      int outputId = it->outputId;
+      if (nodes.find(valId) != nodes.end() && nodes[valId].parentLayer != NULL
+          && nodes[valId].parentLayer->scheme == NVCOMP_SCHEME_RLE) {
+        nodes[outputId].parentLayer = nodes[valId].parentLayer;
+        nodes[outputId].parentLayer->scheme = NVCOMP_SCHEME_RLE_DELTA;
+        nodes[outputId].parentLayer->outputId = outputId;
+        it = layers.erase(it);
+        continue;
+      }
+    }
+    it++;
+  }
+}
+
+/* These functions may not be needed and removed to simplify codebase */
+nvcompError_t nvcompSetWorkspace(
+    nvcompHandle_t /*handle*/,
+    void* /*workspaceStorage*/,
+    size_t /*workspaceBytes*/)
+{
+  std::cerr << "ERROR: nvcompSetWorkspace is not implemented yet!" << std::endl;
+  return nvcompErrorNotSupported;
+}
+
+nvcompError_t
+nvcompGetWorkspaceSize(nvcompHandle_t handle, size_t* workspaceBytes)
+{
+  *workspaceBytes = handles[handle].workspaceBytes;
+
+  return nvcompSuccess;
+}
+
+nvcompError_t nvcompSetStream(nvcompHandle_t handle, cudaStream_t streamId)
+{
+  handles[handle].stream = streamId;
+
+  return nvcompSuccess;
+}
+
+nvcompError_t nvcompGetStream(nvcompHandle_t handle, cudaStream_t* streamId)
+{
+  *streamId = handles[handle].stream;
+
+  return nvcompSuccess;
+}
+
+// if the header is not packed this will shallow copy the pointer
+// otherwise unpack into the output buffer
+template <typename inputT, typename outputT>
+void unpackCpu(
+    outputT** output, nvcompDataNode_t* node, const void* hdr, const void* data)
+{
+  const CascadedMetadata::Header header
+      = *static_cast<const CascadedMetadata::Header*>(hdr);
+  if (node->packing) {
+    for (size_t i = 0; i < header.length; ++i) {
+      const inputT minValue
+          = *CascadedMetadata::getMinValueLocation<inputT>(&header);
+      (*output)[i] = unpackBytes(data, header.numBits, minValue, i);
+    }
+  } else {
+    if (typeid(inputT) == typeid(outputT)) {
+      *output = (outputT*)data;
+    } else {
+      for (size_t i = 0; i < header.length; i++)
+        (*output)[i] = (outputT)((inputT*)data)[i];
+    }
+  }
+}
+
+template <typename outputT>
+void unpackCpu(
+    outputT** output, nvcompDataNode_t* node, const void* hdr, const void* data)
+{
+  NVCOMP_TYPE_TWO_SWITCH_FIRST_ONLY(
+      node->type, outputT, unpackCpu, output, node, hdr, data);
+}
+
+// if the header is not packed this will shallow copy the pointer if it's
+// accessible from the GPU otherwise copy or unpack into the output buffer
+template <typename inputT, typename outputT>
+void unpackGpu(
+    outputT* d_output,
+    nvcompDataNode_t* node,
+    const void* data,
+    const void* h_hdr,
+    cudaStream_t stream)
+{
+  void* d_input = NULL;
+
+  // prepare input data
+  cudaPointerAttributes attr;
+
+  cudaError_t err = cudaPointerGetAttributes(&attr, data);
+  if (err != cudaSuccess) {
+    std::ostringstream oss;
+    oss << data;
+    throw std::runtime_error(
+        "unpackGpu(): Failed to get pointer attributes for " + oss.str()
+        + " due to: " + std::to_string(err));
+  }
+
+  if (attr.type != cudaMemoryTypeUnregistered) {
+    // memory is accessible to the GPU
+    d_input = attr.devicePointer;
+  } else {
+    throw std::runtime_error("unpackGpu(): Data not accessible to the GPU");
+  }
+
+  // Get length of run from the host-side header
+  size_t length = static_cast<const CascadedMetadata::Header*>(h_hdr)->length;
+
+  CascadedMetadata::Header header
+      = *static_cast<const CascadedMetadata::Header*>(h_hdr);
+  const unsigned char numBits = header.numBits;
+  const inputT minValue
+      = *CascadedMetadata::getMinValueLocation<inputT>(&header);
+
+  const dim3 block(512);
+  const dim3 grid(roundUpDiv(length, block.x));
+  if (node->packing) {
+    unpackBytesKernel<<<grid, block, 0, stream>>>(
+        d_input, d_output, numBits, minValue, length);
+  } else {
+    convertKernel<<<grid, block, 0, stream>>>(
+        static_cast<const inputT*>(d_input), d_output, length);
+  }
+}
+
+template <typename outputT>
+void unpackGpu(
+    outputT* d_output,
+    nvcompDataNode_t* node,
+    const void* data,
+    const void* h_hdr,
+    cudaStream_t stream)
+{
+  NVCOMP_TYPE_TWO_SWITCH_FIRST_ONLY(
+      node->type, outputT, unpackGpu, d_output, node, data, h_hdr, stream);
+}
+
+template <typename outputT>
+nvcompError_t nvcompIntHandle_t::decompCPU(
+    nvcompDataNode_t* node, const void** inputHdrs, const void** inputData)
+{
+  size_t maxOutputSize = config->maxOutputSize;
+
+  std::vector<outputT> unpacked_vals;
+  std::vector<size_t> unpacked_runs;
+  outputT* vals_data = NULL;
+  size_t* runs_data = NULL;
+  size_t vals_len;
+
+  nvcompLayer_t* layer = node->parentLayer;
+
+  // add BP only layer
+  if (layer->scheme == NVCOMP_SCHEME_BP) {
+    unpacked_vals.resize(maxOutputSize);
+    vals_data = &unpacked_vals[0];
+    unpackCpu(
+        &vals_data,
+        layer->vals,
+        inputHdrs[layer->valId],
+        inputData[layer->valId]);
+    vals_len
+        = static_cast<const CascadedMetadata::Header*>(inputHdrs[layer->valId])
+              ->length;
+
+    node->length = vals_len;
+
+    // lazy allocation
+    // TODO: move to allocate()
+    if (node->ptr == NULL)
+      node->ptr = new outputT[vals_len];
+
+    // copy and convert type if necessary
+    for (int i = 0; i < vals_len; i++) {
+      ((outputT*)(node->ptr))[i] = vals_data[i];
+    }
+    return nvcompSuccess;
+  }
+
+  // compute vals
+  if (layer->vals->parentLayer != NULL) {
+    decompCPU<outputT>(layer->vals, inputHdrs, inputData);
+    vals_data = (outputT*)layer->vals->ptr;
+    vals_len = layer->vals->length;
+  } else {
+    unpacked_vals.resize(maxOutputSize);
+    vals_data = &unpacked_vals[0];
+    unpackCpu(
+        &vals_data,
+        layer->vals,
+        inputHdrs[layer->valId],
+        inputData[layer->valId]);
+    vals_len
+        = static_cast<const CascadedMetadata::Header*>(inputHdrs[layer->valId])
+              ->length;
+  }
+
+  // compute runs
+  if (layer->runs != NULL) {
+    if (layer->runs->parentLayer != NULL) {
+      decompCPU<size_t>(layer->runs, inputHdrs, inputData);
+      runs_data = (size_t*)layer->runs->ptr;
+    } else {
+      unpacked_runs.resize(maxOutputSize);
+      runs_data = &unpacked_runs[0];
+      unpackCpu(
+          &runs_data,
+          layer->runs,
+          inputHdrs[layer->runId],
+          inputData[layer->runId]);
+    }
+  }
+
+  // decompress (this is using additional memory)
+  std::vector<outputT> next;
+  next.clear();
+  switch (layer->scheme) {
+  case NVCOMP_SCHEME_RLE: {
+    for (int i = 0; i < vals_len; i++)
+      next.insert(next.end(), runs_data[i], vals_data[i]);
+    break;
+  }
+  case NVCOMP_SCHEME_RLE_DELTA: {
+    for (int i = 0; i < vals_len; i++)
+      next.insert(next.end(), runs_data[i], vals_data[i]);
+    for (int i = 1; i < next.size(); i++)
+      next[i] += next[i - 1];
+    break;
+  }
+  case NVCOMP_SCHEME_DELTA: {
+    next.resize(vals_len);
+    next[0] = vals_data[0];
+    for (int i = 1; i < vals_len; i++)
+      next[i] = next[i - 1] + vals_data[i];
+    break;
+  }
+  default:
+    return nvcompErrorNotSupported;
+  }
+
+  node->length = next.size();
+
+  // lazy allocation
+  // TODO: move to allocate()
+  if (node->ptr == NULL)
+    node->ptr = new outputT[next.size()];
+
+  // copy and convert type if necessary
+  for (int i = 0; i < next.size(); i++)
+    ((outputT*)(node->ptr))[i] = next[i];
+
+  return nvcompSuccess;
+}
+
+// Perform Cascaded decompression on the GPU.
+// Assumes all workspace is pre-allocated and assigned, inputHdrs and inputData
+// are GPU-accessible, and h_headers is CPU-accessible
+template <typename outputT, typename runT>
+nvcompError_t nvcompIntHandle_t::decompGPU(
+    nvcompDataNode_t* node,
+    const void** inputData,
+    const void** h_headers,
+    cudaStream_t stream = NULL)
+{
+  // prepare device output buffer if necessary
+  // TODO: move to the init step
+  cudaPointerAttributes attr;
+  outputT* out_ptr = NULL;
+
+  // get typed copies of pointers to avoid casting
+  outputT* const localOutput = static_cast<outputT*>(temp_output);
+  outputT* const localDelta = static_cast<outputT*>(temp_delta);
+  runT* const localRun = static_cast<runT*>(temp_run);
+
+  if (node->ptr == nullptr) {
+    throw std::runtime_error(
+        "nvcompIntHandle_t::decompGPU(): Got node with null ptr.");
+  }
+
+  cudaError_t err = cudaPointerGetAttributes(&attr, node->ptr);
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        "nvcompIntHandle_t::decompGPU(): Failed to get cuda pointer "
+        "attributes: "
+        + std::to_string(err));
+  }
+
+  if (attr.type != cudaMemoryTypeUnregistered) {
+    // direct access is possible
+    out_ptr = (outputT*)attr.devicePointer;
+  } else {
+    throw std::runtime_error("nvcompIntHandle_t::decompGPU(): Workspace memory "
+                             "not accessible to GPU.");
+  }
+
+  nvcompLayer_t* layer = node->parentLayer;
+
+  if (layer->scheme == NVCOMP_SCHEME_BP) {
+    // We assume this is the only layer, and we just do it and exit
+    layer->vals->ptr = out_ptr;
+    unpackGpu(
+        (outputT*)layer->vals->ptr,
+        layer->vals,
+        inputData[layer->valId],
+        h_headers[layer->valId],
+        stream);
+    layer->vals->length
+        = static_cast<const CascadedMetadata::Header*>(h_headers[layer->valId])
+              ->length;
+    assert(layer->vals->length <= max_input_len);
+
+    return nvcompSuccess;
+  }
+
+  // prepare inputs
+  std::swap(temp_output, temp_val);
+  if (layer->vals->parentLayer != NULL) {
+    layer->vals->ptr = localOutput;
+    // when recursing, swap
+    decompGPU<outputT, runT>(layer->vals, inputData, h_headers, stream);
+  } else {
+    // unpack RLE values
+    layer->vals->ptr = localOutput;
+    unpackGpu(
+        (outputT*)layer->vals->ptr,
+        layer->vals,
+        inputData[layer->valId],
+        h_headers[layer->valId],
+        stream);
+    layer->vals->length
+        = static_cast<const CascadedMetadata::Header*>(h_headers[layer->valId])
+              ->length;
+    assert(layer->vals->length <= max_input_len);
+  }
+
+  if (layer->runs != nullptr) {
+    if (layer->runs->parentLayer != nullptr) {
+      throw std::runtime_error("decompGPU(): Runs cannot have parent layers.");
+    } else {
+      // unpack RLE runs
+      layer->runs->ptr = localRun;
+      unpackGpu(
+          (runT*)layer->runs->ptr,
+          layer->runs,
+          inputData[layer->runId],
+          h_headers[layer->runId],
+          stream);
+      layer->runs->length = static_cast<const CascadedMetadata::Header*>(
+                                h_headers[layer->runId])
+                                ->length;
+    }
+  }
+
+  outputT* d_vals = (outputT*)layer->vals->ptr;
+  const size_t input_size = layer->vals->length;
+  assert(input_size <= max_input_len);
+
+  if (layer->scheme == NVCOMP_SCHEME_DELTA) {
+    assert(out_ptr != d_vals);
+    cub::DeviceScan::InclusiveSum(
+        temp_scan, temp_scan_bytes, d_vals, out_ptr, input_size, stream);
+  } else {
+    // must be RLE of some form
+    runT* d_runs = (runT*)layer->runs->ptr;
+
+    assert(layer->runs->length == input_size);
+
+    if (layer->scheme == NVCOMP_SCHEME_RLE_DELTA) {
+      const dim3 block(512);
+      const dim3 grid(roundUpDiv(input_size, block.x));
+      vecMultKernel<<<grid, block, 0, stream>>>(
+          d_vals, d_runs, localDelta, input_size);
+
+      // inclusive scan to compute Delta sums
+      cub::DeviceScan::InclusiveSum(
+          temp_scan,
+          temp_scan_bytes,
+          localDelta,
+          localDelta,
+          input_size,
+          stream);
+    }
+
+    // inclusive scan to compute RLE offsets
+    // TODO: could be merged with the unpack kernel?
+    cub::DeviceScan::InclusiveSum(
+        temp_scan, temp_scan_bytes, d_runs, d_runs, input_size, stream);
+
+    const size_t output_length = node->length;
+
+    // precompute start/end boundaries for each CUDA block
+    size_t output_grid
+        = (output_length + RLE_ELEMS_PER_BLOCK - 1) / RLE_ELEMS_PER_BLOCK;
+    size_t output_grid_block
+        = (output_grid + RLE_THREAD_BLOCK - 1) / RLE_THREAD_BLOCK;
+    searchBlockBoundaries<runT, RLE_THREAD_BLOCK, RLE_ELEMS_PER_THREAD>
+        <<<output_grid_block, RLE_THREAD_BLOCK, 0, stream>>>(
+            start_ind, start_off, output_grid, input_size, d_runs);
+
+    // expand RLE and apply Delta: buf[r] -> buf[r+1]
+    // TODO: implement macro to look nicer?
+    switch (layer->scheme) {
+    case NVCOMP_SCHEME_RLE_DELTA:
+      expandRLEDelta<
+          outputT,
+          outputT,
+          runT,
+          RLE_THREAD_BLOCK,
+          RLE_ELEMS_PER_THREAD,
+          true><<<output_grid, RLE_THREAD_BLOCK, 0, stream>>>(
+          (outputT*)out_ptr,
+          output_length,
+          d_vals,
+          d_runs,
+          localDelta,
+          start_ind,
+          start_off);
+      break;
+    case NVCOMP_SCHEME_RLE:
+      expandRLEDelta<
+          outputT,
+          outputT,
+          runT,
+          RLE_THREAD_BLOCK,
+          RLE_ELEMS_PER_THREAD,
+          false><<<output_grid, RLE_THREAD_BLOCK, 0, stream>>>(
+          (outputT*)out_ptr,
+          output_length,
+          d_vals,
+          d_runs,
+          localDelta,
+          start_ind,
+          start_off);
+      break;
+    default:
+      throw std::runtime_error(
+          "Invalid rle scheme: " + std::to_string(layer->scheme));
+    }
+  }
+
+  return nvcompSuccess;
+}
+
+nvcompError_t
+nvcompSetNodeLength(nvcompHandle_t handle, int nodeId, size_t output_length)
+{
+  nvcompIntHandle_t& h = handles[handle];
+  nvcompIntConfig_t& c = *h.config;
+  c.nodes[nodeId].length = output_length;
+  return nvcompSuccess;
+}
+
+// Main function that sets up Cascaded decompression from the old API.
+// the new cascaded decompression API call is just a wrapper around this (though
+// heavily modified to be asynchronous).
+template <typename outputType, typename runType>
+nvcompError_t nvcompDecompressLaunch(
+    nvcompHandle_t handle,
+    void* outputData,
+    const size_t outputSize,
+    const void** inputData,
+    const void** h_headers)
+{
+  nvcompIntHandle_t& h = handles[handle];
+
+  nvcompIntConfig_t& c = *h.config;
+
+  // TODO: assign all the buffers
+  nvcompDataNode_t* terminal_node = &c.nodes[c.outputId];
+  terminal_node->ptr = outputData;
+
+  nvcompError_t ret = h.decompGPU<outputType, runType>(
+      terminal_node, inputData, h_headers, h.stream);
+
+  const size_t neededBytes = terminal_node->length * sizeof(outputType);
+  if (outputSize < neededBytes) {
+    std::cerr << "Insufficient space to write decompressed date: given "
+              << outputSize << " bytes but need " << neededBytes << " bytes."
+              << std::endl;
+    return nvcompErrorInvalidValue;
+  }
+
+  // this is to enable the correct result for multi-chunk execuation
+  for (auto it = c.nodes.begin(); it != c.nodes.end(); it++) {
+    it->second.length = 0;
+  }
+
+  return ret;
+}
+
+nvcompError_t nvcompDecompressLaunch(
+    nvcompHandle_t handle,
+    const size_t numUncompressedElements,
+    void* const outputData,
+    const size_t outputSize,
+    const void** const inputData,
+    const void** const h_headers)
+{
+  const nvcompType_t outputType = handles[handle].config->outputType;
+  const nvcompType_t runType = selectRunsType(numUncompressedElements);
+
+  NVCOMP_TYPE_TWO_SWITCH_RETURN(
+      outputType,
+      runType,
+      nvcompDecompressLaunch,
+      handle,
+      outputData,
+      outputSize,
+      inputData,
+      h_headers);
+}
+
+nvcompError_t nvcompDestroyHandle(nvcompHandle_t handle)
+{
+  nvcompIntHandle_t& h = handles[handle];
+  nvcompIntConfig_t& c = *h.config;
+
+  // free temp memory
+  h.release();
+
+  // clear all local nodes attached to this config
+  c.nodes.clear();
+
+  // remove the handle from the list
+  handles.erase(handle);
+
+  return nvcompSuccess;
+}
+
+// Modified version of handle creation function from previous API to now be
+// asynchronous Assumes workspaceStorage is already allocated.
+nvcompError_t nvcompCreateHandleAsync(
+    nvcompHandle_t* handle,
+    std::unique_ptr<nvcompIntConfig_t> config,
+    void* workspaceStorage,
+    const size_t workspaceBytes,
+    cudaStream_t stream)
+{
+
+  std::lock_guard<std::mutex> guard(handle_mutex);
+
+  nvcompIntConfig_t& c = *config;
+
+  // first - optimize the plan
+  c.optimizeLayers();
+  // assign pointers - at this point the nodes map is set
+  for (auto it = c.layers.begin(); it != c.layers.end(); it++) {
+    it->vals = &c.nodes[it->valId];
+    it->output = &c.nodes[it->outputId];
+    if (it->runId >= 0)
+      it->runs = &c.nodes[it->runId];
+  }
+
+  if (workspaceBytes < c.getWorkspaceBytes()) {
+    std::cerr << "Insufficient workspace size: got " << workspaceBytes
+              << " but need " << c.getWorkspaceBytes() << std::endl;
+    return nvcompErrorInvalidValue;
+  }
+
+  // find the next available id
+  nvcompHandle_t id = handles.find_next();
+  *handle = id;
+  nvcompIntHandle_t& h = handles[id];
+
+  h.config = std::move(config);
+  h.stream = stream;
+
+  h.workspaceBytes = workspaceBytes;
+  h.workspaceStorage = workspaceStorage;
+
+  h.allocateAsync();
+
+  return nvcompSuccess;
+}
+
+} // namespace nvcomp
+
+using namespace nvcomp;
+
+nvcompError_t nvcompCascadedDecompressGetMetadata(
+    const void* in_ptr,
+    const size_t in_bytes,
+    void** metadata_ptr,
+    cudaStream_t stream)
+{
+  try {
+    CHECK_NOT_NULL(in_ptr);
+    CHECK_NOT_NULL(metadata_ptr);
+
+    CascadedMetadataOnGPU gpuMetadata((void*)in_ptr, in_bytes);
+    *metadata_ptr = new CascadedMetadata(gpuMetadata.copyToHost(stream));
+  } catch (const std::exception& e) {
+    return Check::exception_to_error(
+        e, "nvcompCascadedDecompressGetMetadata()");
+  }
+
+  return nvcompSuccess;
+}
+
+void nvcompCascadedDecompressDestroyMetadata(void* const metadata_ptr)
+{
+  CascadedMetadata* metadata = static_cast<CascadedMetadata*>(metadata_ptr);
+  ::operator delete(metadata);
+}
+
+// TODO: improve estimate with a more sophistocated approach.
+nvcompError_t nvcompCascadedDecompressGetTempSize(
+    const void* metadata_ptr, size_t* temp_bytes)
+{
+  try {
+    CHECK_NOT_NULL(metadata_ptr);
+    CHECK_NOT_NULL(temp_bytes);
+
+    CascadedMetadata* metadata = (CascadedMetadata*)metadata_ptr;
+
+    std::unique_ptr<nvcompIntConfig_t> c = generateConfig(metadata);
+
+    // first - optimize the plan
+    c->optimizeLayers();
+    // assign pointers - at this point the nodes map is set
+    for (auto& layer : c->layers) {
+      layer.vals = &c->nodes[layer.valId];
+      layer.output = &c->nodes[layer.outputId];
+      if (layer.runId >= 0) {
+        layer.runs = &c->nodes[layer.runId];
+      }
+    }
+
+    // Return the required temp storage size
+    *temp_bytes = c->getWorkspaceBytes();
+  } catch (const std::exception& e) {
+    return Check::exception_to_error(
+        e, "nvcompCascadedDecompressGetTempSize()");
+  }
+
+  return nvcompSuccess;
+}
+
+nvcompError_t nvcompCascadedDecompressGetOutputSize(
+    const void* metadata_ptr, size_t* output_bytes)
+{
+  try {
+    *output_bytes = static_cast<const CascadedMetadata*>(metadata_ptr)
+                        ->getUncompressedSize();
+  } catch (const std::exception& e) {
+    return Check::exception_to_error(
+        e, "nvcompCascadedDecompressionGetOutputSize()");
+  }
+
+  return nvcompSuccess;
+}
+
+nvcompError_t nvcompCascadedDecompressAsync(
+    const void* const in_ptr,
+    const size_t in_bytes,
+    void* const temp_ptr,
+    const size_t temp_bytes,
+    const void* const metadata_ptr,
+    void* const out_ptr,
+    const size_t out_bytes,
+    cudaStream_t stream)
+{
+  nvcompHandle_t handle = -1;
+  try {
+    CHECK_NOT_NULL(metadata_ptr);
+
+    const CascadedMetadata* const metadata
+        = static_cast<const CascadedMetadata*>(metadata_ptr);
+
+    if (in_bytes < metadata->getCompressedSize()) {
+      throw NVCompException(
+          nvcompErrorInvalidValue,
+          "in_bytes is smaller than compressed data size: "
+              + std::to_string(in_bytes) + " < "
+              + std::to_string(metadata->getCompressedSize()));
+    }
+
+    std::unique_ptr<nvcompIntConfig_t> c = generateConfig(metadata);
+
+    // first - optimize the plan
+    c->optimizeLayers();
+    // assign pointers - at this point the nodes map is set
+    for (auto& layer : c->layers) {
+      layer.vals = &c->nodes[layer.valId];
+      layer.output = &c->nodes[layer.outputId];
+      if (layer.runId >= 0) {
+        layer.runs = &c->nodes[layer.runId];
+      }
+    }
+
+    CHECK_API_CALL(
+        nvcompCreateHandleAsync(&handle, std::move(c), temp_ptr, temp_bytes, stream));
+    assert(handle >= 0);
+
+    // Pointers to different portions of compressed data
+    std::vector<void*> inputData(metadata->getNumInputs(), nullptr);
+
+    std::vector<CascadedMetadata::Header> inputHdrs;
+    std::vector<CascadedMetadata::Header*> cpuHdrs;
+    for (size_t i = 0; i < metadata->getNumInputs(); i++) {
+      inputHdrs.emplace_back(metadata->getHeader(i));
+      inputData[i] = &((char*)in_ptr)[metadata->getDataOffset(i)];
+    }
+
+    for (CascadedMetadata::Header& hdr : inputHdrs) {
+      cpuHdrs.emplace_back(&hdr);
+    }
+
+    nvcompDecompressLaunch(
+        handle,
+        metadata->getNumUncompressedElements(),
+        out_ptr,
+        out_bytes,
+        (const void**)inputData.data(),
+        (const void**)cpuHdrs.data());
+    nvcompDestroyHandle(handle);
+  } catch (const std::exception& e) {
+    if (handle >= 0) {
+      nvcompDestroyHandle(handle);
+    }
+    return Check::exception_to_error(e, "nvcompCascadedDecompressAsync()");
+  }
+
+  return nvcompSuccess;
+}
+
+nvcompError_t nvcompCascadedCompressGetTempSize(
+    const void* const in_ptr,
+    const size_t in_bytes,
+    const nvcompType_t in_type,
+    const nvcompCascadedFormatOpts* const format_opts,
+    size_t* const temp_bytes)
+{
+  try {
+    checkCompressSize(in_bytes);
+
+    nvcompCascadedCompressionGPU::computeWorkspaceSize(
+        in_ptr, in_bytes, in_type, format_opts, temp_bytes);
+  } catch (const std::exception& e) {
+    return Check::exception_to_error(e, "nvcompCascadedCompressGetTempSize()");
+  }
+
+  return nvcompSuccess;
+}
+
+nvcompError_t nvcompCascadedCompressGetOutputSize(
+    const void* in_ptr,
+    const size_t in_bytes,
+    const nvcompType_t in_type,
+    const nvcompCascadedFormatOpts* format_opts,
+    void* const temp_ptr,
+    const size_t temp_bytes,
+    size_t* const out_bytes,
+    const int exact_out_bytes)
+{
+  try {
+    checkCompressSize(in_bytes);
+
+    if (exact_out_bytes) {
+      throw std::runtime_error("Exact output bytes is unimplemented at "
+                               "this time.");
+    }
+
+    nvcompCascadedCompressionGPU::generateOutputUpperBound(
+        in_ptr,
+        in_bytes,
+        in_type,
+        format_opts,
+        temp_ptr,
+        temp_bytes,
+        out_bytes);
+  } catch (const std::exception& e) {
+    return Check::exception_to_error(
+        e, "nvcompCascadedCompressGetOutputSize()");
+  }
+
+  return nvcompSuccess;
+}
+
+nvcompError_t nvcompCascadedCompressAsync(
+    const void* const in_ptr,
+    const size_t in_bytes,
+    const nvcompType_t in_type,
+    const nvcompCascadedFormatOpts* const format_opts,
+    void* const temp_ptr,
+    const size_t temp_bytes,
+    void* const out_ptr,
+    size_t* const out_bytes,
+    cudaStream_t stream)
+{
+  try {
+    checkCompressSize(in_bytes);
+
+    CHECK_NOT_NULL(out_bytes);
+
+    if (*out_bytes == 0) {
+      throw NVCompException(
+          nvcompErrorInvalidValue,
+          "Output size cannot be zero. Make sure "
+          "to set the size of out_bytes to size of output space allocated "
+          "for compressed output.");
+    }
+
+    nvcompCascadedCompressionGPU::compressAsync(
+        in_ptr,
+        in_bytes,
+        in_type,
+        format_opts,
+        temp_ptr,
+        temp_bytes,
+        out_ptr,
+        out_bytes,
+        stream);
+  } catch (const std::exception& e) {
+    return Check::exception_to_error(e, "nvcompCascadedCompressAsync()");
+  }
+
+  return nvcompSuccess;
+}
+
+
+/*****************************************************************************
+ * Definitions of API calls for automatically selected compression
+ ****************************************************************************/
+nvcompError_t nvcompCascadedCompressAutoGetTempSize(
+    const void* const in_ptr,
+    const size_t in_bytes,
+    const nvcompType_t in_type,
+    size_t* const temp_bytes) 
+{
+
+  // Assume the scheme that requires the most temp space
+  nvcompCascadedFormatOpts biggest_opts;
+  biggest_opts.num_RLEs = 2;
+  biggest_opts.num_deltas = 2;
+  biggest_opts.use_bp = 1;
+
+  return API_WRAPPER(nvcompCascadedCompressGetTempSize(
+             in_ptr,
+             in_bytes,
+             in_type,
+             &biggest_opts,
+             temp_bytes), "nvcompCascadedCompressAutoGetTempSize()");
+}
+
+nvcompError_t nvcompCascadedCompressAutoGetOutputSize(
+    const void* in_ptr,
+    size_t in_bytes,
+    nvcompType_t in_type,
+    void* temp_ptr,
+    size_t temp_bytes,
+    size_t* out_bytes)
+{
+  // Assume the scheme that can result in the largest output
+  nvcompCascadedFormatOpts biggest_opts;
+  biggest_opts.num_RLEs = 2;
+  biggest_opts.num_deltas = 2;
+  biggest_opts.use_bp = 1;
+
+  return API_WRAPPER(nvcompCascadedCompressGetOutputSize(
+             in_ptr,
+             in_bytes,
+             in_type,
+             &biggest_opts,
+             temp_ptr,
+             temp_bytes,
+             out_bytes,
+             0), "nvcompCascadedCompressAutoGetOutputSize()");
+}
+
+nvcompError_t nvcompCascadedCompressAuto(
+    const void* in_ptr,
+    size_t in_bytes,
+    nvcompType_t in_type,
+    void* temp_ptr,
+    size_t temp_bytes,
+    void* out_ptr,
+    size_t* out_bytes,
+    unsigned seed,
+    cudaStream_t stream)
+{
+  try {
+    nvcompCascadedSelectorOpts selector_opts;
+    selector_opts.sample_size = 1024;
+    selector_opts.num_samples = 100;
+    selector_opts.seed = seed;
+
+    size_t type_bytes = sizeOfnvcompType(in_type);
+
+    // Adjust sample size if input is too small
+    if(in_bytes < (selector_opts.sample_size * selector_opts.num_samples * type_bytes)) {
+      selector_opts.sample_size = in_bytes / (10*type_bytes);
+      selector_opts.num_samples = 10;
+    }
+    
+    nvcompCascadedFormatOpts format_opts;
+    double est_ratio;
+
+    // Run selector to get format opts for compression
+    CHECK_API_CALL(nvcompCascadedSelectorSelectConfig(
+             in_ptr,
+             in_bytes,
+             in_type,
+             selector_opts,
+             temp_ptr,
+             temp_bytes,
+             &format_opts,
+             &est_ratio,
+             stream));
+    CudaUtils::sync(stream);
+
+    // Run compression
+    CHECK_API_CALL(nvcompCascadedCompressAsync(
+             in_ptr,
+             in_bytes,
+             in_type,
+             &format_opts,
+             temp_ptr,
+             temp_bytes,
+             out_ptr,
+             out_bytes,
+             stream));
+  } catch (const std::exception& e) {
+    return Check::exception_to_error(e, "nvcompCascadedCompressAuto()");
+  }
+
+  return nvcompSuccess;
+}

--- a/nvcomp/CascadedDecompressionKernels.cuh
+++ b/nvcomp/CascadedDecompressionKernels.cuh
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2018-2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NVCOMP_GPUKERNELS_H
+#define NVCOMP_GPUKERNELS_H
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weffc++"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
+#include <cub/cub.cuh>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+#include "unpack.h"
+
+namespace nvcomp
+{
+
+template <typename V, typename R>
+__global__ void vecMultKernel(
+    const V* const a, const R* const b, V* const out, const size_t num)
+{
+  const size_t tid = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+
+  if (tid < num) {
+    out[tid] = a[tid] * b[tid];
+  }
+}
+
+template <typename OUT, typename IN>
+__global__ void
+convertKernel(const IN* const d_input, OUT* const d_output, const size_t num)
+{
+  const size_t tid = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+
+  if (tid < num) {
+    d_output[tid] = static_cast<OUT>(d_input[tid]);
+  }
+}
+
+template <typename OUT, typename IN>
+__global__ void unpackBytesKernel(
+    const void* const d_input,
+    OUT* const d_output,
+    const unsigned char numBits,
+    const IN minValue,
+    const size_t num)
+{
+  const size_t tid = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+
+  if (tid < num) {
+    d_output[tid]
+        = static_cast<OUT>(unpackBytes(d_input, numBits, minValue, tid));
+  }
+}
+
+template <typename runT>
+__device__ void binarySearch(
+    size_t& ind,
+    size_t& offset,
+    const runT* scan,
+    const size_t size,
+    size_t val)
+{
+  size_t low = 0;
+  size_t high = size - 1;
+  while (high > low) {
+    size_t mid = (low + high) / 2;
+    if (scan[mid] <= val)
+      low = mid + 1;
+    else
+      high = mid;
+  }
+  if (low > 0) {
+    offset = val - scan[low - 1];
+  } else {
+    offset = val;
+  }
+  ind = low;
+}
+
+template <typename runT, int threadBlock, int elemsPerThread>
+__global__ void searchBlockBoundaries(
+    size_t* start_ind,
+    size_t* start_off,
+    const size_t num_blocks,
+    const size_t inputSize,
+    const runT* runs_scan)
+{
+  const int smemLimit = threadBlock * elemsPerThread;
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  if (tid < num_blocks) {
+    binarySearch(
+        start_ind[tid], start_off[tid], runs_scan, inputSize, tid * smemLimit);
+  }
+  if (tid == num_blocks - 1) {
+    start_ind[num_blocks] = inputSize - 1;
+    start_off[num_blocks] = 0;
+  }
+}
+
+template <
+    typename inputT,
+    typename outputT,
+    typename runT,
+    int threadBlock,
+    int elemsPerThread,
+    bool delta>
+__global__ void expandRLEDelta(
+    outputT* output,
+    const size_t outputSize,
+    const inputT* input,
+    const runT* runs_scan,
+    const inputT* delta_scan,
+    const size_t* start_ind,
+    const size_t* start_off)
+{
+  // limit of our expansion determined by available smem
+  const int smemLimit = threadBlock * elemsPerThread;
+
+  // all shared memory allocations
+  __shared__ inputT in_vals[smemLimit];
+  __shared__ inputT out_vals[smemLimit];
+  __shared__ int offs[smemLimit];
+  __shared__ size_t base_scan;
+  __shared__ inputT base_delta;
+  __shared__ size_t block_start_ind, block_start_off;
+  __shared__ size_t block_end_ind;
+
+// init offs with all zeros
+#pragma unroll
+  for (int i = 0; i < elemsPerThread; i++)
+    offs[threadIdx.x + i * threadBlock] = 0;
+
+  // find input indices and offsets based on output block index
+  if (threadIdx.x == 0) {
+    block_start_ind = start_ind[blockIdx.x];
+    block_start_off = start_off[blockIdx.x];
+    block_end_ind = start_ind[blockIdx.x + 1];
+  }
+
+  __syncthreads();
+
+  // store values and block offset in shared memory
+  for (int i = 0; i < elemsPerThread; i++)
+    if (block_start_ind + threadIdx.x + threadBlock * i <= block_end_ind)
+      in_vals[threadIdx.x + threadBlock * i]
+          = input[block_start_ind + threadIdx.x + threadBlock * i];
+
+  if (threadIdx.x == 0) {
+    // starting scan value for this block (-1 because inclusive)
+    if (block_start_ind > 0)
+      base_scan = runs_scan[block_start_ind - 1];
+    else
+      base_scan = 0;
+    // base delta value for this block
+    if (delta) {
+      if (block_start_ind > 0)
+        base_delta = delta_scan[block_start_ind - 1]
+                     + block_start_off * input[block_start_ind];
+      else
+        base_delta = block_start_off * input[block_start_ind];
+    } else
+      base_delta = 0;
+  }
+
+  __syncthreads();
+
+  // store 1s in scan positions until smem limit
+  // 0 0 0 0 1 0 0 1 0 0 0 0
+  for (int i = 0; i < elemsPerThread; i++)
+    if (block_start_ind + threadIdx.x + threadBlock * i <= block_end_ind) {
+      int s = runs_scan[block_start_ind + threadIdx.x + threadBlock * i]
+              - base_scan - block_start_off;
+      if (s >= 0 && s < smemLimit)
+        offs[s] = 1;
+    }
+
+  __syncthreads();
+
+  // perform inclusive scan
+  // 0 0 0 0 1 1 1 2 2 2 2 2
+  typedef cub::BlockScan<int, threadBlock> BlockScan;
+  __shared__ typename BlockScan::TempStorage temp_storage;
+  int thread_data[elemsPerThread];
+#pragma unroll
+  for (int i = 0; i < elemsPerThread; i++)
+    thread_data[i] = offs[threadIdx.x * elemsPerThread + i];
+  BlockScan(temp_storage).InclusiveSum(thread_data, thread_data);
+
+// write values in their positions in smem
+// A A A A B B B C C C C C
+#pragma unroll
+  for (int i = 0; i < elemsPerThread; i++)
+    out_vals[threadIdx.x * elemsPerThread + i] = in_vals[thread_data[i]];
+
+  __syncthreads();
+
+  if (delta) {
+    // now perform the delta expand - simply another scan
+    // A 2A 3A 3A+B 3A+2B 3A+3B 3A+3B+C 3A+3B+2C ...
+    typedef cub::BlockScan<inputT, threadBlock> BlockScanT;
+    __shared__ typename BlockScanT::TempStorage temp_storage_t;
+    inputT thread_data_t[elemsPerThread];
+#pragma unroll
+    for (int i = 0; i < elemsPerThread; i++)
+      thread_data_t[i] = out_vals[threadIdx.x * elemsPerThread + i];
+    BlockScanT(temp_storage_t).InclusiveSum(thread_data_t, thread_data_t);
+
+// store in shared memory
+#pragma unroll
+    for (int i = 0; i < elemsPerThread; i++)
+      out_vals[threadIdx.x * elemsPerThread + i] = thread_data_t[i];
+
+    __syncthreads();
+  }
+
+// store final values to global memory
+// here we also do type conversion if necessary
+#pragma unroll
+  for (int i = 0; i < elemsPerThread; i++) {
+    size_t outputPos
+        = threadIdx.x + threadBlock * i + base_scan + block_start_off;
+    if (outputPos < outputSize)
+      output[outputPos]
+          = (outputT)(out_vals[threadIdx.x + threadBlock * i] + base_delta);
+  }
+}
+
+} // namespace nvcomp
+
+#endif

--- a/nvcomp/CascadedMetadata.cpp
+++ b/nvcomp/CascadedMetadata.cpp
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "CascadedMetadata.h"
+#include "common.h"
+#include "CascadedCommon.h"
+
+#include <cassert>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+#include <iostream>
+
+namespace nvcomp
+{
+
+/******************************************************************************
+ * CONSTANTS ******************************************************************
+ *****************************************************************************/
+
+using Header = CascadedMetadata::Header;
+
+namespace
+{
+
+constexpr const size_t NULL_OFFSET = static_cast<size_t>(-1);
+}
+
+/******************************************************************************
+ * CONSTRUCTORS / DESTRUCTOR **************************************************
+ *****************************************************************************/
+
+CascadedMetadata::CascadedMetadata(
+    const nvcompCascadedFormatOpts opts,
+    const nvcompType_t type,
+    const size_t uncompressedBytes,
+    const size_t compressedBytes) :
+    Metadata(type, uncompressedBytes, compressedBytes, COMPRESSION_ID),
+    m_formatOpts(opts),
+    m_headers(),
+    m_dataOffsets(),
+    m_dataType(),
+    m_isSaved()
+{
+  if (static_cast<size_t>(m_formatOpts.num_RLEs) > MAX_NUM_RLES) {
+    throw std::runtime_error(
+        "Invalid number of RLEs: " + std::to_string(m_formatOpts.num_RLEs)
+        + ", maximum is " + std::to_string(MAX_NUM_RLES));
+  }
+
+  initialize();
+}
+
+/******************************************************************************
+ * PUBLIC METHODS *************************************************************
+ *****************************************************************************/
+
+int CascadedMetadata::getNumRLEs() const
+{
+  return m_formatOpts.num_RLEs;
+}
+
+int CascadedMetadata::getNumDeltas() const
+{
+  return m_formatOpts.num_deltas;
+}
+
+unsigned int CascadedMetadata::getNumInputs() const
+{
+  // Determine the number of unique data id's that will be present in the
+  // compressed data. Currently, the input data gets assigned a value of 0,
+  // each RLE produces a runs and values which each take an id, and delta also
+  // produces a values which takes an id. Bitpacking is not treated as a layer
+  // unless it is the only present operation, which is what the 'max' below is
+  // for.
+  return static_cast<unsigned int>(
+      std::max(1, m_formatOpts.num_RLEs * 2 + m_formatOpts.num_deltas) + 1);
+}
+
+bool CascadedMetadata::useBitPacking() const
+{
+  return m_formatOpts.use_bp;
+}
+
+void CascadedMetadata::setHeader(const size_t index, const Header header)
+{
+  if (index >= getNumInputs()) {
+    throw std::runtime_error(
+        "Invalid header index to set: " + std::to_string(index) + " / "
+        + std::to_string(getNumInputs()));
+  }
+
+  assert(index < m_headers.size());
+
+  m_headers[index] = header;
+}
+
+void CascadedMetadata::setDataOffset(const size_t index, const size_t offset)
+{
+  if (index >= getNumInputs()) {
+    throw std::runtime_error(
+        "Invalid data index to set: " + std::to_string(index) + " / "
+        + std::to_string(getNumInputs()));
+  }
+
+  m_dataOffsets[index] = offset;
+}
+
+Header CascadedMetadata::getHeader(const size_t index) const
+{
+  if (index >= getNumInputs()) {
+    throw std::runtime_error(
+        "Invalid header index to set: " + std::to_string(index) + " / "
+        + std::to_string(getNumInputs()));
+  }
+  assert(index < m_headers.size());
+
+  return m_headers[index];
+}
+
+size_t CascadedMetadata::getNumElementsOf(const size_t index) const
+{
+  return m_headers[index].length;
+}
+
+size_t CascadedMetadata::getDataOffset(const size_t index) const
+{
+  if (index >= getNumInputs()) {
+    throw std::runtime_error(
+        "Invalid data index to set: " + std::to_string(index) + " / "
+        + std::to_string(getNumInputs()));
+  }
+
+  const size_t offset = m_dataOffsets[index];
+
+  if (offset == NULL_OFFSET) {
+    throw std::runtime_error(
+        "Cannot get data offset which has not been set: "
+        + std::to_string(index));
+  }
+
+  return offset;
+}
+
+bool CascadedMetadata::haveAnyOffsetsBeenSet() const
+{
+  for (const size_t offset : m_dataOffsets) {
+    if (offset != NULL_OFFSET) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool CascadedMetadata::haveAllOffsetsBeenSet() const
+{
+  for (const size_t offset : m_dataOffsets) {
+    if (offset == NULL_OFFSET) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool CascadedMetadata::isSaved(const size_t index) const
+{
+  if (index >= getNumInputs()) {
+    throw std::runtime_error(
+        "Invalid data index to check if saved: " + std::to_string(index) + " / "
+        + std::to_string(getNumInputs()));
+  }
+
+  return m_isSaved[index];
+}
+
+nvcompType_t CascadedMetadata::getDataType(size_t index) const
+{
+  if (index >= getNumInputs()) {
+    throw std::runtime_error(
+        "Invalid data index to get type of: " + std::to_string(index) + " / "
+        + std::to_string(getNumInputs()));
+  }
+
+  return m_dataType[index];
+}
+
+/******************************************************************************
+ * PRIVATE METHODS ************************************************************
+ *****************************************************************************/
+
+void CascadedMetadata::initialize()
+{
+  m_headers.resize(getNumInputs());
+  m_dataOffsets.resize(getNumInputs(), NULL_OFFSET);
+  m_dataType.resize(getNumInputs(), getValueType());
+  m_isSaved.resize(getNumInputs(), false);
+
+  // fill out data based on tree
+  const int numRLEs = getNumRLEs();
+  const int numDeltas = getNumDeltas();
+  const bool bitPacking = useBitPacking();
+
+  int vals_id = 0;
+
+  const int numSteps = std::max(numRLEs, numDeltas);
+  for (int r = numSteps - 1; r >= 0; r--) {
+    int nextValId;
+
+    if (numSteps - r - 1 < numRLEs) {
+      const int runId = ++vals_id;
+      const int valId = ++vals_id;
+
+      // rle
+
+      if (numRLEs - 1 - r < numDeltas) {
+        // delta
+        nextValId = ++vals_id;
+      } else {
+        nextValId = valId;
+      }
+
+      // save runs output `runId`
+      m_isSaved[runId] = true;
+      if (bitPacking) {
+        m_dataType[runId] = NVCOMP_TYPE_BITS;
+      } else {
+        m_dataType[runId] = selectRunsType(getNumUncompressedElements());
+      }
+    } else {
+      // delta only
+      nextValId = ++vals_id;
+    }
+
+    if (r == 0) {
+      // save last layer `nextValId`
+      m_isSaved[nextValId] = true;
+      if (bitPacking) {
+        m_dataType[nextValId] = NVCOMP_TYPE_BITS;
+      } else {
+        m_dataType[nextValId] = getValueType();
+      }
+    }
+  }
+
+  // If there are no RLEs or Deltas, we will do a single BP step.
+  if (numRLEs == 0 && numDeltas == 0) {
+    const int nextValId = ++vals_id;
+
+    // bit pack `nextValId`
+    m_isSaved[nextValId] = true;
+    m_dataType[nextValId] = NVCOMP_TYPE_BITS;
+  }
+}
+
+} // namespace nvcomp

--- a/nvcomp/CascadedMetadata.h
+++ b/nvcomp/CascadedMetadata.h
@@ -1,0 +1,351 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CASCACDEDMETADATA_H
+#define CASCACDEDMETADATA_H
+
+#include "Metadata.h"
+#include "cascaded.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#ifdef __CUDACC__
+#define NVCOMP_HOST_DEVICE __device__ __host__
+#else
+#define NVCOMP_HOST_DEVICE
+#endif
+
+namespace nvcomp
+{
+
+class CascadedMetadata : public Metadata
+{
+public:
+  constexpr static int COMPRESSION_ID = 0x1000;
+
+  constexpr static const size_t MAX_NUM_RLES = 8;
+
+  union MinValue
+  {
+    MinValue() = default;
+    MinValue(const int8_t num) : i8(num)
+    {
+    }
+    MinValue(const uint8_t num) : u8(num)
+    {
+    }
+    MinValue(const int16_t num) : i16(num)
+    {
+    }
+    MinValue(const uint16_t num) : u16(num)
+    {
+    }
+    MinValue(const int32_t num) : i32(num)
+    {
+    }
+    MinValue(const uint32_t num) : u32(num)
+    {
+    }
+    MinValue(const int64_t num) : i64(num)
+    {
+    }
+    MinValue(const uint64_t num) : u64(num)
+    {
+    }
+
+    int8_t i8;
+    uint8_t u8;
+    int16_t i16;
+    uint16_t u16;
+    int32_t i32;
+    uint32_t u32;
+    int64_t i64;
+    uint64_t u64;
+  };
+
+  static_assert(std::is_pod<MinValue>::value, "MinValue must be a POD type.");
+
+  struct Header
+  {
+    uint64_t length;
+    MinValue minValue;
+    uint8_t numBits;
+  };
+
+  /**
+   * @brief Create a new metadta object.
+   *
+   * @param opts The cascaded compression options.
+   * @param type The type of data element to compress.
+   * @param uncompressedBytes The size of the data while uncompressed.
+   * @param compressedBytes The size of the data and metadata compressed.
+   */
+  CascadedMetadata(
+      nvcompCascadedFormatOpts opts,
+      nvcompType_t type,
+      size_t uncompressedBytes,
+      size_t compressedBytes);
+
+  /**
+   * @brief Get the number of Run Length Encodings in the scheme.
+   *
+   * @return The number of Run Length Encodings.
+   */
+  int getNumRLEs() const;
+
+  /**
+   * @brief Get the number of delta encodings in the scheme.
+   *
+   * @return The number of delta encodings.
+   */
+  int getNumDeltas() const;
+
+  /**
+   * @brief Get the number inputs/layers in the scheme.
+   *
+   * @return The number of inputs/layers.
+   */
+  unsigned int getNumInputs() const;
+
+  /**
+   * @brief Get whether to use bitpacking or not.
+   *
+   * @return True if bit packing is used.
+   */
+  bool useBitPacking() const;
+
+  /**
+   * @brief Check if any data offsets have been set.
+   *
+   * @return True if any of the data offsets have been set.
+   */
+  bool haveAnyOffsetsBeenSet() const;
+
+  /**
+   * @brief Check if all data offsets have been set.
+   *
+   * @return True if all of the data offsets have been set.
+   */
+  bool haveAllOffsetsBeenSet() const;
+
+  /**
+   * @brief Set the header for the given input/layer.
+   *
+   * @param index The index of the input/layer.
+   * @param header The header to set.
+   *
+   * @throw An exception if the index is invalid.
+   */
+  void setHeader(size_t index, Header header);
+
+  /**
+   * @brief Set the data offset for the given input/layer. The offset should be
+   * from the start of the serialized metadata.
+   *
+   * @param index The input/layer index.
+   * @param offset The offset in bytes.
+   *
+   * @throw An exception if the index is invalid.
+   */
+  void setDataOffset(size_t index, size_t offset);
+
+  /**
+   * @brief Get the header for the given input/layer.
+   *
+   * @param index The index of the input/layer.
+   *
+   * @return The header.
+   *
+   * @throw An exception if the index is invalid.
+   */
+  Header getHeader(size_t index) const;
+
+  /**
+   * @brief Get the length in elements of a given input/layer.
+   *
+   * @param index The index of the input/layer.
+   *
+   * @return The length in elements.
+   */
+  size_t getNumElementsOf(size_t index) const;
+
+  /**
+   * @brief Get the data offset for the given input/layer.
+   *
+   * @param index The index of the input/layer.
+   *
+   * @return The offset in bytes.
+   *
+   * @throw An exception if the given index is invalid, or the offset for that
+   * index has not yet been set.
+   */
+  size_t getDataOffset(size_t index) const;
+
+  /**
+   * @brief Check if a given layer is a saved layer (compressed).
+   *
+   * @param index The index of the input/layer.
+   *
+   * @return True if the layer's data is saved.
+   */
+  bool isSaved(size_t index) const;
+
+  /**
+   * @brief Get the type associated with the input/layer.
+   *
+   * @param index The index of the input/layer.
+   *
+   * @return The type.
+   */
+  nvcompType_t getDataType(size_t index) const;
+
+  template <typename T>
+  static inline NVCOMP_HOST_DEVICE T*
+  getMinValueLocation(CascadedMetadata::Header* const deviceHeader);
+
+  /**
+   * @brief Get the minimum value associated with a given layer/input. If the
+   * given layer input does not contain a bit packing or the template type does
+   * not batch the packed type, the return value is unspecified.
+   *
+   * @tparam T The type of value that is packed.
+   * @param index T The index of the layer/input.
+   *
+   * @return The minimum value of the bitpacking.
+   */
+  template <typename T>
+  T getMinValueOf(const size_t index) const
+  {
+    Header header = getHeader(index);
+    const T minValue = *CascadedMetadata::getMinValueLocation<T>(&header);
+    return minValue;
+  }
+
+private:
+  /**
+   * @brief The configuration of cascaded compression to be used/used.
+   */
+  nvcompCascadedFormatOpts m_formatOpts;
+
+  /**
+   * @brief The header for each layer, output or not (that is, this will be the
+   * length of `getNumInputs()`). This is stored in the
+   * metadata such that the exact size of intermediate layers can be known
+   * before decompression starts, allowing it to be done asyncronously, and
+   * allowing memory allocations only of the exact sizes needed.
+   */
+  std::vector<Header> m_headers;
+
+  /**
+   * @brief The offsets of data for each layer, output or not (that is,
+   * this will be the length of `getNumInputs()`). However, the offset for a
+   * non-output layer is unspeficied.
+   */
+  std::vector<size_t> m_dataOffsets;
+
+  std::vector<nvcompType_t> m_dataType;
+
+  std::vector<bool> m_isSaved;
+
+  /**
+   * @brief Setup the offset arrays, after m_formatOpts has been set or
+   * changed. This will wipe any previously stored data.
+   */
+  void initialize();
+};
+
+template <>
+inline NVCOMP_HOST_DEVICE int8_t* CascadedMetadata::getMinValueLocation<int8_t>(
+    CascadedMetadata::Header* const deviceHeader)
+{
+  return &(deviceHeader->minValue.i8);
+}
+
+template <>
+inline NVCOMP_HOST_DEVICE uint8_t*
+CascadedMetadata::getMinValueLocation<uint8_t>(
+    CascadedMetadata::Header* const deviceHeader)
+{
+  return &(deviceHeader->minValue.u8);
+}
+
+template <>
+inline NVCOMP_HOST_DEVICE int16_t*
+CascadedMetadata::getMinValueLocation<int16_t>(
+    CascadedMetadata::Header* const deviceHeader)
+{
+  return &(deviceHeader->minValue.i16);
+}
+
+template <>
+inline NVCOMP_HOST_DEVICE uint16_t*
+CascadedMetadata::getMinValueLocation<uint16_t>(
+    CascadedMetadata::Header* const deviceHeader)
+{
+  return &(deviceHeader->minValue.u16);
+}
+
+template <>
+inline NVCOMP_HOST_DEVICE int32_t*
+CascadedMetadata::getMinValueLocation<int32_t>(
+    CascadedMetadata::Header* const deviceHeader)
+{
+  return &(deviceHeader->minValue.i32);
+}
+
+template <>
+inline NVCOMP_HOST_DEVICE uint32_t*
+CascadedMetadata::getMinValueLocation<uint32_t>(
+    CascadedMetadata::Header* const deviceHeader)
+{
+  return &(deviceHeader->minValue.u32);
+}
+
+template <>
+inline NVCOMP_HOST_DEVICE int64_t*
+CascadedMetadata::getMinValueLocation<int64_t>(
+    CascadedMetadata::Header* const deviceHeader)
+{
+  return &(deviceHeader->minValue.i64);
+}
+
+template <>
+inline NVCOMP_HOST_DEVICE uint64_t*
+CascadedMetadata::getMinValueLocation<uint64_t>(
+    CascadedMetadata::Header* const deviceHeader)
+{
+  return &(deviceHeader->minValue.u64);
+}
+
+} // namespace nvcomp
+
+#undef NVCOMP_HOST_DEVICE
+
+#endif

--- a/nvcomp/CascadedMetadataOnGPU.cu
+++ b/nvcomp/CascadedMetadataOnGPU.cu
@@ -1,0 +1,559 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "CascadedCommon.h"
+#include "CascadedMetadataOnGPU.h"
+#include "CudaUtils.h"
+#include "common.h"
+
+#include <cassert>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace nvcomp
+{
+
+/******************************************************************************
+ * TYPES **********************************************************************
+ *****************************************************************************/
+
+namespace
+{
+using VERSION_TYPE = uint16_t;
+using NUM_RLES_TYPE = uint8_t;
+using NUM_DELTAS_TYPE = uint8_t;
+using USE_BITPACKING_TYPE = uint8_t;
+using COMP_BYTES_TYPE = uint64_t;
+using DECOMP_BYTES_TYPE = uint64_t;
+using IN_TYPE_TYPE = int32_t;
+using NUM_INPUTS_TYPE = int32_t;
+using OFFSET_TYPE = uint64_t;
+using HEADER_TYPE = CascadedMetadata::Header;
+} // namespace
+
+/******************************************************************************
+ * CONSTANTS ******************************************************************
+ *****************************************************************************/
+
+namespace
+{
+
+constexpr const size_t NULL_NUM_INPUTS = static_cast<size_t>(-1);
+
+constexpr const size_t MAX_NUM_RLES = CascadedMetadata::MAX_NUM_RLES;
+
+enum OffsetType : unsigned int
+{
+  OFFSET_VERSION = 0,
+  OFFSET_NUM_RLES
+  = roundUpTo(OFFSET_VERSION + sizeof(VERSION_TYPE), sizeof(NUM_RLES_TYPE)),
+  OFFSET_NUM_DELTAS
+  = roundUpTo(OFFSET_NUM_RLES + sizeof(NUM_RLES_TYPE), sizeof(NUM_DELTAS_TYPE)),
+  OFFSET_USE_BITPACKING = roundUpTo(
+      OFFSET_NUM_DELTAS + sizeof(NUM_DELTAS_TYPE), sizeof(USE_BITPACKING_TYPE)),
+  OFFSET_COMP_BYTES = roundUpTo(
+      OFFSET_USE_BITPACKING + sizeof(USE_BITPACKING_TYPE),
+      sizeof(COMP_BYTES_TYPE)),
+  OFFSET_DECOMP_BYTES = roundUpTo(
+      OFFSET_COMP_BYTES + sizeof(COMP_BYTES_TYPE), sizeof(DECOMP_BYTES_TYPE)),
+  OFFSET_IN_TYPE = roundUpTo(
+      OFFSET_DECOMP_BYTES + sizeof(DECOMP_BYTES_TYPE), sizeof(IN_TYPE_TYPE)),
+  OFFSET_NUM_INPUTS
+  = roundUpTo(OFFSET_IN_TYPE + sizeof(IN_TYPE_TYPE), sizeof(NUM_INPUTS_TYPE)),
+  OFFSET_HEADERS
+  = roundUpTo(OFFSET_NUM_INPUTS + sizeof(NUM_INPUTS_TYPE), sizeof(OFFSET_TYPE))
+};
+} // namespace
+
+/******************************************************************************
+ * DEVICE FUNCTIONS ***********************************************************
+ *****************************************************************************/
+
+namespace
+{
+
+inline constexpr __device__ __host__ unsigned int
+serializedMetadataSize(const int numInputs)
+{
+  return OFFSET_HEADERS + sizeof(OFFSET_TYPE) * numInputs
+         + sizeof(HEADER_TYPE) * numInputs;
+}
+
+template <typename T, OffsetType offset>
+__device__ __host__ void setField(uint8_t* const data, T const v)
+{
+  *reinterpret_cast<T*>(data + offset) = v;
+}
+
+template <typename T, OffsetType offset>
+__device__ __host__ void
+setField(uint8_t* const data, T const v, const size_t dynamicOffset)
+{
+  reinterpret_cast<T*>(data + offset)[dynamicOffset] = v;
+}
+
+template <typename T, OffsetType offset>
+__device__ __host__ T getField(const uint8_t* const data)
+{
+  return *reinterpret_cast<const T*>(data + offset);
+}
+
+template <typename T, OffsetType offset>
+__device__ __host__ T
+getField(const uint8_t* const data, const size_t dynamicOffset)
+{
+  return reinterpret_cast<const T*>(data + offset)[dynamicOffset];
+}
+
+__device__ __host__ size_t getOffsetsOffset(size_t numInputs)
+{
+  return roundUpTo(
+      OFFSET_HEADERS + sizeof(HEADER_TYPE) * numInputs, sizeof(OFFSET_TYPE));
+}
+
+} // namespace
+
+/******************************************************************************
+ * KERNELS ********************************************************************
+ *****************************************************************************/
+
+namespace
+{
+
+__global__ void serializeV1(
+    void* const dest,
+    const size_t destSize,
+    const int numRLEs,
+    const int numDeltas,
+    const bool useBitPacking,
+    const size_t comp_bytes,
+    const size_t decomp_bytes,
+    const nvcompType_t in_type,
+    const int numInputs,
+    size_t* const serializedSizeDevice)
+{
+  using Chunk = uint32_t;
+
+  __shared__ uint8_t localBuffer[serializedMetadataSize(MAX_NUM_RLES + 1)];
+
+  assert(blockIdx.x == 0);
+
+  // master thread assigns local buffer
+  if (threadIdx.x == 0) {
+    setField<VERSION_TYPE, OFFSET_VERSION>(localBuffer, 1);
+    setField<NUM_RLES_TYPE, OFFSET_NUM_RLES>(localBuffer, numRLEs);
+    setField<NUM_DELTAS_TYPE, OFFSET_NUM_DELTAS>(localBuffer, numDeltas);
+    setField<USE_BITPACKING_TYPE, OFFSET_USE_BITPACKING>(
+        localBuffer, useBitPacking);
+    setField<COMP_BYTES_TYPE, OFFSET_COMP_BYTES>(localBuffer, comp_bytes);
+    setField<DECOMP_BYTES_TYPE, OFFSET_DECOMP_BYTES>(localBuffer, decomp_bytes);
+    setField<IN_TYPE_TYPE, OFFSET_IN_TYPE>(localBuffer, in_type);
+    setField<NUM_INPUTS_TYPE, OFFSET_NUM_INPUTS>(localBuffer, numInputs);
+
+    if (serializedSizeDevice) {
+      *serializedSizeDevice = serializedMetadataSize(numInputs);
+    }
+  }
+
+  __syncthreads();
+
+  // all threads copy to global memory
+  for (int idx = threadIdx.x; idx * sizeof(Chunk) < OFFSET_HEADERS;
+       idx += blockDim.x) {
+    static_cast<Chunk*>(dest)[idx] = reinterpret_cast<Chunk*>(localBuffer)[idx];
+  }
+}
+
+__global__ void setOffset(
+    void* const serializedMetadata,
+    const size_t index,
+    const size_t* const offsetDevice)
+{
+  assert(blockIdx.x == 0);
+  assert(threadIdx.x == 0);
+
+  uint8_t* const serializedBytes = static_cast<uint8_t*>(serializedMetadata);
+
+  const int numInputs
+      = getField<NUM_INPUTS_TYPE, OFFSET_NUM_INPUTS>(serializedBytes);
+
+  // dataOffsets
+  setField<OFFSET_TYPE, static_cast<OffsetType>(0)>(
+      serializedBytes + getOffsetsOffset(numInputs),
+      static_cast<OFFSET_TYPE>(*offsetDevice),
+      index);
+}
+
+} // namespace
+
+/******************************************************************************
+ * HELPER FUNCTIONS ***********************************************************
+ *****************************************************************************/
+
+namespace
+{
+
+template <typename T>
+constexpr bool isFixedWidth()
+{
+  return std::is_same<T, char>::value || std::is_same<T, int8_t>::value
+         || std::is_same<T, uint8_t>::value || std::is_same<T, int16_t>::value
+         || std::is_same<T, uint16_t>::value || std::is_same<T, int32_t>::value
+         || std::is_same<T, uint32_t>::value || std::is_same<T, int64_t>::value
+         || std::is_same<T, uint64_t>::value;
+}
+
+template <typename T>
+size_t readFixedWidthData(
+    T* const val,
+    const void* const ptr,
+    const size_t offset,
+    const size_t maxSize)
+{
+  assert(isFixedWidth<T>());
+
+  size_t newOffset = offset + sizeof(*val);
+
+  if (newOffset > maxSize) {
+    throw std::runtime_error(
+        "Not enough room to read member, need at least "
+        + std::to_string(newOffset) + " bytes, but given only "
+        + std::to_string(maxSize));
+  }
+
+  *val = *reinterpret_cast<const T*>(static_cast<const char*>(ptr) + offset);
+
+  return newOffset;
+}
+
+CascadedMetadata deserializeMetadataFromGPUVersion1(
+    const void* const devicePtr, const size_t size, cudaStream_t stream)
+{
+  NUM_INPUTS_TYPE numInputs;
+  CudaUtils::copy_async(
+      &numInputs,
+      (const NUM_INPUTS_TYPE*)(static_cast<const uint8_t*>(devicePtr) + OFFSET_NUM_INPUTS),
+      1,
+      DEVICE_TO_HOST,
+      stream);
+  CudaUtils::sync(stream);
+
+  std::vector<uint8_t> localBuffer(serializedMetadataSize(numInputs));
+  if (size < localBuffer.size()) {
+    throw std::runtime_error(
+        "Insufficient space to deserialize metadata "
+        "from: "
+        + std::to_string(size) + " but require "
+        + std::to_string(localBuffer.size()));
+  }
+
+  CudaUtils::copy_async(
+      (uint8_t*)localBuffer.data(),
+      (const uint8_t*)devicePtr,
+      localBuffer.size(),
+      DEVICE_TO_HOST,
+      stream);
+  CudaUtils::sync(stream);
+
+  // here we convert to types of fixed width by the C++ standard rather than
+  // just doing a memcpy of the struct, to ensure portability.
+
+  nvcompCascadedFormatOpts format_opts;
+  format_opts.num_RLEs
+      = getField<NUM_RLES_TYPE, OFFSET_NUM_RLES>(localBuffer.data());
+  format_opts.num_deltas
+      = getField<NUM_DELTAS_TYPE, OFFSET_NUM_DELTAS>(localBuffer.data());
+  format_opts.use_bp = getField<USE_BITPACKING_TYPE, OFFSET_USE_BITPACKING>(
+      localBuffer.data());
+  const COMP_BYTES_TYPE comp_bytes
+      = getField<COMP_BYTES_TYPE, OFFSET_COMP_BYTES>(localBuffer.data());
+  const DECOMP_BYTES_TYPE decomp_bytes
+      = getField<DECOMP_BYTES_TYPE, OFFSET_DECOMP_BYTES>(localBuffer.data());
+  const IN_TYPE_TYPE in_type
+      = getField<IN_TYPE_TYPE, OFFSET_IN_TYPE>(localBuffer.data());
+
+  CascadedMetadata metadata(
+      format_opts,
+      static_cast<nvcompType_t>(in_type),
+      decomp_bytes,
+      comp_bytes);
+
+  if (numInputs != static_cast<int>(metadata.getNumInputs())) {
+    throw std::runtime_error(
+        "Mismatch in numInputs while deserializing "
+        "metadata: "
+        + std::to_string(numInputs) + " vs. "
+        + std::to_string(metadata.getNumInputs()));
+  }
+
+  std::vector<OFFSET_TYPE> hdrOffsets(metadata.getNumInputs());
+  std::vector<OFFSET_TYPE> dataOffsets(metadata.getNumInputs());
+
+  for (size_t i = 0; i < metadata.getNumInputs(); ++i) {
+    const HEADER_TYPE header
+        = getField<HEADER_TYPE, OFFSET_HEADERS>(localBuffer.data(), i);
+    metadata.setHeader(i, header);
+  }
+  for (size_t i = 0; i < metadata.getNumInputs(); ++i) {
+    const OFFSET_TYPE dataOffset
+        = getField<OFFSET_TYPE, static_cast<OffsetType>(0)>(
+            localBuffer.data() + getOffsetsOffset(metadata.getNumInputs()), i);
+    metadata.setDataOffset(i, dataOffset);
+  }
+
+  return metadata;
+}
+
+} // namespace
+
+/******************************************************************************
+ * PUBLIC STATIC METHODS ******************************************************
+ *****************************************************************************/
+
+size_t
+CascadedMetadataOnGPU::getSerializedSizeOf(const CascadedMetadata& metadata)
+{
+  return serializedMetadataSize(metadata.getNumInputs());
+}
+
+/******************************************************************************
+ * CONSTRUCTORS / DESTRUCTOR **************************************************
+ *****************************************************************************/
+
+CascadedMetadataOnGPU::CascadedMetadataOnGPU(void* const ptr, size_t maxSize) :
+    m_ptr(ptr),
+    m_maxSize(maxSize),
+    m_numInputs(NULL_NUM_INPUTS)
+{
+  if (ptr == nullptr) {
+    throw std::runtime_error("Location given to CascadedMetadataOnGPU() must "
+                             "be a valid pointer.");
+  } else if (m_maxSize < OFFSET_HEADERS) {
+    throw std::runtime_error(
+        "Maximum size given to CascadedMetdataOnGPU() "
+        "must be greater than "
+        + std::to_string(OFFSET_HEADERS) + " bytes.");
+  }
+}
+
+/******************************************************************************
+ * PUBLIC METHODS *************************************************************
+ *****************************************************************************/
+
+void CascadedMetadataOnGPU::copyToGPU(
+    const CascadedMetadata& metadata,
+    size_t* const serializedSizeDevice,
+    cudaStream_t stream)
+{
+  const size_t requiredSize = serializedMetadataSize(metadata.getNumInputs());
+  if (m_maxSize < requiredSize) {
+    throw std::runtime_error(
+        "Invalid space for serialized metadata on GPU: "
+        + std::to_string(m_maxSize) + " when " + std::to_string(requiredSize)
+        + " is needed.");
+  }
+
+  serializeV1<<<1, 64, 0, stream>>>(
+      m_ptr,
+      m_maxSize,
+      metadata.getNumRLEs(),
+      metadata.getNumDeltas(),
+      metadata.useBitPacking(),
+      metadata.getCompressedSize(),
+      metadata.getUncompressedSize(),
+      metadata.getValueType(),
+      metadata.getNumInputs(),
+      serializedSizeDevice);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        "Failed to launch metadata serialization kernel: "
+        + std::to_string(err));
+  }
+
+  if (metadata.haveAnyOffsetsBeenSet()) {
+    if (!metadata.haveAllOffsetsBeenSet()) {
+      throw std::runtime_error(
+          "Only some offsets have been set before calling "
+          "CascadedMetadataOnGPU::copyToGPU(). This is not "
+          "a valid state for copying CascadedMetadata to the GPU.");
+    }
+
+    for (size_t i = 0; i < metadata.getNumInputs(); ++i) {
+      const HEADER_TYPE header = metadata.getHeader(i);
+      CudaUtils::copy_async(
+          (HEADER_TYPE*)(static_cast<uint8_t*>(m_ptr) + OFFSET_HEADERS + i * sizeof(header)),
+          &header,
+          1,
+          HOST_TO_DEVICE,
+          stream);
+    }
+
+    for (size_t i = 0; i < metadata.getNumInputs(); ++i) {
+      const OFFSET_TYPE offset = metadata.getDataOffset(i);
+      CudaUtils::copy_async(
+          (OFFSET_TYPE*)(static_cast<uint8_t*>(m_ptr)
+              + getOffsetsOffset(metadata.getNumInputs())
+              + sizeof(OFFSET_TYPE) * i),
+          &offset,
+          1,
+          HOST_TO_DEVICE,
+          stream);
+    }
+  }
+
+  // if successful, set the number of inputs
+  m_numInputs = metadata.getNumInputs();
+}
+
+void CascadedMetadataOnGPU::copyToGPU(
+    const CascadedMetadata& metadata, cudaStream_t stream)
+{
+  copyToGPU(metadata, nullptr, stream);
+}
+
+size_t CascadedMetadataOnGPU::getSerializedSize() const
+{
+  verifyInitialized();
+
+  return serializedMetadataSize(m_numInputs);
+}
+
+void CascadedMetadataOnGPU::saveOffset(
+    size_t index, const size_t* offsetDevice, cudaStream_t stream)
+{
+  verifyInitialized();
+
+  if (index >= m_numInputs) {
+    throw std::runtime_error(
+        "Invalid input index " + std::to_string(index) + " / "
+        + std::to_string(m_numInputs)
+        + " given to "
+          "CascadedMetadataOnGPU::saveOffsets().");
+  }
+
+  setOffset<<<1, 1, 0, stream>>>(m_ptr, index, offsetDevice);
+}
+
+void CascadedMetadataOnGPU::setCompressedSizeFromGPU(
+    const size_t* sizeOnDevice, cudaStream_t stream)
+{
+  // TODO: re-write so that we don't depend on 64-bit architecture
+  static_assert(
+      sizeof(size_t) == sizeof(COMP_BYTES_TYPE),
+      "Requires size_t be 64 bits wide.");
+
+  COMP_BYTES_TYPE* const compBytesDevice = reinterpret_cast<COMP_BYTES_TYPE*>(
+      static_cast<char*>(m_ptr) + OFFSET_COMP_BYTES);
+
+  cudaError_t err = cudaMemcpyAsync(
+      compBytesDevice,
+      sizeOnDevice,
+      sizeof(COMP_BYTES_TYPE),
+      cudaMemcpyDeviceToDevice,
+      stream);
+
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        "Async memcpy in "
+        "CascadedMetadataOnGPU::setCompressedSizeFromGPU() failed with: "
+        + std::to_string(err));
+  }
+}
+
+CascadedMetadata CascadedMetadataOnGPU::copyToHost(cudaStream_t stream)
+{
+  // read the version of the serialized metadata.
+  VERSION_TYPE version;
+
+  CudaUtils::copy_async(
+      &version,
+      static_cast<const VERSION_TYPE*>(m_ptr),
+      1,
+      DEVICE_TO_HOST,
+      stream);
+  CudaUtils::sync(stream);
+
+  if (version == 1) {
+    CascadedMetadata metadata
+        = deserializeMetadataFromGPUVersion1(m_ptr, m_maxSize, stream);
+    m_numInputs = metadata.getNumInputs();
+
+    return metadata;
+  } else {
+    throw std::runtime_error(
+        "Unsupported Metadata version: " + std::to_string(version));
+  }
+}
+
+CascadedMetadata::Header*
+CascadedMetadataOnGPU::getHeaderLocation(const size_t index)
+{
+  verifyIndex(index);
+
+  return reinterpret_cast<HEADER_TYPE*>(
+             static_cast<uint8_t*>(m_ptr) + OFFSET_HEADERS)
+         + index;
+}
+
+const CascadedMetadata::Header*
+CascadedMetadataOnGPU::getHeaderLocation(const size_t index) const
+{
+  verifyIndex(index);
+
+  return reinterpret_cast<const HEADER_TYPE*>(
+             static_cast<const uint8_t*>(m_ptr) + OFFSET_HEADERS)
+         + index;
+}
+
+/******************************************************************************
+ * PRIVATE METHODS ************************************************************
+ *****************************************************************************/
+
+void CascadedMetadataOnGPU::verifyInitialized() const
+{
+  if (m_numInputs == NULL_NUM_INPUTS) {
+    throw std::runtime_error("CascadedMetadataOnGPU::copyToGPU() or "
+                             "CascadedMetdataOnGPU::copyToHost() must be "
+                             "called before other methods.");
+  }
+}
+
+void CascadedMetadataOnGPU::verifyIndex(const size_t index) const
+{
+  verifyInitialized();
+
+  if (index >= m_numInputs) {
+    throw std::runtime_error(
+        "Invalid index to set header for: " + std::to_string(index) + " / "
+        + std::to_string(m_numInputs));
+  }
+}
+
+} // namespace nvcomp

--- a/nvcomp/CascadedMetadataOnGPU.h
+++ b/nvcomp/CascadedMetadataOnGPU.h
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CASCADEDMETADATAONGPU_H
+#define CASCADEDMETADATAONGPU_H
+
+#include "CascadedMetadata.h"
+
+#include "cuda_runtime.h"
+
+namespace nvcomp
+{
+
+class CascadedMetadataOnGPU
+{
+public:
+  /**
+   * @brief Get the serialized size a metadata object would occupy on the GPU.
+   *
+   * @param metadata The metadata.
+   *
+   * @return The size in bytes that would be occupied.
+   */
+  static size_t getSerializedSizeOf(const CascadedMetadata& metadata);
+
+  /**
+   * @brief Create a new serialized metadata object. This is used either to
+   * copy metadata to the GPU, or copy it to the CPU from the GPU.
+   *
+   * @param ptr The memory location on the GPU that will be used for the
+   * serialized metadata.
+   * @param maxSize The maximum size the metadata can occupy (the size of the
+   * allocation usually).
+   */
+  CascadedMetadataOnGPU(void* ptr, size_t maxSize);
+
+  // disable copying
+  CascadedMetadataOnGPU(const CascadedMetadataOnGPU&) = delete;
+  CascadedMetadataOnGPU& operator=(const CascadedMetadataOnGPU&) = delete;
+
+  /**
+   * @brief Copy and serialize the given metadata object to to the GPU
+   * asynchronously.
+   *
+   * @param metadata The metadata object to serialize.
+   * @param serializedSizeDPtr The pointer to the location on the device to
+   * save the serialized size to (may be NULL).
+   * @param stream The stream to asynchronously execute on.
+   */
+  void copyToGPU(
+      const CascadedMetadata& metadata,
+      size_t* serializedSizeDPtr,
+      cudaStream_t stream);
+
+  /**
+   * @brief Copy and serialize the given metadata object to to the GPU
+   * asynchronously.
+   *
+   * @param metadata The metadata object to serialize.
+   * @param stream The stream to asynchronously execute on.
+   */
+  void copyToGPU(const CascadedMetadata& metadata, cudaStream_t stream);
+
+  /**
+   * @brief Get the size of this metadata on the GPU.
+   *
+   * @return The size in bytes.
+   */
+  size_t getSerializedSize() const;
+
+  /**
+   * @brief Get a copy of the metadata on the CPU. This will synchronize with
+   * the stream.
+   *
+   * @stream The stream to transfer on.
+   *
+   * @return The metadata on the CPU.
+   */
+  CascadedMetadata copyToHost(cudaStream_t stream);
+
+  /**
+   * @brief Save the offset scalar stored on the device to the serialized
+   * metadata.
+   *
+   * @param index The layer/input to set the data offset for.
+   * @param offsetDPtr The pointer to the offset on the device.
+   * @param stream The stream to asynchronously operate on.
+   */
+  void saveOffset(size_t index, const size_t* offsetDPtr, cudaStream_t stream);
+
+  /**
+   * @brief Set the compressed size in the serialized metadata.
+   *
+   * @param sizeDPtr The pointer to the compressed size on the device.
+   * @param stream The stream to asynchronously operator on.
+   */
+  void setCompressedSizeFromGPU(const size_t* sizeDptr, cudaStream_t stream);
+
+  /**
+   * @brief Get a pointer to the given header on the device.
+   *
+   * @param index The input/layer to get the header of.
+   *
+   * @return The pointer to the header on the device.
+   */
+  CascadedMetadata::Header* getHeaderLocation(size_t index);
+
+  /**
+   * @brief Get a pointer to the given header on the device.
+   *
+   * @param index The input/layer to get the header of.
+   *
+   * @return The pointer to the header on the device.
+   */
+  const CascadedMetadata::Header* getHeaderLocation(size_t index) const;
+
+private:
+  void* m_ptr;
+  size_t m_maxSize;
+  size_t m_numInputs;
+
+  /**
+   * @brief Ensures that copyToGPU() has already been called (even if the
+   * asynchronous work associated with it has not finished) on this object and
+   * necessary information has been set, to allow quering.
+   *
+   * @throw An exception if copyToGPU() has not been successfully called.
+   */
+  void verifyInitialized() const;
+
+  /**
+   * @brief Verify that the given index is a valid one to operate on. If it
+   * is greater than the number of inputs, or the number of inputs has not
+   * been initialized, an exception will be thrown.
+   *
+   * @param index The index to check.
+   *
+   * @throw An exception if the index is not valid.
+   */
+  void verifyIndex(size_t index) const;
+};
+
+} // namespace nvcomp
+
+#endif

--- a/nvcomp/CascadedSelector.cpp
+++ b/nvcomp/CascadedSelector.cpp
@@ -1,0 +1,320 @@
+/*
+ * Copyright (c) Copyright-2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "CascadedSelector.h"
+#include "CascadedSelectorKernels.h"
+#include "TempSpaceBroker.h"
+#include "common.h"
+#include "nvcomp.hpp"
+#include "type_macros.h"
+
+#include <algorithm>
+#include <chrono>
+#include <iostream>
+#include <limits>
+#include <random>
+#include <stdlib.h>
+#include <vector>
+#include <cstddef>
+#include <stdexcept>
+
+using namespace std;
+using namespace nvcomp;
+
+namespace
+{
+// Number of compression schemes to try to determine best configuration
+constexpr int const NUM_SCHEMES = 5; 
+// Maximum value allowed for sample_size
+constexpr int const MAX_SAMPLE_SIZE = 1024;
+
+template <typename T>
+void get_workspace_size_internal(const size_t num_samples, size_t* temp_size)
+{
+  size_t required_size = sizeof(size_t) * num_samples;
+  required_size = roundUpTo(required_size, 8);
+  required_size += sizeof(unsigned long long int) * NUM_SCHEMES;
+  *temp_size = required_size;
+}
+
+template <typename T>
+nvcompCascadedFormatOpts internal_select(
+    const void* input_data,
+    const size_t in_bytes,
+    const size_t sample_ele,
+    const size_t num_samples,
+    double* comp_ratio,
+    void* d_temp_comp,
+    const size_t workspace_size,
+    const size_t max_size,
+    unsigned seed,
+    cudaStream_t stream)
+{
+
+  if (workspace_size < max_size) {
+    throw std::runtime_error(
+        "Insufficient workspace for perform selection: "
+        + std::to_string(workspace_size) + " / " + std::to_string(max_size));
+  }
+
+  if (sample_ele > MAX_SAMPLE_SIZE) {
+    throw std::runtime_error("sample size is too large, the maximum number of "
+                             "elements per sample is 1024\n");
+  }
+
+  const size_t sample_bytes = sample_ele * sizeof(T);
+
+  size_t num_chunks = in_bytes / sample_bytes;
+  size_t bracket_size = num_chunks / num_samples;
+  std::vector<size_t> sample_offsets(num_samples);
+
+  // TODO: The last chunk of the input data is discarded. Change it so that the
+  // last chunk can be also incuded during the sampling process.
+
+  std::minstd_rand0 g1(seed);
+
+  for (size_t i = 0; i < num_samples; i++) {
+    int idx = g1() % bracket_size;
+    sample_offsets[i] = idx + bracket_size * i;
+  }
+
+  size_t out_sizes[NUM_SCHEMES];
+  std::vector<size_t> sample_ptrs(num_samples);
+
+  for (size_t i = 0; i < num_samples; i++) {
+
+    size_t sample_off = sample_offsets[i] * sample_ele;
+    sample_ptrs[i] = sample_off;
+  }
+
+  size_t* d_sample_ptrs;
+  TempSpaceBroker tempSpace(d_temp_comp, workspace_size);
+  tempSpace.reserve(&d_sample_ptrs, num_samples);
+
+  cudaMemcpyAsync(
+      d_sample_ptrs,
+      sample_ptrs.data(),
+      sizeof(size_t) * num_samples,
+      cudaMemcpyHostToDevice,
+      stream);
+
+  SamplingFastOption(
+      input_data,
+      d_sample_ptrs,
+      sample_bytes,
+      num_samples,
+      getnvcompType<T>(),
+      tempSpace.next(),
+      tempSpace.spaceLeft(),
+      out_sizes,
+      NUM_SCHEMES,
+      stream);
+
+  cudaError_t err = cudaStreamSynchronize(stream);
+
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        "Fail to launch SampleFusedOption: " + std::to_string(err));
+  }
+
+  std::vector<size_t> outsizeVector;
+  for (int i = 0; i < NUM_SCHEMES; i++) {
+    outsizeVector.push_back(out_sizes[i]);
+  }
+
+  std::vector<size_t>::iterator result;
+  result = std::min_element(outsizeVector.begin(), outsizeVector.end());
+
+  int idx = std::distance(outsizeVector.begin(), result);
+  int RLEs = idx / 2;
+  int Deltas = (RLEs == 2) ? 1 : (idx % 2);
+
+  *comp_ratio
+      = ((double)(sample_bytes * num_samples) / (double)(outsizeVector[idx]));
+  nvcompCascadedFormatOpts opts = {RLEs, Deltas, 1};
+
+  return opts;
+}
+} // namespace
+
+namespace nvcomp
+{
+
+namespace internal
+{
+
+// Define types that are acceptable for Cascaded Compression
+template class CascadedSelector<int8_t>;
+template class CascadedSelector<uint8_t>;
+template class CascadedSelector<int16_t>;
+template class CascadedSelector<uint16_t>;
+template class CascadedSelector<int32_t>;
+template class CascadedSelector<uint32_t>;
+template class CascadedSelector<int64_t>;
+template class CascadedSelector<uint64_t>;
+
+template<typename T>
+inline CascadedSelector<T>::CascadedSelector(
+    const void* input,
+    const size_t byte_len,
+    nvcompCascadedSelectorOpts selector_opts):
+    input_data(input),
+    input_byte_len(byte_len),
+    max_temp_size(0),
+    opts(selector_opts)
+{
+  size_t temp;
+
+  NVCOMP_TYPE_ONE_SWITCH(
+      getnvcompType<T>(), get_workspace_size_internal, opts.num_samples, &temp);
+
+  temp = roundUpTo(temp, 8);
+
+  this->max_temp_size = temp;
+}
+
+template<typename T>
+inline size_t CascadedSelector<T>::get_temp_size() const
+
+{
+  return max_temp_size;
+}
+
+
+
+template<typename T>
+inline nvcompCascadedFormatOpts CascadedSelector<T>::select_config(
+    void* d_workspace, size_t workspace_size, double* comp_ratio, cudaStream_t stream)
+{
+
+  NVCOMP_TYPE_ONE_SWITCH_RETURN(
+      getnvcompType<T>(),
+      internal_select,
+      input_data,
+      input_byte_len,
+      opts.sample_size,
+      opts.num_samples,
+      comp_ratio,
+      d_workspace,
+      workspace_size,
+      max_temp_size,
+      opts.seed,
+      stream);
+}
+
+
+template<typename T>
+inline nvcompCascadedFormatOpts CascadedSelector<T>::select_config(
+    void* d_workspace, size_t workspace_size, cudaStream_t stream)
+{
+
+  double comp_ratio;
+
+  NVCOMP_TYPE_ONE_SWITCH_RETURN(
+      getnvcompType<T>(),
+      internal_select,
+      input_data,
+      input_byte_len,
+      opts.sample_size,
+      opts.num_samples,
+      &comp_ratio,
+      d_workspace,
+      workspace_size,
+      max_temp_size,
+      opts.seed,
+      stream);
+}
+
+} // namespace nvcomp
+} // namespace nvcomp
+
+nvcompError_t nvcompCascadedSelectorGetTempSize(
+    size_t in_bytes,
+    nvcompType_t in_type,
+    nvcompCascadedSelectorOpts selector_opts,
+    size_t* temp_bytes)
+{
+  // check that input is big enough to get all the samples
+  if(in_bytes < (selector_opts.sample_size * selector_opts.num_samples)) {
+    return nvcompErrorInvalidValue;
+  }
+
+  NVCOMP_TYPE_ONE_SWITCH(
+      in_type, get_workspace_size_internal, selector_opts.num_samples, temp_bytes);
+
+  *temp_bytes = roundUpTo(*temp_bytes, 8);
+  return nvcompSuccess;
+}
+
+
+nvcompCascadedFormatOpts callSelectorSelectConfig(
+    const void* in_ptr,
+    size_t in_bytes,
+    nvcompType_t in_type,
+    nvcompCascadedSelectorOpts opts,
+    void* temp_ptr,
+    size_t temp_bytes,
+    double* est_ratio,
+    cudaStream_t stream)
+{
+
+  size_t required_bytes;
+  nvcompCascadedSelectorGetTempSize(in_bytes, in_type, opts, &required_bytes);
+
+  NVCOMP_TYPE_ONE_SWITCH_RETURN(
+      in_type,
+      internal_select,
+      in_ptr,
+      in_bytes,
+      opts.sample_size,
+      opts.num_samples,
+      est_ratio,
+      temp_ptr,
+      temp_bytes,
+      required_bytes,
+      opts.seed,
+      stream);
+}
+  
+
+nvcompError_t nvcompCascadedSelectorSelectConfig(
+    const void* in_ptr,
+    size_t in_bytes,
+    nvcompType_t in_type,
+    nvcompCascadedSelectorOpts selector_opts,
+    void* temp_ptr,
+    size_t temp_bytes,
+    nvcompCascadedFormatOpts* format_opts,
+    double* est_ratio,
+    cudaStream_t stream)
+{
+
+  *format_opts = callSelectorSelectConfig(in_ptr, in_bytes, in_type, selector_opts, temp_ptr, temp_bytes, est_ratio, stream);
+      
+  return nvcompSuccess;
+}

--- a/nvcomp/CascadedSelector.h
+++ b/nvcomp/CascadedSelector.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Copyright 2020-2021, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "cascaded.hpp"
+
+namespace nvcomp
+{
+namespace internal
+{
+
+/**
+ *@brief Primary class for the Cascaded Selector used to determine the
+ * best configuration to run cascaded compression on a given input.
+ *
+ *@param T the datatype of the input
+ */
+template <typename T>
+class CascadedSelector
+{
+private:
+  const void* input_data;
+  size_t input_byte_len;
+  size_t max_temp_size; // Internal variable used to store the temp buffer size
+  nvcompCascadedSelectorOpts opts; // Sampling options
+
+public:
+  /**
+   *@brief Create a new CascadedSelector for the given input data
+   *
+   *@param input The input data device pointer to select a cheme for
+   *@param byte_len The number of bytes of input data
+   *@param num_sample_ele The number of elements in a sample
+   *@param num_sample The number of samples
+   *@param type The type of input data
+   */
+  CascadedSelector(
+      const void* input,
+      size_t byte_len,
+      nvcompCascadedSelectorOpts opts);
+
+  // disable copying
+  CascadedSelector(const CascadedSelector&) = delete;
+  CascadedSelector& operator=(const CascadedSelector&) = delete;
+
+  /*
+   *@brief return the required size of workspace buffer in bytes
+   */
+  size_t get_temp_size() const;
+
+  /*
+   *@brief Select a CascadedSelector compression scheme that can provide the
+   *best compression ratio and reports estimated compression ratio.
+   *
+   *@param d_worksapce The device potiner for the workspace
+   *@param workspace_len The size of workspace buffer in bytes
+   *@param comp_ratio The estimated compssion ratio using the bbest scheme (output)
+   *@param stream The input stream to run the select function
+   *@return Selected Cascaded options (RLE, Delta encoding, bit packing)
+   */
+  nvcompCascadedFormatOpts select_config(
+      void* d_workspace,
+      size_t workspace_len,
+      double* comp_ratio,
+      cudaStream_t stream);
+
+  /*
+   *@brief Select a CascadedSelector compression scheme that can provide the
+   *best compression ratio - does NOT return estimated compression ratio.
+   *
+   *@param d_worksapce The device potiner for the workspace
+   *@param workspace_len The size of workspace buffer in bytes
+   *@param stream The input stream to run the select function
+   *@return Selected Cascaded options (RLE, Delta encoding, bit packing)
+   */
+  nvcompCascadedFormatOpts select_config(
+      void* d_workspace,
+      size_t workspace_len,
+      cudaStream_t stream);
+
+};
+
+}
+}

--- a/nvcomp/CascadedSelectorKernels.cu
+++ b/nvcomp/CascadedSelectorKernels.cu
@@ -1,0 +1,603 @@
+/*
+ * Copyright (c) Copyright-2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "BitPackGPU.h"
+#include "DeltaGPU.h"
+#include "CascadedSelectorKernels.h"
+#include "TempSpaceBroker.h"
+#include "common.h"
+#include "CascadedCommon.h"
+#include "nvcomp.hpp"
+#include "type_macros.h"
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weffc++"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
+#include <cub/device/device_run_length_encode.cuh>
+#include <cub/device/device_scan.cuh>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+#include <algorithm>
+#include <cassert>
+#include <climits>
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace nvcomp
+{
+
+namespace
+{
+
+/**************************************************************************
+ * Device Functions
+ *************************************************************************/
+
+// Device function to perform RLE on a buffer per block
+template <typename VALUE, typename COUNT, int BLOCK_SIZE, int TILE_SIZE>
+__device__ void deviceRLEKernel(
+    COUNT* const runBuffer,
+    VALUE* const valBuffer,
+    COUNT* const prefix,
+    size_t const num,
+    int ITEMS_PER_THREAD)
+{
+  COUNT sum = 0;
+  {
+    VALUE val = valBuffer[threadIdx.x * ITEMS_PER_THREAD];
+    for (int i = 0; i < ITEMS_PER_THREAD; ++i) {
+      const int tid = threadIdx.x * ITEMS_PER_THREAD + i;
+      VALUE nextVal;
+      if (tid < num) {
+        nextVal = valBuffer[tid + 1];
+        sum += nextVal != val;
+        val = nextVal;
+      }
+    }
+  }
+
+  __syncthreads();
+  // prefixsum bit mask
+
+  {
+    typedef cub::BlockScan<COUNT, BLOCK_SIZE> BlockScan;
+    __shared__ typename BlockScan::TempStorage temp_storage;
+
+    BlockScan(temp_storage).InclusiveSum(sum, sum);
+
+    prefix[threadIdx.x + 1] = sum;
+  }
+
+  __syncthreads();
+
+  {
+    int outIdx = prefix[threadIdx.x];
+    VALUE val = valBuffer[threadIdx.x * ITEMS_PER_THREAD];
+    for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+      const int tid = threadIdx.x * ITEMS_PER_THREAD + i;
+      const VALUE nextVal = valBuffer[tid + 1];
+      if (nextVal != val) {
+        runBuffer[outIdx + 1] = tid + 1;
+        val = nextVal;
+        ++outIdx;
+      }
+    }
+  }
+}
+
+// Compute min and max of a buffer
+template <typename VALUE, typename COUNT, int BLOCK_SIZE, int TILE_SIZE>
+__device__ void deviceFindMinMax(
+    const size_t num,
+    COUNT* const prefix,
+    COUNT* const runBuffer,
+    VALUE* const valBuffer,
+    VALUE* const valBuffer2,
+    bool const prevValFlag,
+    COUNT* localRunMin,
+    COUNT* localRunMax,
+    VALUE* localValMin,
+    VALUE* localValMax,
+    uint64_t* const maxConnectedRun,
+    bool const connectedFlag,
+    bool const firstLayer)
+{
+  COUNT numCompacted = prefix[BLOCK_SIZE];
+
+  if (threadIdx.x == 0 && blockIdx.x == gridDim.x - 1) {
+    COUNT remain = num % TILE_SIZE;
+    runBuffer[numCompacted] = (remain == 0) ? (TILE_SIZE) : remain;
+  }
+
+  __syncthreads();
+
+  COUNT cur_run = runBuffer[1] - runBuffer[0];
+  COUNT cur_run_min = cur_run;
+  COUNT cur_run_max = cur_run;
+
+  VALUE cur_val = valBuffer[0];
+  VALUE cur_val_min = valBuffer[0];
+  VALUE cur_val_max = cur_val_min;
+
+  for (int tid = threadIdx.x; tid < numCompacted; tid += BLOCK_SIZE) {
+    cur_run = runBuffer[tid + 1] - runBuffer[tid];
+
+    if (firstLayer && connectedFlag) {
+      if (tid == 0) {
+        if (prevValFlag)
+          atomicAdd(
+              (unsigned long long*)(&(maxConnectedRun[blockIdx.x])),
+              (unsigned long long)(cur_run));
+        else
+          atomicAdd((unsigned long long*)(&(maxConnectedRun[blockIdx.x])), 0);
+      }
+    }
+
+    int validx = runBuffer[tid];
+    cur_val = valBuffer[validx];
+
+    cur_run_min = (tid == threadIdx.x) ? cur_run : min(cur_run_min, cur_run);
+    cur_run_max = (tid == threadIdx.x) ? cur_run : max(cur_run_max, cur_run);
+
+    if (firstLayer)
+      valBuffer2[tid] = cur_val;
+
+    cur_val_min = (tid == threadIdx.x) ? cur_val : min(cur_val_min, cur_val);
+    cur_val_max = (tid == threadIdx.x) ? cur_val : max(cur_val_max, cur_val);
+  }
+
+  __syncthreads();
+
+  {
+    typedef cub::BlockScan<COUNT, BLOCK_SIZE> BlockScan;
+    __shared__ typename BlockScan::TempStorage temp_storage;
+    BlockScan(temp_storage).InclusiveScan(cur_run_min, cur_run_min, cub::Min());
+    BlockScan(temp_storage).InclusiveScan(cur_run_max, cur_run_max, cub::Max());
+  }
+
+  __syncthreads();
+  {
+    typedef cub::BlockScan<VALUE, BLOCK_SIZE> BlockScan;
+    __shared__ typename BlockScan::TempStorage temp_storage;
+    BlockScan(temp_storage).InclusiveScan(cur_val_min, cur_val_min, cub::Min());
+    BlockScan(temp_storage).InclusiveScan(cur_val_max, cur_val_max, cub::Max());
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x == 0) {
+    *localRunMin = cur_run_min;
+    *localValMin = cur_val_min;
+  }
+  if (threadIdx.x == (BLOCK_SIZE - 1)) {
+    *localRunMax = cur_run_max;
+    *localValMax = cur_val_max;
+  }
+
+  __syncthreads();
+}
+/**************************************************************
+ * Kernels
+ *************************************************************/
+
+// Kernel to perform the fused compression on a sample of the input
+template <typename VALUE, typename COUNT, int BLOCK_SIZE, int TILE_SIZE>
+__global__ void SampleFusedKernel(
+    const VALUE* const in,
+    size_t* const sample_offsets,
+    const size_t num,
+    unsigned long long int* const sizeBuffer
+
+)
+{
+  __shared__ size_t s_offset;
+
+  if (threadIdx.x == 0) {
+    s_offset = sample_offsets[blockIdx.x];
+  }
+  __syncthreads();
+
+  constexpr const int ITEMS_PER_THREAD = TILE_SIZE / BLOCK_SIZE;
+
+  __shared__ COUNT prefix[BLOCK_SIZE + 1];
+  __shared__ COUNT runBuffer[TILE_SIZE + 1];
+  __shared__ VALUE valBuffer1stRLE[TILE_SIZE + 1];
+  __shared__ VALUE valBuffer2ndRLE[TILE_SIZE + 1];
+
+  __shared__ COUNT localRunMinFor1stRLE;
+  __shared__ COUNT localRunMaxFor1stRLE;
+  __shared__ VALUE localValMinFor1stRLE;
+  __shared__ VALUE localValMaxFor1stRLE;
+
+  __shared__ COUNT localRunMinFor2ndRLE;
+  __shared__ COUNT localRunMaxFor2ndRLE;
+  __shared__ VALUE localValMinFor2ndRLE;
+  __shared__ VALUE localValMaxFor2ndRLE;
+
+  // load data
+  __syncthreads();
+  for (int tid = threadIdx.x; tid < TILE_SIZE; tid += BLOCK_SIZE) {
+    int gTid = tid + s_offset;
+    if (tid < num) {
+      valBuffer1stRLE[tid] = in[gTid];
+    } else {
+      int maxTid = num + s_offset - 1;
+      valBuffer1stRLE[tid] = in[maxTid];
+    }
+  }
+
+  if (threadIdx.x == 0) {
+    prefix[0] = 0;
+    runBuffer[0] = 0;
+  }
+
+  __syncthreads();
+
+// Have each block run RLE on a tile of sampled input
+  size_t tile_size = TILE_SIZE;
+  deviceRLEKernel<VALUE, COUNT, BLOCK_SIZE, TILE_SIZE>(
+      runBuffer, valBuffer1stRLE, prefix, tile_size, ITEMS_PER_THREAD);
+
+  __syncthreads();
+
+// Find min and max values used to estimate compression ratio
+  deviceFindMinMax<VALUE, COUNT, BLOCK_SIZE, TILE_SIZE>(
+     num,
+      prefix,
+      runBuffer,
+      valBuffer1stRLE,
+      valBuffer2ndRLE,
+      false,
+      &localRunMinFor1stRLE,
+      &localRunMaxFor1stRLE,
+      &localValMinFor1stRLE,
+      &localValMaxFor1stRLE,
+      NULL,
+      false,
+      true);
+
+  __syncthreads();
+
+  // Initialize input for 2nd RLE stage testing
+  size_t numOutFor1stRLE = prefix[BLOCK_SIZE];
+  size_t num2ndRLE = prefix[BLOCK_SIZE];
+  const int ITEMS_PER_THREAD2 = ceil((double)num2ndRLE / (double)BLOCK_SIZE);
+
+  for (int ph = 0; ph < ITEMS_PER_THREAD2; ph++) {
+    int tid = ph * BLOCK_SIZE + threadIdx.x;
+    if (tid == 0) {
+      valBuffer1stRLE[tid] = in[0];
+    } else {
+      valBuffer1stRLE[tid] = valBuffer2ndRLE[tid] - valBuffer2ndRLE[tid - 1];
+    }
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x == 0) {
+    prefix[0] = 0;
+    runBuffer[0] = 0;
+  }
+
+  __syncthreads();
+
+  // Run 2nd RLE on output from first tested stage
+  deviceRLEKernel<VALUE, COUNT, BLOCK_SIZE, TILE_SIZE>(
+      runBuffer, valBuffer1stRLE, prefix, (size_t)num2ndRLE, ITEMS_PER_THREAD2);
+
+  __syncthreads();
+
+  size_t numOutFor2ndRLE = prefix[BLOCK_SIZE];
+
+  // Compute min and max for 2nd RLE stage
+  deviceFindMinMax<VALUE, COUNT, BLOCK_SIZE, TILE_SIZE>(
+      num2ndRLE,
+      prefix,
+      runBuffer,
+      valBuffer1stRLE,
+      valBuffer2ndRLE,
+      false,
+      &localRunMinFor2ndRLE,
+      &localRunMaxFor2ndRLE,
+      &localValMinFor2ndRLE,
+      &localValMaxFor2ndRLE,
+      NULL,
+      false,
+      false);
+
+  __syncthreads();
+
+  // Thread 0 computes the statistics of each compression scheme
+  // for the data the block processed
+  if (threadIdx.x == 0) {
+    VALUE valRangeFor1stRLE = localValMaxFor1stRLE - (localValMinFor1stRLE);
+    COUNT runRangeFor1stRLE = localRunMaxFor1stRLE - (localRunMinFor1stRLE);
+    size_t valBitsFor1stRLE;
+    size_t runBitsFor1stRLE;
+    size_t valBitsFor2ndRLE;
+    size_t runBitsFor2ndRLE;
+
+    // Compute number of bits needed for VALS if using 1 RLE
+    if (sizeof(valRangeFor1stRLE) > sizeof(int)) {
+      valBitsFor1stRLE
+          = sizeof(long long int) * 8
+            - __clzll(static_cast<long long int>(valRangeFor1stRLE));
+    } else {
+      valBitsFor1stRLE
+          = sizeof(int) * 8 - __clz(static_cast<int>(valRangeFor1stRLE));
+    }
+
+    // Compute number of bits needed for RUNS if using 1 RLE
+    if (sizeof(runRangeFor1stRLE) > sizeof(int)) {
+      runBitsFor1stRLE
+          = sizeof(long long int) * 8
+            - __clzll(static_cast<long long int>(runRangeFor1stRLE));
+    } else {
+
+      runBitsFor1stRLE
+          = sizeof(int) * 8 - __clz(static_cast<int>(runRangeFor1stRLE));
+    }
+
+    VALUE valRangeFor2ndRLE = localValMaxFor2ndRLE - (localValMinFor2ndRLE);
+    COUNT runRangeFor2ndRLE = localRunMaxFor2ndRLE - (localRunMinFor2ndRLE);
+
+    // Compute number of bits needed for VALS if using 2 RLEs
+    if (sizeof(valRangeFor2ndRLE) > sizeof(int)) {
+      valBitsFor2ndRLE
+          = sizeof(long long int) * 8
+            - __clzll(static_cast<long long int>(valRangeFor2ndRLE));
+    } else {
+
+      valBitsFor2ndRLE
+          = sizeof(int) * 8 - __clz(static_cast<int>(valRangeFor2ndRLE));
+    }
+
+    // Compute number of bits needed for RUNS if using 2 RLEs
+    if (sizeof(runRangeFor2ndRLE) > sizeof(int)) {
+      runBitsFor2ndRLE
+          = sizeof(long long int) * 8
+            - __clzll(static_cast<long long int>(runRangeFor2ndRLE));
+    } else {
+
+      runBitsFor2ndRLE
+         = sizeof(int) * 8 - __clz(static_cast<int>(runRangeFor2ndRLE));
+    }
+
+    // Ensure tha tthe number of bits will be at least 1
+    valBitsFor1stRLE
+        = max((unsigned long long)valBitsFor1stRLE, (unsigned long long)1);
+    valBitsFor2ndRLE
+        = max((unsigned long long)valBitsFor2ndRLE, (unsigned long long)1);
+    runBitsFor1stRLE
+        = max((unsigned long long)runBitsFor1stRLE, (unsigned long long)1);
+    runBitsFor2ndRLE
+        = max((unsigned long long)runBitsFor2ndRLE, (unsigned long long)1);
+
+    // Compute sizes of each compressed output of vals and runs for each stage
+    size_t run1stRLE = runBitsFor1stRLE * numOutFor1stRLE;
+    run1stRLE = roundUpTo(roundUpDiv(run1stRLE, 8ULL), sizeof(COUNT));
+    run1stRLE = roundUpTo(run1stRLE, sizeof(size_t));
+
+    size_t val1stRLE = valBitsFor1stRLE * numOutFor1stRLE;
+    val1stRLE = roundUpTo(roundUpDiv(val1stRLE, 8ULL), sizeof(VALUE));
+    val1stRLE = roundUpTo(val1stRLE, sizeof(size_t));
+
+    size_t val1stDelta = valBitsFor2ndRLE * numOutFor1stRLE;
+    val1stDelta = roundUpTo(roundUpDiv(val1stDelta, 8ULL), sizeof(VALUE));
+    val1stDelta = roundUpTo(val1stDelta, sizeof(size_t));
+
+    size_t run2ndRLE = runBitsFor2ndRLE * numOutFor2ndRLE;
+    run2ndRLE = roundUpTo(roundUpDiv(run2ndRLE, 8ULL), sizeof(COUNT));
+    run2ndRLE = roundUpTo(run2ndRLE, sizeof(size_t));
+
+    size_t val2ndRLE = valBitsFor2ndRLE * numOutFor2ndRLE;
+    val2ndRLE = roundUpTo(roundUpDiv(val2ndRLE, 8ULL), sizeof(VALUE));
+    val2ndRLE = roundUpTo(val2ndRLE, sizeof(size_t));
+
+    // Compute the final compressed size of each compression scheme
+    size_t R0D0B1 = valBitsFor1stRLE * num;
+    R0D0B1 = roundUpTo(roundUpDiv(R0D0B1, 8ULL), sizeof(VALUE));
+    R0D0B1 = roundUpTo(R0D0B1, sizeof(size_t));
+    size_t R0D1B1 = valBitsFor2ndRLE * num;
+    R0D1B1 = roundUpTo(roundUpDiv(R0D1B1, 8ULL), sizeof(VALUE));
+    R0D1B1 = roundUpTo(R0D1B1, sizeof(size_t));
+
+    size_t R1D0B1 = run1stRLE + val1stRLE;
+    size_t R1D1B1 = run1stRLE + val1stDelta;
+    size_t R2D1B1 = run1stRLE + run2ndRLE + val2ndRLE;
+
+    // Add total compression for block to overall sum of all samples
+    atomicAdd(&(sizeBuffer[0]), static_cast<unsigned long long int>(R0D0B1));
+    atomicAdd(&(sizeBuffer[1]), static_cast<unsigned long long int>(R0D1B1));
+    atomicAdd(&(sizeBuffer[2]), static_cast<unsigned long long int>(R1D0B1));
+    atomicAdd(&(sizeBuffer[3]), static_cast<unsigned long long int>(R1D1B1));
+    atomicAdd(&(sizeBuffer[4]), static_cast<unsigned long long int>(R2D1B1));
+  }
+}
+
+
+/******************************************************************************
+ * Internal function calls
+******************************************************************************/
+
+/*
+ *@brief Selected a cascaded compression scheme by Sampling Fast Selector
+ *@param in The input memory location on the GPU
+ *@sample_ptrs The input data offsets for each samples
+ *@param workspace The workspace memory location on the GPU
+ *@param workspaceSize The size of the workspace memory in bytes
+ *@param maxNum The number of elements in a sample
+ *@param outSizeBuffer The buffer for the size of compreesed data for all
+ *schemesin bytes (output)
+ *@numSamples The number of samples
+ *@NUM_SCHMES The number of cascaded schemes.
+ *@param stream The stream to execute the kernel on
+ */
+
+template <typename VALUE, typename COUNT>
+void SampleFusedInternal(
+    const void* const in,
+    size_t* const sample_ptrs,
+    void* const workspace,
+    const size_t workspaceSize,
+    const size_t maxNum,
+    size_t* const outsizeBuffer,
+    size_t const numSamples,
+    const int NUM_SCHEMES,
+    cudaStream_t stream)
+
+{
+
+  constexpr const int BLOCK_SIZE = 128;
+  constexpr const int SAMPLE_TILE_SIZE = 1024;
+
+  if (NUM_SCHEMES != 5) {
+    throw std::runtime_error("Number of schemes should be 5\n");
+  }
+
+  const size_t grid_size = numSamples;
+  const dim3 grid(grid_size);
+  const dim3 block(BLOCK_SIZE);
+
+  unsigned long long int* d_sizeBuffer;
+
+  TempSpaceBroker tempSpace(workspace, workspaceSize);
+  tempSpace.reserve(&d_sizeBuffer, NUM_SCHEMES);
+
+  cudaMemsetAsync(d_sizeBuffer, 0, sizeof(*d_sizeBuffer) * NUM_SCHEMES, stream);
+
+  const VALUE* const inTyped = static_cast<const VALUE*>(in);
+
+  SampleFusedKernel<VALUE, COUNT, BLOCK_SIZE, SAMPLE_TILE_SIZE>
+      <<<grid, block, 0, stream>>>(inTyped, sample_ptrs, maxNum, d_sizeBuffer);
+
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        "Fail to launch SampleFusedKernel: " + std::to_string(err));
+  }
+
+  unsigned long long int size_buffer[NUM_SCHEMES];
+  err = cudaMemcpyAsync(
+      size_buffer,
+      d_sizeBuffer,
+      sizeof(unsigned long long int) * NUM_SCHEMES,
+      cudaMemcpyDeviceToHost,
+      stream);
+  err = cudaStreamSynchronize(stream);
+
+  if (err != cudaSuccess) {
+    throw std::runtime_error("size buffer cuda memcpy failed\n");
+  }
+
+  for (int i = 0; i < NUM_SCHEMES; i++) {
+    outsizeBuffer[i] = (size_t)size_buffer[i];
+  }
+}
+
+/*
+ *@brief Selected a cascaded compression scheme by Sampling Fast Selector
+ *
+ *@param in The input memory location on the GPU
+ *@sample_ptrs The input data offsets for each samples
+ *@param temp_ptr The workspace memory location on the GPU
+ *@param temp_bytes The size of the workspace memory in bytes
+ *@param outsize The buffer for the size of compreesed data for all schemesin
+ *bytes (output)
+ *@param numSamples The number of samples.
+ *@param num_schemes The number of cascaded schemes.
+ *@param stream The stream to execute the kernel on
+ */
+template <typename valT, typename runT>
+void SampleFusedOption_internal(
+    const void* const in,
+    size_t* const sample_ptrs,
+    const size_t in_bytes,
+    void* const temp_ptr,
+    const size_t temp_bytes,
+    size_t* outsize,
+    size_t const numSamples,
+    const int num_schemes,
+    cudaStream_t stream)
+{
+
+  const size_t maxNum = in_bytes / sizeof(valT);
+
+  SampleFusedInternal<valT, runT>(
+      in,
+      sample_ptrs,
+      temp_ptr,
+      temp_bytes,
+      maxNum,
+      outsize,
+      numSamples,
+      num_schemes,
+      stream);
+}
+
+} // namespace
+
+void SamplingFastOption(
+    const void* const in,
+    size_t* const sample_offsets,
+    const size_t sample_bytes,
+    const size_t num_samples,
+    const nvcompType_t in_type,
+    void* const workspace,
+    const size_t workspaceSize,
+    size_t* outsizeBuffer,
+    int num_schemes,
+    cudaStream_t stream)
+{
+
+  const nvcompType_t countType
+      = selectRunsType(sample_bytes / sizeOfnvcompType(in_type));
+
+  NVCOMP_TYPE_TWO_SWITCH(
+      in_type,
+      countType,
+      SampleFusedOption_internal,
+      in,
+      sample_offsets,
+      sample_bytes,
+      workspace,
+      workspaceSize,
+      outsizeBuffer,
+      num_samples,
+      num_schemes,
+      stream);
+}
+
+} // namespace nvcomp

--- a/nvcomp/CascadedSelectorKernels.h
+++ b/nvcomp/CascadedSelectorKernels.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Copyright-2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CASCADEDSELECTORKERNEL_HPP
+#define CASCADEDSELECTORKERNEL_HPP
+
+#include "cascaded.hpp"
+#include "nvcomp.hpp"
+
+namespace nvcomp
+{
+  /*
+   *@brief Computes the sum of all sample output buffer with all different
+   *schemes.
+   *@param in The input memory location on the GPU
+   *@param sample_offsets, the offsets to compute the starting point for the
+   *samples
+   *@param sample_bytes The size of the sample memory location on the GPU in
+   *bytes
+   *@param num_samples The number of samples
+   *@param in_type The type of the input elements
+   *@param workspace The workspace used internally by kernels
+   *@param workspaceSize The size of the workspace size in bytes
+   *@param outsize The computed output buffere size (result)
+   *@param NUM_SCHEMES The number of schemes.
+   *@param stream The stream to execute the kernel on
+   **/
+
+  void SamplingFastOption(
+      const void* const in,
+      size_t* const sample_offsets,
+      const size_t sample_bytes,
+      const size_t num_samples,
+      const nvcompType_t in_type,
+      void* const workspace,
+      const size_t workspaceSize,
+      size_t* outsize,
+      int NUM_SCHEMES,
+      cudaStream_t stream);
+
+} // namespace nvcomp
+
+#endif

--- a/nvcomp/Check.cpp
+++ b/nvcomp/Check.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Check.h"
+
+namespace nvcomp
+{
+
+/******************************************************************************
+ * PUBLIC STATIC METHODS ******************************************************
+ *****************************************************************************/
+
+void Check::not_null(
+    const void* const ptr,
+    const std::string& name,
+    const std::string& filename,
+    const int line)
+{
+  if (ptr == nullptr) {
+    print_fail_position(filename, line);
+    throw std::runtime_error("'" + name + "' must not be null.");
+  }
+}
+
+void Check::api_call(
+    const nvcompError_t err, const std::string& filename, const int line)
+{
+  if (err != nvcompSuccess) {
+    print_fail_position(filename, line);
+    throw NVCompException(err, "API CALL FAILED");
+  }
+}
+
+nvcompError_t Check::exception_to_error(
+    const std::exception& e, const std::string& function_name)
+{
+  std::string context;
+  if (!function_name.empty()) {
+    context = "In " + function_name + ": ";
+  }
+
+  // generic error
+  nvcompError_t err = nvcompErrorInvalidValue;
+
+  // NOTE: this depends on RTTI being enabled.
+  if (dynamic_cast<const NVCompException*>(&e)) {
+    const NVCompException& nve = dynamic_cast<const NVCompException&>(e);
+    err = nve.get_error();
+  }
+
+  std::cerr << "ERROR: " << context << e.what() << std::endl;
+  return err;
+}
+
+void Check::print_fail_position(const std::string& filename, const int line)
+{
+  std::cerr << "CHECK FAILED: " << filename << ":" << line << std::endl;
+}
+
+} // namespace nvcomp

--- a/nvcomp/Check.h
+++ b/nvcomp/Check.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NVCOMP_CHECK_H
+#define NVCOMP_CHECK_H
+
+#include "nvcomp.h"
+#include "nvcomp.hpp"
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace nvcomp
+{
+
+class Check
+{
+public:
+  static void not_null(
+      const void* const ptr,
+      const std::string& name,
+      const std::string& filename,
+      const int line);
+
+  template <typename T>
+  static void equal(
+      const T& a,
+      const T& b,
+      const std::string& a_name,
+      const std::string& b_name,
+      const std::string& filename,
+      const int line)
+  {
+    if (!(a == b)) {
+      print_fail_position(filename, line);
+      std::cerr << a_name << "(" << a << ")"
+                << " != " << b_name << "(" << b << ")" << std::endl;
+      throw NVCompException(nvcompErrorInternal, "CHECK_EQ Failed");
+    }
+  }
+
+  static void
+  api_call(nvcompError_t err, const std::string& filename, const int line);
+
+  // NOTE: there is no C++11/C++14 standard way to get the function name.
+  // In the future we could try to handle major compilers, and get the
+  // name that way, as well as use the c++20 method.
+  static nvcompError_t
+  exception_to_error(const std::exception& e, const std::string& function_name);
+
+private:
+  static void print_fail_position(const std::string& filename, const int line);
+};
+
+} // namespace nvcomp
+
+#define CHECK_API_CALL(call) Check::api_call(call, __FILE__, __LINE__)
+
+#define CHECK_EQ(a, b) Check::equal(a, b, #a, #b, __FILE__, __LINE__)
+
+#define CHECK_NOT_NULL(ptr) Check::not_null(ptr, #ptr, __FILE__, __LINE__)
+
+#define API_WRAPPER(call, func_name)                                           \
+  [](auto err) {                                                               \
+    try {                                                                      \
+      Check::api_call(err, __FILE__, __LINE__);                                \
+    } catch (const std::exception& e) {                                        \
+      return Check::exception_to_error(e, func_name);                          \
+    }                                                                          \
+    return err;                                                                \
+  }(call)
+
+#endif

--- a/nvcomp/CudaUtils.h
+++ b/nvcomp/CudaUtils.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NVCOMP_CUDAUTILS_H
+#define NVCOMP_CUDAUTILS_H
+
+#include "cuda_runtime.h"
+
+#include <stdexcept>
+#include <string>
+
+namespace nvcomp
+{
+
+enum CopyDirection {
+  HOST_TO_DEVICE = cudaMemcpyHostToDevice,
+  DEVICE_TO_HOST = cudaMemcpyDeviceToHost,
+  DEVICE_TO_DEVICE = cudaMemcpyDeviceToDevice
+};
+
+class CudaUtils
+{
+public:
+  /**
+   * @brief Convert cuda errors into exceptions. Will throw an exception
+   * unless `err == cudaSuccess`.
+   *
+   * @param err The error.
+   * @param msg The message to attach to the exception.
+   */
+  static void check(const cudaError_t err, const std::string& msg)
+  {
+    if (err != cudaSuccess) {
+      std::string errorStr(
+          "Encountered Cuda Error: " + std::to_string(err) + ": '"
+          + std::string(cudaGetErrorString(err)) + "'");
+      if (!msg.empty()) {
+        errorStr += ": " + msg;
+      }
+      errorStr += ".";
+
+      throw std::runtime_error(errorStr);
+    }
+  }
+
+  static void sync(cudaStream_t stream)
+  {
+    check(cudaStreamSynchronize(stream), "Failed to sync with stream");
+  }
+
+  static void check_last_error(const std::string& msg = "")
+  {
+    check(cudaGetLastError(), msg);
+  }
+
+  /**
+   * @brief Perform checked asynchronous memcpy.
+   *
+   * @tparam T The data type.
+   * @param dst The destination address.
+   * @param src The source address.
+   * @param count The number of elements to copy.
+   * @param kind The direction of the copy.
+   * @param stream THe stream to operate on.
+   */
+  template <typename T>
+  static void copy_async(
+      T* const dst,
+      const T* const src,
+      const size_t count,
+      const CopyDirection kind,
+      cudaStream_t stream)
+  {
+    check(
+        cudaMemcpyAsync(dst, src, sizeof(T) * count,
+          static_cast<cudaMemcpyKind>(kind), stream),
+        "CudaUtils::copy_async(dst, src, count, kind, stream)");
+  }
+
+  /**
+   * @brief Perform a synchronous memcpy.
+   *
+   * @tparam T The data type.
+   * @param dst The destination address.
+   * @param src The source address.
+   * @param count The number of elements to copy.
+   * @param kind The direction of the copy.
+   */
+  template <typename T>
+  static void copy(
+      T* const dst,
+      const T* const src,
+      const size_t count,
+      const CopyDirection kind)
+  {
+    check(
+        cudaMemcpy(dst, src, sizeof(T) * count, static_cast<cudaMemcpyKind>(kind)),
+        "CudaUtils::copy(dst, src, count, kind)");
+  }
+
+
+};
+
+} // namespace nvcomp
+
+#endif

--- a/nvcomp/DeltaGPU.cu
+++ b/nvcomp/DeltaGPU.cu
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "DeltaGPU.h"
+#include "common.h"
+#include "CascadedCommon.h"
+#include "type_macros.h"
+
+#include <cassert>
+#include <limits>
+
+namespace nvcomp
+{
+
+/******************************************************************************
+ * CONSTANTS ******************************************************************
+ *****************************************************************************/
+
+namespace
+{
+
+constexpr int const BLOCK_SIZE = 1024;
+
+} // namespace
+
+/******************************************************************************
+ * KERNELS ********************************************************************
+ *****************************************************************************/
+
+namespace
+{
+
+template <typename VALUE>
+__global__ void deltaKernel(
+    VALUE** const outputPtr,
+    const VALUE* const input,
+    const size_t* const numDevice,
+    const size_t maxNum)
+{
+  const size_t num = *numDevice;
+
+  if (BLOCK_SIZE * blockIdx.x < num) {
+    VALUE* const output = *outputPtr;
+
+    const int idx = threadIdx.x + BLOCK_SIZE * blockIdx.x;
+
+    __shared__ VALUE buffer[BLOCK_SIZE + 1];
+
+    if (idx < num) {
+      buffer[threadIdx.x + 1] = input[idx];
+    }
+
+    if (threadIdx.x == 0) {
+      // first thread must do something special
+      if (idx > 0) {
+        buffer[0] = input[idx - 1];
+      } else {
+        buffer[0] = 0;
+      }
+    }
+
+    __syncthreads();
+
+    if (idx < num) {
+      output[idx] = buffer[threadIdx.x + 1] - buffer[threadIdx.x];
+    }
+  }
+}
+
+} // namespace
+
+/******************************************************************************
+ * HELPER FUNCTIONS ***********************************************************
+ *****************************************************************************/
+
+namespace
+{
+
+template <typename VALUE>
+void deltaLaunch(
+    void** const outPtr,
+    void const* const in,
+    const size_t* const numDevice,
+    const size_t maxNum,
+    cudaStream_t stream)
+{
+  VALUE** const outTypedPtr = reinterpret_cast<VALUE**>(outPtr);
+  const VALUE* const inTyped = static_cast<const VALUE*>(in);
+
+  const dim3 block(BLOCK_SIZE);
+  const dim3 grid(roundUpDiv(maxNum, BLOCK_SIZE));
+  deltaKernel<<<grid, block, 0, stream>>>(
+      outTypedPtr, inTyped, numDevice, maxNum);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        "Failed to launch deltaKernel kernel: " + std::to_string(err));
+  }
+}
+
+} // namespace
+
+/******************************************************************************
+ * PUBLIC STATIC METHODS ******************************************************
+ *****************************************************************************/
+
+void DeltaGPU::compress(
+    void* const /* workspace */,
+    const size_t /* workspaceSize*/,
+    const nvcompType_t inType,
+    void** const outPtr,
+    const void* const in,
+    const size_t* const numDevice,
+    const size_t maxNum,
+    cudaStream_t stream)
+{
+  NVCOMP_TYPE_ONE_SWITCH(
+      inType, deltaLaunch, outPtr, in, numDevice, maxNum, stream);
+}
+
+size_t DeltaGPU::requiredWorkspaceSize(
+    const size_t /*num*/, const nvcompType_t /* type */)
+{
+  return 0;
+}
+
+} // namespace nvcomp

--- a/nvcomp/DeltaGPU.h
+++ b/nvcomp/DeltaGPU.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NVCOMP_DELTAGPU_H
+#define NVCOMP_DELTAGPU_H
+
+#include "cascaded.h"
+#include "cuda_runtime.h"
+
+#include <cstddef>
+
+namespace nvcomp
+{
+
+class DeltaGPU
+{
+public:
+  /**
+   * @brief Encode a series of values using delta encoding. That is for the
+   * series [a, b, c, ..., z], store [a, b-a, b-c, ..., z-y].
+   *
+   * @param workspace The temporary workspace to use.
+   * @param workspaceSize The size of the temporary workspace to use.
+   * @param valueType The type of value to delta encode.
+   * @param outValuesPtr The location to write output stored on the device.
+   * @param inValues The input location.
+   * @param numDevice The actual number of values on the device.
+   * @param maxNum The maximum number of values.
+   * @param stream The stream to operate on.
+   */
+  static void compress(
+      void* workspace,
+      size_t workspaceSize,
+      nvcompType_t valueType,
+      void** const outValuesPtr,
+      const void* inValues,
+      const size_t* numDevice,
+      const size_t maxNum,
+      cudaStream_t stream);
+
+  /**
+   * @brief Get the required size of the workspace in bytes.
+   *
+   * @param num The number of elements to compress.
+   * @param type The type of elements.
+   *
+   * @return The size in bytes of the required workspace.
+   */
+  static size_t requiredWorkspaceSize(size_t num, nvcompType_t type);
+};
+
+} // namespace nvcomp
+
+#endif

--- a/nvcomp/LICENSE
+++ b/nvcomp/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of NVIDIA CORPORATION nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/nvcomp/LZ4.cpp
+++ b/nvcomp/LZ4.cpp
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "lz4.h"
+
+#include "Check.h"
+#include "CudaUtils.h"
+#include "LZ4BatchCompressor.h"
+#include "LZ4CompressionKernels.h"
+#include "LZ4Metadata.h"
+#include "LZ4MetadataOnGPU.h"
+#include "MutableLZ4MetadataOnGPU.h"
+#include "common.h"
+#include "nvcomp.h"
+#include "nvcomp.hpp"
+#include "type_macros.h"
+
+#include <cassert>
+#include <iostream>
+#include <list>
+#include <map>
+#include <mutex>
+#include <sstream>
+#include <vector>
+
+
+using namespace nvcomp;
+
+int LZ4IsData(const void* const in_ptr, size_t in_bytes, cudaStream_t stream)
+{
+  // Need at least 2 size_t variables to be valid.
+  if(in_ptr == NULL || in_bytes < sizeof(size_t)) {
+    return false;
+  }
+  size_t header_val;
+  CudaUtils::copy_async(
+      &header_val,
+      static_cast<const size_t*>(in_ptr),
+      1,
+      DEVICE_TO_HOST,
+      stream);
+  CudaUtils::sync(stream);
+  return (header_val == LZ4_FLAG); 
+}
+
+nvcompError_t nvcompLZ4DecompressGetMetadata(
+    const void* const in_ptr,
+    const size_t in_bytes,
+    void** const metadata_ptr,
+    cudaStream_t stream)
+{
+  return API_WRAPPER(
+      nvcompBatchedLZ4DecompressGetMetadata(
+          (const void**)&in_ptr, &in_bytes, 1, metadata_ptr, stream),
+      "nvcompLZ4DecompressGetMetadata()");
+}
+
+void nvcompLZ4DecompressDestroyMetadata(void* const metadata_ptr)
+{
+  nvcompBatchedLZ4DecompressDestroyMetadata(metadata_ptr);
+}
+
+nvcompError_t
+nvcompLZ4DecompressGetTempSize(const void* metadata_ptr, size_t* temp_bytes)
+{
+  return API_WRAPPER(
+      nvcompBatchedLZ4DecompressGetTempSize(metadata_ptr, temp_bytes),
+      "nvcompLZ4DecompressGetTempSize()");
+}
+
+nvcompError_t
+nvcompLZ4DecompressGetOutputSize(const void* metadata_ptr, size_t* output_bytes)
+{
+  return API_WRAPPER(
+      nvcompBatchedLZ4DecompressGetOutputSize(metadata_ptr, 1, output_bytes),
+      "nvcompLZ4DecompressGetOutputSize()");
+}
+
+nvcompError_t nvcompLZ4DecompressAsync(
+    const void* const in_ptr,
+    const size_t in_bytes,
+    void* const temp_ptr,
+    const size_t temp_bytes,
+    const void* const metadata_ptr,
+    void* const out_ptr,
+    const size_t out_bytes,
+    cudaStream_t stream)
+{
+  return API_WRAPPER(
+      nvcompBatchedLZ4DecompressAsync(
+          &in_ptr,
+          &in_bytes,
+          1,
+          temp_ptr,
+          temp_bytes,
+          (const void* const*)metadata_ptr,
+          &out_ptr,
+          &out_bytes,
+          stream),
+      "nvcompLZ4DecompressAsync()");
+}
+
+nvcompError_t nvcompLZ4CompressGetTempSize(
+    const void* in_ptr,
+    const size_t in_bytes,
+    nvcompType_t /*in_type*/,
+    const nvcompLZ4FormatOpts* const format_opts,
+    size_t* const temp_bytes)
+{
+  return API_WRAPPER(
+      nvcompBatchedLZ4CompressGetTempSize(
+          &in_ptr, &in_bytes, 1, format_opts, temp_bytes),
+      "nvcompLZ4CompressGetTempSize()");
+}
+
+nvcompError_t nvcompLZ4CompressGetOutputSize(
+    const void* const in_ptr,
+    const size_t in_bytes,
+    const nvcompType_t /*in_type*/,
+    const nvcompLZ4FormatOpts* format_opts,
+    void* const temp_ptr,
+    const size_t temp_bytes,
+    size_t* const out_bytes,
+    const int exact_out_bytes)
+{
+  if (exact_out_bytes) {
+    std::cerr
+        << "LZ4CompressGetOutputSize(): Exact output bytes is unimplemented at "
+           "this time."
+        << std::endl;
+    return nvcompErrorInvalidValue;
+  }
+
+  return API_WRAPPER(
+      nvcompBatchedLZ4CompressGetOutputSize(
+          &in_ptr, &in_bytes, 1, format_opts, temp_ptr, temp_bytes, out_bytes),
+      "LZ4CompressGetOutputSize()");
+}
+
+nvcompError_t nvcompLZ4CompressAsync(
+    const void* in_ptr,
+    const size_t in_bytes,
+    const nvcompType_t /* in_type */,
+    const nvcompLZ4FormatOpts* format_opts,
+    void* const temp_ptr,
+    const size_t temp_bytes,
+    void* const out_ptr,
+    size_t* const out_bytes,
+    cudaStream_t stream)
+{
+  return API_WRAPPER(
+      nvcompBatchedLZ4CompressAsync(
+          &in_ptr,
+          &in_bytes,
+          1,
+          format_opts,
+          temp_ptr,
+          temp_bytes,
+          &out_ptr,
+          out_bytes,
+          stream),
+      "nvcompLZ4CompressAsync");
+}

--- a/nvcomp/LZ4Batch.cpp
+++ b/nvcomp/LZ4Batch.cpp
@@ -1,0 +1,429 @@
+/*
+ * Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "lz4.h"
+
+#include "BatchedLZ4Metadata.h"
+#include "Check.h"
+#include "CudaUtils.h"
+#include "LZ4BatchCompressor.h"
+#include "LZ4CompressionKernels.h"
+#include "LZ4Metadata.h"
+#include "LZ4MetadataOnGPU.h"
+#include "MutableBatchedLZ4MetadataOnGPU.h"
+#include "common.h"
+#include "nvcomp.h"
+#include "nvcomp.hpp"
+#include "type_macros.h"
+
+#include <cassert>
+#include <iostream>
+#include <list>
+#include <map>
+#include <mutex>
+#include <sstream>
+#include <vector>
+
+
+using namespace nvcomp;
+namespace
+{
+
+using LZ4MetadataPtr = std::unique_ptr<LZ4Metadata>;
+
+void check_format_opts(const nvcompLZ4FormatOpts* const format_opts)
+{
+  CHECK_NOT_NULL(format_opts);
+
+  if (format_opts->chunk_size < lz4MinChunkSize()) {
+    throw std::runtime_error(
+        "LZ4 minimum chunk size is " + std::to_string(lz4MinChunkSize()));
+  } else if (format_opts->chunk_size > lz4MaxChunkSize()) {
+    throw std::runtime_error(
+        "LZ4 maximum chunk size is " + std::to_string(lz4MaxChunkSize()));
+  }
+}
+
+LZ4MetadataPtr get_individual_metadata(
+    const void* const in_ptr, const size_t in_bytes, cudaStream_t stream)
+{
+  // Get size of metadata object
+  size_t metadata_bytes;
+  CudaUtils::copy_async(
+      &metadata_bytes, ((const size_t*)in_ptr) + 1, 1, DEVICE_TO_HOST, stream);
+  CudaUtils::sync(stream);
+
+  if (in_bytes < metadata_bytes) {
+    throw std::runtime_error(
+        "Compressed data is too small to contain "
+        "metadata of size "
+        + std::to_string(metadata_bytes) + " / " + std::to_string(in_bytes));
+  }
+
+  std::vector<char> metadata_buffer(metadata_bytes);
+  CudaUtils::copy_async(
+      metadata_buffer.data(),
+      (const char*)in_ptr,
+      metadata_bytes,
+      DEVICE_TO_HOST,
+      stream);
+  CudaUtils::sync(stream);
+
+  return LZ4MetadataPtr(
+      new LZ4Metadata(metadata_buffer.data(), metadata_buffer.size()));
+}
+
+} // namespace
+
+/******************************************************************************
+ *     C-style API calls for BATCHED compression/decompress defined below.
+ *****************************************************************************/
+
+int LZ4IsMetadata(const void* const metadata_ptr)
+{
+  const Metadata* const metadata = static_cast<const Metadata*>(metadata_ptr);
+  return metadata->getCompressionType() == LZ4Metadata::COMPRESSION_ID;
+}
+
+nvcompError_t nvcompBatchedLZ4DecompressGetMetadata(
+    const void** in_ptr,
+    const size_t* in_bytes,
+    size_t batch_size,
+    void** metadata_ptr,
+    cudaStream_t stream)
+{
+  try {
+    BatchedLZ4Metadata batch_metadata;
+
+    for(size_t i=0; i<batch_size; i++) {
+      LZ4MetadataPtr m
+          = get_individual_metadata(in_ptr[i], in_bytes[i], stream);
+      batch_metadata.add(std::move(m));
+    }
+
+    cudaStreamSynchronize(stream);
+
+    *metadata_ptr = new BatchedLZ4Metadata(std::move(batch_metadata));
+  } catch (std::exception& e) {
+    return Check::exception_to_error(
+        e, "nvcompBatchedLZ4DecompressGetMetadata()");
+  }
+
+  return nvcompSuccess;
+}
+
+void nvcompBatchedLZ4DecompressDestroyMetadata(void* metadata_ptr)
+{
+  delete static_cast<BatchedLZ4Metadata*>(metadata_ptr);
+}
+
+nvcompError_t
+nvcompBatchedLZ4DecompressGetTempSize(const void* metadata_ptr, size_t* temp_bytes)
+{
+  try {
+    CHECK_NOT_NULL(metadata_ptr);
+    CHECK_NOT_NULL(temp_bytes);
+
+    const BatchedLZ4Metadata& metadata
+        = *static_cast<const BatchedLZ4Metadata*>((void*)metadata_ptr);
+
+    const size_t batch_size = metadata.size();
+
+    size_t total_temp_bytes=0;
+    for(size_t b=0;  b<batch_size; b++) {
+      const size_t chunk_size = metadata[b]->getUncompChunkSize();
+
+      const size_t num_chunks = metadata[b]->getNumChunks();
+
+      size_t this_temp_bytes
+          = lz4DecompressComputeTempSize(num_chunks, chunk_size);
+
+      total_temp_bytes += this_temp_bytes;
+    }
+    *temp_bytes = total_temp_bytes;
+    
+  } catch (const std::exception& e) {
+    return Check::exception_to_error(e, "nvcompBatchedDecompressGetTempSize()");
+  }
+
+  return nvcompSuccess;
+}
+
+nvcompError_t
+nvcompBatchedLZ4DecompressGetOutputSize(const void* metadata_ptr, size_t batch_size, size_t* output_bytes)
+{
+  try {
+    CHECK_NOT_NULL(metadata_ptr);
+    CHECK_NOT_NULL(output_bytes);
+
+    BatchedLZ4Metadata& metadata
+        = *static_cast<BatchedLZ4Metadata*>((void*)metadata_ptr);
+
+    CHECK_EQ(batch_size, metadata.size());
+
+    for (size_t i = 0; i < batch_size; i++) {
+      output_bytes[i] = metadata[i]->getUncompressedSize();
+    }
+  } catch (const std::exception& e) {
+    return Check::exception_to_error(
+        e, "nvcompBatchedLZ4DecompressGetOutputSize()");
+  }
+
+  return nvcompSuccess;
+}
+
+nvcompError_t nvcompBatchedLZ4DecompressAsync(
+    const void* const* in_ptr,
+    const size_t* in_bytes,
+    size_t batch_size,
+    void* const temp_ptr,
+    const size_t temp_bytes,
+    const void* metadata_ptr,
+    void* const* out_ptr,
+    const size_t* out_bytes,
+    cudaStream_t stream)
+{
+  try {
+    CHECK_NOT_NULL(metadata_ptr);
+    CHECK_NOT_NULL(out_ptr);
+    CHECK_NOT_NULL(in_ptr);
+
+    if (temp_bytes > 0) {
+      CHECK_NOT_NULL(temp_ptr);
+    }
+
+    BatchedLZ4Metadata& metadata
+        = *static_cast<BatchedLZ4Metadata*>((void*)metadata_ptr);
+    std::vector<const size_t*> comp_prefix;
+    comp_prefix.reserve(batch_size);
+    std::vector<int> chunks_in_item;
+    chunks_in_item.reserve(batch_size);
+
+    for (size_t i = 1; i < batch_size; ++i) {
+      if (metadata[i]->getUncompChunkSize()
+          != metadata[i - 1]->getUncompChunkSize()) {
+        throw NVCompException(
+            nvcompErrorNotSupported,
+            "Cannot decompress items in the same batch with different chunk "
+            "sizes.");
+      }
+    }
+
+    for (size_t i = 0; i < batch_size; i++) {
+      if (in_bytes[i] < metadata[i]->getCompressedSize()) {
+        throw NVCompException(
+            nvcompErrorInvalidValue,
+            "Input buffer of input " + std::to_string(i)
+                + " is smaller than compressed data size: "
+                + std::to_string(in_bytes[i]) + " < "
+                + std::to_string(metadata[i]->getCompressedSize()));
+      } else if (out_bytes[i] < metadata[i]->getUncompressedSize()) {
+        throw NVCompException(
+            nvcompErrorInvalidValue,
+            "Output buffer for input " + std::to_string(i)
+                + " is smaller than the uncompressed data size: "
+                + std::to_string(out_bytes[i]) + " < "
+                + std::to_string(metadata[i]->getUncompressedSize()));
+      }
+
+      LZ4MetadataOnGPU metadataGPU(in_ptr[i], in_bytes[i]);
+
+      comp_prefix.emplace_back(metadataGPU.compressed_prefix_ptr());
+      chunks_in_item.emplace_back(metadata[i]->getNumChunks());
+    }
+
+    lz4DecompressBatches(
+        temp_ptr,
+        temp_bytes,
+        out_ptr,
+        reinterpret_cast<const uint8_t* const*>(in_ptr),
+        batch_size,
+        comp_prefix.data(),
+        metadata[0]->getUncompChunkSize(), // All batches have some chunk size
+        chunks_in_item.data(),
+        stream);
+  } catch (const std::exception& e) {
+    return Check::exception_to_error(e, "nvcompBatchedLZ4DecompressAsync()");
+  }
+
+  return nvcompSuccess;
+}
+
+nvcompError_t nvcompBatchedLZ4CompressGetTempSize(
+    const void* const* const /* in_ptr */,
+    const size_t* const in_bytes,
+    const size_t batch_size,
+    const nvcompLZ4FormatOpts* const format_opts,
+    size_t* const temp_bytes)
+{
+  try {
+    CHECK_NOT_NULL(in_bytes);
+    CHECK_NOT_NULL(temp_bytes);
+    check_format_opts(format_opts);
+
+    *temp_bytes = LZ4BatchCompressor::calculate_workspace_size(
+        in_bytes, batch_size, format_opts->chunk_size);
+
+  } catch (const std::exception& e) {
+    return Check::exception_to_error(
+        e, "nvcompBatchedLZ4CompressGetTempSize()");
+  }
+
+  return nvcompSuccess;
+}
+
+nvcompError_t nvcompBatchedLZ4CompressGetOutputSize(
+    const void* const* const in_ptr,
+    const size_t* const in_bytes,
+    const size_t batch_size,
+    const nvcompLZ4FormatOpts* const format_opts,
+    void* const /* temp_ptr */,
+    const size_t /* temp_bytes */,
+    size_t* const out_bytes)
+{
+  try {
+    // error check inputs
+    CHECK_NOT_NULL(in_ptr);
+    CHECK_NOT_NULL(in_bytes);
+    CHECK_NOT_NULL(out_bytes);
+    check_format_opts(format_opts);
+
+    for (size_t b = 0; b < batch_size; ++b) {
+      if (in_ptr[b] == nullptr) {
+        throw std::runtime_error(
+            "in_ptr[" + std::to_string(b) + "] must not be null.");
+      }
+
+      const size_t chunk_bytes = format_opts->chunk_size;
+      const int total_chunks = roundUpDiv(in_bytes[b], chunk_bytes);
+
+      const size_t metadata_bytes
+          = LZ4Metadata::OffsetAddr * sizeof(size_t)
+            + ((total_chunks + 1)
+               * sizeof(size_t)); // 1 extra val to store total length
+
+      const size_t max_comp_bytes
+          = lz4ComputeMaxSize(chunk_bytes) * total_chunks;
+
+      out_bytes[b] = metadata_bytes + max_comp_bytes;
+    }
+
+  } catch (const std::exception& e) {
+    return Check::exception_to_error(
+        e, "nvcompBatchedLZ4CompressGetOutputSize()");
+  }
+
+  return nvcompSuccess;
+}
+
+nvcompError_t nvcompBatchedLZ4CompressAsync(
+    const void* const* const in_ptr,
+    const size_t* const in_bytes,
+    const size_t batch_size,
+    const nvcompLZ4FormatOpts* const format_opts,
+    void* const temp_ptr,
+    size_t const temp_bytes,
+    void* const* const out_ptr,
+    size_t* const out_bytes,
+    cudaStream_t stream)
+{
+  try {
+    // error check inputs
+    CHECK_NOT_NULL(format_opts);
+    CHECK_NOT_NULL(in_ptr);
+    CHECK_NOT_NULL(in_bytes);
+    CHECK_NOT_NULL(temp_ptr);
+    CHECK_NOT_NULL(out_ptr);
+    CHECK_NOT_NULL(out_bytes);
+
+    // check if we have enough room to output
+    std::vector<size_t> req_out_bytes(batch_size);
+    CHECK_API_CALL(nvcompBatchedLZ4CompressGetOutputSize(
+        in_ptr,
+        in_bytes,
+        batch_size,
+        format_opts,
+        temp_ptr,
+        temp_bytes,
+        req_out_bytes.data()));
+    for (size_t i = 0; i < batch_size; ++i) {
+      if (req_out_bytes[i] > out_bytes[i]) {
+        throw NVCompException(
+            nvcompErrorInvalidValue,
+            "Output size for batch item " + std::to_string(i)
+                + " is too "
+                  "small: "
+                + std::to_string(out_bytes[i]) + " / "
+                + std::to_string(req_out_bytes[i])
+                + " required bytes. Make sure "
+                  "to set the size of out_bytes to size of output space "
+                  "allocated "
+                  "for each item in the batch.");
+      }
+    }
+
+    const size_t chunk_bytes = format_opts->chunk_size;
+
+    // build the metadatas and configure pointers
+    std::vector<LZ4Metadata> metadata;
+    metadata.reserve(batch_size);
+    for (size_t i = 0; i < batch_size; ++i) {
+      metadata.emplace_back(NVCOMP_TYPE_BITS, chunk_bytes, in_bytes[i], 0);
+    }
+
+    MutableBatchedLZ4MetadataOnGPU metadataGPU(out_ptr, out_bytes, batch_size);
+
+    std::vector<size_t> out_data_start(batch_size);
+    metadataGPU.copyToGPU(
+        metadata, temp_ptr, temp_bytes, out_data_start.data(), stream);
+
+    const uint8_t* const* const typed_in_ptr
+        = reinterpret_cast<const uint8_t* const*>(in_ptr);
+    LZ4BatchCompressor compressor(
+        typed_in_ptr, in_bytes, batch_size, chunk_bytes);
+
+    compressor.configure_workspace(temp_ptr, temp_bytes);
+
+    // the location the prefix sum of the chunks of each item is stored
+    std::vector<size_t*> out_prefix(batch_size);
+    for (size_t i = 0; i < batch_size; ++i) {
+      out_prefix[i] = metadataGPU.compressed_prefix_ptr(i);
+    }
+
+    uint8_t* const* const typed_out_ptr
+        = reinterpret_cast<uint8_t* const*>(out_ptr);
+    compressor.configure_output(
+        typed_out_ptr, out_prefix.data(), out_data_start.data(), out_bytes);
+
+    compressor.compress_async(stream);
+  } catch (const std::exception& e) {
+    return Check::exception_to_error(e, "nvcompBatchedLZ4CompressAsync()");
+  }
+
+  return nvcompSuccess;
+}

--- a/nvcomp/LZ4BatchCompressor.cu
+++ b/nvcomp/LZ4BatchCompressor.cu
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "CudaUtils.h"
+#include "LZ4BatchCompressor.h"
+#include "LZ4CompressionKernels.h"
+#include "TempSpaceBroker.h"
+#include "common.h"
+
+namespace nvcomp
+{
+
+/******************************************************************************
+ * KERNELS ********************************************************************
+ *****************************************************************************/
+
+namespace
+{
+template <int BLOCK_SIZE>
+__global__ void collectItemSizes(
+    size_t* const item_sizes,
+    const size_t* const* const item_prefixes,
+    const size_t* const uncomp_sizes,
+    const size_t chunk_size,
+    const size_t batch_size)
+{
+  const size_t item = blockIdx.x * BLOCK_SIZE + threadIdx.x;
+
+  if (item < batch_size) {
+    const size_t num_chunks = roundUpDiv(uncomp_sizes[item], chunk_size);
+
+    item_sizes[item] = item_prefixes[item][num_chunks];
+  }
+}
+
+} // namespace
+
+/******************************************************************************
+ * HELPER FUNCTIONS ***********************************************************
+ *****************************************************************************/
+
+namespace
+{
+
+size_t compute_staging_bytes(
+    const size_t* const decomp_data_size,
+    const size_t batch_size,
+    const size_t chunk_size)
+{
+  const size_t num_chunks
+      = lz4ComputeChunksInBatch(decomp_data_size, batch_size, chunk_size);
+
+  const size_t staging_bytes = roundUpTo(
+      lz4CompressComputeTempSize(num_chunks, chunk_size), sizeof(size_t));
+
+  return staging_bytes;
+}
+
+} // namespace
+
+/******************************************************************************
+ * PUBLIC STATIC METHODS ******************************************************
+ *****************************************************************************/
+
+size_t LZ4BatchCompressor::calculate_workspace_size(
+    const size_t* const decomp_data_size,
+    const size_t batch_size,
+    const size_t chunk_size)
+{
+  const size_t staging_bytes
+      = compute_staging_bytes(decomp_data_size, batch_size, chunk_size);
+  const size_t pointer_bytes = 2 * batch_size * sizeof(uint8_t*);
+  const size_t size_bytes
+      = (batch_size * sizeof(size_t*)) + (batch_size * sizeof(size_t));
+  const size_t offset_bytes = (batch_size + 1) * sizeof(size_t);
+
+  return staging_bytes + pointer_bytes + size_bytes + offset_bytes;
+}
+
+/******************************************************************************
+ * CONSTRUCTORS / DESTRUCTOR **************************************************
+ *****************************************************************************/
+
+LZ4BatchCompressor::LZ4BatchCompressor(
+    const uint8_t* const* decomp_data,
+    const size_t* decomp_data_size,
+    const size_t batch_size,
+    const size_t chunk_size) :
+    m_batch_size(batch_size),
+    m_chunk_size(chunk_size),
+    m_buffer(),
+    m_input_ptrs(nullptr),
+    m_input_sizes(nullptr),
+    m_output_ptrs(nullptr),
+    m_output_sizes(nullptr),
+    m_output_offsets(nullptr),
+    m_workspace(nullptr),
+    m_workspace_size(0),
+    m_host_item_sizes(nullptr),
+    m_output_configured(false)
+{
+  const size_t input_ptrs = batch_size * sizeof(*decomp_data);
+  const size_t input_sizes = batch_size * sizeof(*decomp_data_size);
+  const size_t output_ptrs = batch_size * sizeof(uint8_t*);
+  const size_t output_sizes = batch_size * sizeof(size_t*);
+  const size_t output_offsets = batch_size * sizeof(size_t);
+
+  const size_t buffer_size
+      = input_ptrs + input_sizes + output_sizes + output_ptrs + output_offsets;
+
+  m_buffer.resize(buffer_size);
+
+  m_input_ptrs = reinterpret_cast<const uint8_t**>(m_buffer.data());
+  m_input_sizes = reinterpret_cast<size_t*>(m_buffer.data() + input_ptrs);
+  m_output_ptrs
+      = reinterpret_cast<uint8_t**>(m_buffer.data() + input_ptrs + input_sizes);
+  m_output_sizes = reinterpret_cast<size_t**>(
+      m_buffer.data() + input_ptrs + input_sizes + output_ptrs);
+  m_output_offsets = reinterpret_cast<size_t*>(
+      m_buffer.data() + input_sizes + input_ptrs + output_sizes
+      + output_offsets);
+
+  std::copy(decomp_data_size, decomp_data_size + batch_size, m_input_sizes);
+  std::copy(decomp_data, decomp_data + batch_size, m_input_ptrs);
+}
+
+/******************************************************************************
+ * PUBLIC METHODS *************************************************************
+ *****************************************************************************/
+
+size_t LZ4BatchCompressor::get_workspace_size() const
+{
+  return calculate_workspace_size(m_input_sizes, m_batch_size, m_chunk_size);
+}
+
+void LZ4BatchCompressor::configure_workspace(
+    void* const workspace, const size_t size)
+{
+  const size_t required_Size = get_workspace_size();
+  if (size < required_Size) {
+    throw std::runtime_error(
+        "Insufficient workspace size: " + std::to_string(size) + " / "
+        + std::to_string(required_Size));
+  } else if (workspace == nullptr) {
+    throw std::runtime_error("Workspace cannot be null.");
+  }
+
+  m_workspace = workspace;
+  m_workspace_size = size;
+}
+
+void LZ4BatchCompressor::configure_output(
+    uint8_t* const* const device_locations,
+    size_t* const* const device_sizes,
+    const size_t* const device_offsets,
+    size_t* const host_item_sizes)
+{
+  std::copy(device_sizes, device_sizes + m_batch_size, m_output_sizes);
+  std::copy(device_locations, device_locations + m_batch_size, m_output_ptrs);
+  std::copy(device_offsets, device_offsets + m_batch_size, m_output_offsets);
+  m_host_item_sizes = host_item_sizes;
+  m_output_configured = true;
+}
+
+void LZ4BatchCompressor::compress_async(cudaStream_t stream)
+{
+  if (!is_workspace_configured()) {
+    throw std::runtime_error(
+        "Workspace must be configured before compressing.");
+  } else if (!is_output_configured()) {
+    throw std::runtime_error("Output must be configured before compressing.");
+  }
+
+  TempSpaceBroker temp(m_workspace, m_workspace_size);
+
+  uint8_t* workspace;
+  const size_t workspace_size
+      = compute_staging_bytes(m_input_sizes, m_batch_size, m_chunk_size);
+  temp.reserve(&workspace, workspace_size);
+
+  // these have all the same size, and generally should on all platforms as
+  // the definition of size_t should make it the same size
+  static_assert(
+      alignof(size_t) == alignof(uint8_t*),
+      "Pointers must have the same alignment as size_t");
+
+  const uint8_t** in_ptrs_device;
+  temp.reserve(&in_ptrs_device, m_batch_size);
+
+  size_t* in_sizes_device;
+  temp.reserve(&in_sizes_device, m_batch_size);
+
+  uint8_t** out_ptrs_device;
+  temp.reserve(&out_ptrs_device, m_batch_size);
+
+  size_t** out_sizes_device;
+  temp.reserve(&out_sizes_device, m_batch_size);
+
+  size_t* out_prefix_offsets_device;
+  temp.reserve(&out_prefix_offsets_device, m_batch_size);
+
+  const size_t buffer_size = reinterpret_cast<const uint8_t*>(
+                                 out_prefix_offsets_device + m_batch_size)
+                             - reinterpret_cast<const uint8_t*>(in_ptrs_device);
+
+  if (buffer_size > m_buffer.size()) {
+    throw std::runtime_error(
+        "Internal error: mismatched buffer sizes: "
+        + std::to_string(buffer_size) + " / "
+        + std::to_string(m_buffer.size()));
+  }
+
+  // just cop from the first pointer to the end of the last
+  CudaUtils::copy_async<uint8_t>(
+      reinterpret_cast<uint8_t*>(in_ptrs_device),
+      m_buffer.data(),
+      buffer_size,
+      HOST_TO_DEVICE,
+      stream);
+
+  // TODO: implement step_size
+  lz4CompressBatch(
+      in_ptrs_device,
+      in_sizes_device,
+      m_input_sizes,
+      m_batch_size,
+      m_chunk_size,
+      workspace,
+      workspace_size,
+      out_ptrs_device,
+      out_sizes_device,
+      out_prefix_offsets_device,
+      stream);
+
+  // repurpose in item sizes for collecting batch totals
+  if (m_host_item_sizes) {
+    size_t* item_sizes_device = in_sizes_device;
+
+    // We're using 64 threads here to maximize the number of active thread
+    // blocks we can have for a given number of items, as we would expect to
+    // struggle to make use of much of the GPU with a number of items in the
+    // hundreds or thousands.
+    constexpr const int BLOCK_SIZE = 64;
+
+    const dim3 grid(roundUpDiv(m_batch_size, BLOCK_SIZE));
+    const dim3 block(BLOCK_SIZE);
+
+    collectItemSizes<BLOCK_SIZE><<<grid, block, 0, stream>>>(
+        item_sizes_device,
+        out_sizes_device,
+        in_sizes_device,
+        m_chunk_size,
+        m_batch_size);
+
+    CudaUtils::copy_async(
+        m_host_item_sizes, item_sizes_device, m_batch_size,
+        DEVICE_TO_HOST, stream);
+  }
+}
+
+/******************************************************************************
+ * PRIVATE METHODS ************************************************************
+ *****************************************************************************/
+
+bool LZ4BatchCompressor::is_workspace_configured() const
+{
+  return m_workspace != nullptr;
+}
+
+bool LZ4BatchCompressor::is_output_configured() const
+{
+  return m_output_configured;
+}
+
+} // namespace nvcomp

--- a/nvcomp/LZ4BatchCompressor.h
+++ b/nvcomp/LZ4BatchCompressor.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "cuda_runtime.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace nvcomp
+{
+
+class LZ4BatchCompressor
+{
+public:
+  static size_t calculate_workspace_size(
+      const size_t* decomp_data_size, size_t batch_size, size_t chunk_size);
+
+  /**
+   * @brief Create a new LZ4BatchCompressor.
+   *
+   * @param batch_size The number of items in the batch.
+   * @param chunk_size The size of each chunk to compress.
+   */
+  LZ4BatchCompressor(
+      const uint8_t* const* decomp_data,
+      const size_t* decomp_data_size,
+      const size_t batch_size,
+      const size_t chunk_size);
+
+  LZ4BatchCompressor(const LZ4BatchCompressor& other) = delete;
+  LZ4BatchCompressor& operator=(const LZ4BatchCompressor& other) = delete;
+
+  /**
+   * @brief Get the size of the workspace required.
+   *
+   * @return The size of the workspace in bytes.
+   */
+  size_t get_workspace_size() const;
+
+  /**
+   * @brief Set the allocated workspace.
+   *
+   * @param workspace The workspace.
+   * @param size The size of the workspace in bytes.
+   */
+  void configure_workspace(void* workspace, size_t size);
+
+  void configure_output(
+      uint8_t* const* device_locations,
+      size_t* const* device_sizes,
+      const size_t* device_offsets,
+      size_t* const host_item_sizes);
+
+  void compress_async(cudaStream_t stream);
+
+private:
+  size_t m_batch_size;
+  size_t m_chunk_size;
+  std::vector<uint8_t> m_buffer;
+  const uint8_t** m_input_ptrs;
+  size_t* m_input_sizes;
+  uint8_t** m_output_ptrs;
+  size_t** m_output_sizes;
+  size_t* m_output_offsets;
+  void* m_workspace;
+  size_t m_workspace_size;
+  size_t* m_host_item_sizes;
+  bool m_output_configured;
+
+  bool is_workspace_configured() const;
+
+  bool is_output_configured() const;
+};
+
+} // namespace nvcomp

--- a/nvcomp/LZ4CompressionKernels.cu
+++ b/nvcomp/LZ4CompressionKernels.cu
@@ -1,0 +1,1362 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "CudaUtils.h"
+#include "LZ4CompressionKernels.h"
+#include "TempSpaceBroker.h"
+#include "common.h"
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weffc++"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
+#include <cub/cub.cuh>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+#include "cuda_runtime.h"
+
+#include <cassert>
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+using offset_type = uint16_t;
+using word_type = uint32_t;
+using position_type = size_t;
+using double_word_type = uint64_t;
+using item_type = uint32_t;
+
+namespace nvcomp {
+
+constexpr const int COMP_THREADS = 32;
+constexpr const int DECOMP_THREADS = 32;
+constexpr const int Y_DIM = 2;
+constexpr const position_type BUFFER_SIZE
+    = DECOMP_THREADS * sizeof(double_word_type);
+constexpr const position_type PREFETCH_DIST = BUFFER_SIZE / 2;
+
+constexpr const position_type HASH_TABLE_SIZE = 1U << 14;
+constexpr const offset_type NULL_OFFSET = static_cast<offset_type>(-1);
+constexpr const position_type MAX_OFFSET = (1U << 16) - 1;
+
+constexpr const size_t MIN_CHUNK_SIZE = sizeof(offset_type) * HASH_TABLE_SIZE;
+constexpr const size_t MAX_CHUNK_SIZE = 1U << 24; // 16 MB
+
+// ideally this would fit in a quad-word -- right now though it spills into
+// 24-bytes (instead of 16-bytes).
+struct chunk_header
+{
+  const uint8_t* src;
+  uint8_t* dst;
+  uint32_t size;
+};
+
+struct compression_chunk_header
+{
+  const uint8_t* src;
+  uint8_t* dst;
+  offset_type* hash;
+  size_t* comp_size;
+  uint32_t size;
+};
+
+/******************************************************************************
+ * DEVICE FUNCTIONS AND KERNELS ***********************************************
+ *****************************************************************************/
+
+inline __device__ __host__ size_t maxSizeOfStream(const size_t size)
+{
+  const size_t expansion = size + 1 + roundUpDiv(size, 255);
+  return roundUpTo(expansion, sizeof(size_t));
+}
+
+inline __device__ void syncCTA()
+{
+  if (DECOMP_THREADS > 32) {
+    __syncthreads();
+  } else {
+    __syncwarp();
+  }
+}
+
+inline __device__ int warpBallot(int vote)
+{
+  return __ballot_sync(0xffffffff, vote);
+}
+
+template <typename T>
+inline __device__ int warpMatchAny(const int participants, T val)
+{
+#if __CUDA_ARCH__ >= 700
+  return __match_any_sync(participants, val);
+#else
+  int mask = 0;
+
+  // full search
+  assert(blockDim.x == 32);
+  for (int d = 1; d < 32; ++d) {
+    const int nbr_id = (threadIdx.x + d) & 31;
+    mask |= (val == __shfl_sync(participants, val, nbr_id)) << nbr_id;
+  }
+
+  return mask;
+#endif
+}
+
+template <typename T>
+inline __device__ void writeWord(uint8_t* const address, const T word)
+{
+#pragma unroll
+  for (size_t i = 0; i < sizeof(T); ++i) {
+    address[i] = static_cast<uint8_t>((word >> (8 * i)) & 0xff);
+  }
+}
+
+template <typename T>
+inline __device__ T readWord(const uint8_t* const address)
+{
+  T word = 0;
+  for (size_t i = 0; i < sizeof(T); ++i) {
+    word |= address[i] << (8 * i);
+  }
+
+  return word;
+}
+
+template<int BLOCK_SIZE>
+inline __device__ void writeLSIC(uint8_t* const out, const position_type number)
+{
+  assert(BLOCK_SIZE == blockDim.x);
+
+  const position_type num = (number / 0xffu) + 1;
+  const uint8_t leftOver = number % 0xffu;
+  for (size_t i = threadIdx.x; i < num; i += BLOCK_SIZE) {
+    const uint8_t val = i + 1 < num ? 0xffu : leftOver;
+    out[i] = val;
+  }
+}
+
+struct token_type
+{
+  position_type num_literals;
+  position_type num_matches;
+
+   __device__ bool hasNumLiteralsOverflow() const
+  {
+    return num_literals >= 15;
+  }
+
+   __device__ bool hasNumMatchesOverflow() const
+  {
+    return num_matches >= 19;
+  }
+
+  __device__ position_type numLiteralsOverflow() const
+  {
+    if (hasNumLiteralsOverflow()) {
+      return num_literals - 15;
+    } else {
+      return 0;
+    }
+  }
+
+  __device__ uint8_t numLiteralsForHeader() const
+  {
+    if (hasNumLiteralsOverflow()) {
+      return 15;
+    } else {
+      return num_literals;
+    }
+  }
+
+  __device__ position_type numMatchesOverflow() const
+  {
+    if (hasNumMatchesOverflow()) {
+      assert(num_matches >= 19);
+      return num_matches - 19;
+    } else {
+      assert(num_matches < 19);
+      return 0;
+    }
+  }
+
+  __device__ uint8_t numMatchesForHeader() const
+  {
+    if (hasNumMatchesOverflow()) {
+      return 15;
+    } else {
+      return num_matches - 4;
+    }
+  }
+  __device__ position_type lengthOfLiteralEncoding() const
+  {
+    if (hasNumLiteralsOverflow()) {
+      const position_type num = numLiteralsOverflow();
+      const position_type length = (num / 0xff) + 1;
+      return length;
+    }
+    return 0;
+  }
+
+  __device__ position_type lengthOfMatchEncoding() const
+  {
+    if (hasNumMatchesOverflow()) {
+      const position_type num = numMatchesOverflow();
+      const position_type length = (num / 0xff) + 1;
+      return length;
+    }
+    return 0;
+  }
+};
+
+class BufferControl
+{
+public:
+
+  __device__ BufferControl(
+      uint8_t* const buffer, const uint8_t* const compData, const position_type length) :
+      m_offset(0),
+      m_length(length),
+      m_buffer(buffer),
+      m_compData(compData)
+  {
+    // do nothing
+  }
+
+  #ifdef WARP_READ_LSIC
+    // this is currently unused as its slower
+  inline __device__ position_type queryLSIC(const position_type idx) const
+  {
+    if (idx + DECOMP_THREADS <= end()) {
+      // most likely case
+      const uint8_t byte = rawAt(idx)[threadIdx.x];
+
+      uint32_t mask = warpBallot(byte != 0xff);
+      mask = __brev(mask);
+  
+      const position_type fullBytes = __clz(mask);
+  
+      if (fullBytes < DECOMP_THREADS) {
+        return fullBytes * 0xff + rawAt(idx)[fullBytes];
+      } else {
+        return DECOMP_THREADS * 0xff;
+      }
+    } else {
+      uint8_t byte;
+      if (idx + threadIdx.x < end()) {
+        byte = rawAt(idx)[threadIdx.x];
+      } else {
+        byte = m_compData[idx + threadIdx.x];
+      }
+
+      uint32_t mask = warpBallot(byte != 0xff);
+      mask = __brev(mask);
+  
+      const position_type fullBytes = __clz(mask);
+  
+      if (fullBytes < DECOMP_THREADS) {
+        return fullBytes * 0xff + __shfl_sync(0xffffffff, byte, fullBytes);
+      } else {
+        return DECOMP_THREADS * 0xff;
+      }
+    }
+  }
+  #endif
+  
+  inline __device__ position_type readLSIC(position_type& idx) const
+  {
+  #ifdef WARP_READ_LSIC
+    position_type num = 0;
+    while (true) {
+      const position_type block = queryLSIC(idx);
+      num += block;
+  
+      if (block < DECOMP_THREADS * 0xff) {
+        idx += (block / 0xff) + 1;
+        break;
+      } else {
+        idx += DECOMP_THREADS;
+      }
+    }
+    return num;
+  #else
+    position_type num = 0;
+    uint8_t next = 0xff;
+    // read from the buffer
+    while (next == 0xff && idx < end()) {
+      next = rawAt(idx)[0];
+      ++idx;
+      num += next;
+    }
+      // read from global memory
+    while (next == 0xff) {
+      next = m_compData[idx];
+      ++idx;
+      num += next;
+    }
+    return num;
+  #endif
+  }
+  
+    inline __device__ const uint8_t* raw() const
+    {
+      return m_buffer;
+    }
+  
+    inline __device__ const uint8_t* rawAt(const position_type i) const
+    {
+      return raw() + (i - begin());
+    }
+    inline __device__ uint8_t operator[](const position_type i) const
+    {
+      if (i >= m_offset && i - m_offset < BUFFER_SIZE) {
+        return m_buffer[i - m_offset];
+      } else {
+        return m_compData[i];
+      }
+    }
+
+    inline __device__ void setAndAlignOffset(const position_type offset)
+    {
+      static_assert(
+          sizeof(size_t) == sizeof(const uint8_t*),
+          "Size of pointer must be equal to size_t.");
+
+      const uint8_t* const alignedPtr = reinterpret_cast<const uint8_t*>(
+          (reinterpret_cast<size_t>(m_compData + offset)
+           / sizeof(double_word_type))
+          * sizeof(double_word_type));
+
+      m_offset = alignedPtr - m_compData;
+    }
+
+    inline __device__ void loadAt(const position_type offset)
+    {
+      setAndAlignOffset(offset);
+
+      if (m_offset + BUFFER_SIZE <= m_length) {
+        assert(
+            reinterpret_cast<size_t>(m_compData + m_offset)
+                % sizeof(double_word_type)
+            == 0);
+        assert(BUFFER_SIZE == DECOMP_THREADS * sizeof(double_word_type));
+        const double_word_type* const word_data
+            = reinterpret_cast<const double_word_type*>(m_compData + m_offset);
+        double_word_type* const word_buffer
+            = reinterpret_cast<double_word_type*>(m_buffer);
+        word_buffer[threadIdx.x] = word_data[threadIdx.x];
+      } else {
+  #pragma unroll
+      for (int i = threadIdx.x; i < BUFFER_SIZE; i += DECOMP_THREADS) {
+        if (m_offset + i < m_length) {
+          m_buffer[i] = m_compData[m_offset + i];
+        }
+      }
+    }
+  
+    syncCTA();
+  }
+  
+  inline __device__ position_type begin() const
+  {
+    return m_offset;
+  }
+  
+  
+  inline __device__ position_type end() const
+  {
+    return m_offset + BUFFER_SIZE;
+  }
+
+private:
+  position_type m_offset;
+  const position_type m_length;
+  uint8_t* const m_buffer;
+  const uint8_t* const m_compData;
+}; //End BufferControl Class
+
+
+inline __device__ void coopCopyNoOverlap(
+    uint8_t* const dest, const uint8_t* const source, const size_t length)
+{
+  for (size_t i = threadIdx.x; i < length; i += blockDim.x) {
+    dest[i] = source[i];
+  }
+}
+
+inline __device__ void coopCopyRepeat(
+    uint8_t* const dest,
+    const uint8_t* const source,
+    const position_type dist,
+    const position_type length)
+{
+// if there is overlap, it means we repeat, so we just
+// need to organize our copy around that
+  for (position_type i = threadIdx.x; i < length; i += blockDim.x) {
+    dest[i] = source[i % dist];
+  }
+}
+
+inline __device__ void coopCopyOverlap(
+    uint8_t* const dest,
+    const uint8_t* const source,
+    const position_type dist,
+    const position_type length)
+{
+  if (dist < length) {
+    coopCopyRepeat(dest, source, dist, length);
+  } else {
+    coopCopyNoOverlap(dest, source, length);
+  }
+}
+
+inline __device__ position_type hash(const word_type key)
+{
+  // needs to be 12 bits
+  return (__brev(key) + (key^0xc375)) & (HASH_TABLE_SIZE - 1);
+}
+
+inline __device__ uint8_t encodePair(const uint8_t t1, const uint8_t t2)
+{
+  return ((t1 & 0x0f) << 4) | (t2 & 0x0f);
+}
+
+inline __device__ token_type decodePair(const uint8_t num)
+{
+  return token_type{static_cast<uint8_t>((num & 0xf0) >> 4),
+                    static_cast<uint8_t>(num & 0x0f)};
+}
+
+template<int BLOCK_SIZE>
+inline __device__ void copyLiterals(
+    uint8_t* const dest, const uint8_t* const source, const size_t length)
+{
+  assert(BLOCK_SIZE == blockDim.x);
+  for (size_t i = threadIdx.x; i < length; i += BLOCK_SIZE) {
+    dest[i] = source[i];
+  }
+}
+
+inline __device__ position_type lengthOfMatch(
+    const uint8_t* const data,
+    const position_type prev_location,
+    const position_type next_location,
+    const position_type length)
+{
+  assert(prev_location < next_location);
+
+  position_type match_length = length - next_location - 5;
+  for (position_type j = 0; j + next_location + 5 < length; j += blockDim.x) {
+    const position_type i = threadIdx.x + j;
+    int match = i + next_location + 5 < length
+                    ? (data[prev_location + i] != data[next_location + i])
+                    : 1;
+    match = warpBallot(match);
+    if (match) {
+      match_length = j + __clz(__brev(match));
+      break;
+    }
+  }
+
+  return match_length;
+}
+
+inline __device__ position_type
+convertIdx(const offset_type offset, const position_type pos)
+{
+  constexpr const position_type OFFSET_SIZE = MAX_OFFSET + 1;
+
+  assert(offset <= pos);
+
+  position_type realPos = (pos / OFFSET_SIZE) * OFFSET_SIZE + offset;
+  if (realPos >= pos) {
+    realPos -= OFFSET_SIZE;
+  }
+  assert(realPos < pos);
+
+  return realPos;
+}
+
+inline __device__ bool isValidHash(
+    const uint8_t* const data,
+    const offset_type* const hashTable,
+    const position_type key,
+    const position_type hashPos,
+    const position_type decomp_idx)
+{
+  const position_type hashed_offset = hashTable[hashPos];
+
+  if (hashed_offset == NULL_OFFSET) {
+    return false;
+  }
+
+  const position_type offset = convertIdx(hashed_offset, decomp_idx);
+
+  if (decomp_idx - offset > MAX_OFFSET) {
+    // can't match current position, ahead, or NULL_OFFSET
+    return false;
+  }
+
+  const word_type hashKey = readWord<word_type>(data + offset);
+
+  if (hashKey != key) {
+    return false;
+  }
+
+  return true;
+}
+
+template<int BLOCK_SIZE>
+inline __device__ void writeSequenceData(
+    uint8_t* const compData,
+    const uint8_t* const decompData,
+    const token_type token,
+    const offset_type offset,
+    const position_type decomp_idx,
+    position_type& comp_idx)
+{
+  assert(token.num_matches == 0 || token.num_matches >= 4);
+
+  // -> add token
+  if (threadIdx.x == 0) {
+    compData[comp_idx]
+        = encodePair(token.numLiteralsForHeader(), token.numMatchesForHeader());
+  }
+  ++comp_idx;
+
+  // -> add literal length
+  const position_type literalEncodingLength = token.lengthOfLiteralEncoding();
+  if (literalEncodingLength) {
+    writeLSIC<BLOCK_SIZE>(compData + comp_idx, token.numLiteralsOverflow());
+    comp_idx += literalEncodingLength;
+  }
+
+  // -> add literals
+  copyLiterals<BLOCK_SIZE>(
+      compData + comp_idx, decompData + decomp_idx, token.num_literals);
+  comp_idx += token.num_literals;
+
+  // -> add offset
+  if (token.num_matches > 0) {
+    assert(offset > 0);
+
+    if (threadIdx.x == 0) {
+      writeWord(compData + comp_idx, offset);
+    }
+    comp_idx += sizeof(offset);
+
+    // -> add match length
+    if (token.hasNumMatchesOverflow()) {
+      writeLSIC<BLOCK_SIZE>(compData + comp_idx, token.numMatchesOverflow());
+      comp_idx += token.lengthOfMatchEncoding();
+    }
+  }
+}
+
+inline __device__ int numValidThreadsToMask(
+    const int numValidThreads)
+{
+  return 0xffffffff >> (32-numValidThreads);
+}
+
+inline __device__ void insertHashTableWarp(
+    offset_type* hashTable,
+    const offset_type pos,
+    const word_type next,
+    const int numValidThreads)
+{
+  position_type hashPos = hash(next);
+
+  if (threadIdx.x < numValidThreads) {
+    const int match = warpMatchAny(numValidThreadsToMask(numValidThreads), hashPos);
+    if (!match || 31 - __clz(match) == threadIdx.x) {
+      // I'm the last match -- can insert
+      hashTable[hashPos] = pos & MAX_OFFSET;
+    }
+  }
+
+  __syncwarp();
+}
+
+__device__ void compressStream(
+    uint8_t* compData,
+    const uint8_t* decompData,
+    offset_type* const hashTable,
+    const size_t length,
+    size_t* comp_length)
+{
+  assert(blockDim.x == COMP_THREADS);
+  static_assert(COMP_THREADS <= 32, "Compression can be done with at "
+      "most one warp");
+
+  position_type decomp_idx = 0;
+  position_type comp_idx = 0;
+
+  for (position_type i = threadIdx.x; i < HASH_TABLE_SIZE; i += COMP_THREADS) {
+    hashTable[i] = NULL_OFFSET;
+  }
+
+  __syncwarp();
+
+  while (decomp_idx < length) {
+    const position_type tokenStart = decomp_idx;
+    while (true) {
+      if (decomp_idx + 5 + 4 >= length) {
+        // jump to end
+        decomp_idx = length;
+
+        // no match -- literals to the end
+        token_type tok;
+        tok.num_literals = length - tokenStart;
+        tok.num_matches = 0;
+        writeSequenceData<COMP_THREADS>(compData, decompData, tok, 0, tokenStart, comp_idx);
+        break;
+      }
+
+      // begin adding tokens to the hash table until we find a match
+      uint8_t byte = 0;
+      if (decomp_idx + 5 + threadIdx.x < length) {
+        byte = decompData[decomp_idx + threadIdx.x];
+      }
+
+      // each thread needs a four byte word, but only separated by a byte e.g.:
+      // for two threads, the five bytes [ 0x12 0x34 0x56 0x78 0x9a ] would
+      // be assigned as [0x78563412 0x9a785634 ] to the two threads
+      // (little-endian). That means when reading 32 bytes, we can only fill
+      // the first 29 thread's 4-byte words.
+      word_type next = byte;
+      // collect second byte
+      next |= __shfl_down_sync(0xffffffff, byte, 1) << 8;
+      // collect third and fourth bytes
+      next |= __shfl_down_sync(0xffffffff, next, 2) << 16;
+
+      // since we do not have valid data for the last 3 threads (or more if
+      // we're at the end of the data), mark them as inactive.
+      const int numValidThreads
+          = min(static_cast<size_t>(COMP_THREADS - 3), length - decomp_idx - 9);
+
+      // first try to find a local match
+      position_type match_location = length;
+      int match_mask_self = 0;
+      if (threadIdx.x < numValidThreads) {
+        match_mask_self = warpMatchAny(numValidThreadsToMask(numValidThreads), next);
+      }
+
+      // each thread has a mask of other threads with matches, next we need
+      // to find the first thread with a match before it
+      const int match_mask_warp = warpBallot(
+          match_mask_self && __clz(__brev(match_mask_self)) != threadIdx.x);
+
+      int first_match_thread;
+      if (match_mask_warp) {
+        // find the byte offset (thread id) within the warp where the first
+        // match is located
+        first_match_thread = __clz(__brev(match_mask_warp));
+
+        // determine the global position for the finding thread
+        match_location = __clz(__brev(match_mask_self)) + decomp_idx;
+
+        // comunicate the global position of the match to other threads
+        match_location = __shfl_sync(0xffffffff, match_location, first_match_thread);
+      } else {
+        first_match_thread = COMP_THREADS;
+      }
+
+      // only go to the hash table, if there is a possibility of a finding an
+      // earlier match
+      if (first_match_thread > 0) {
+        // go to hash table for an earlier match
+        position_type hashPos = hash(next);
+        const int match_found = threadIdx.x < numValidThreads
+                                    ? isValidHash(
+                                          decompData,
+                                          hashTable,
+                                          next,
+                                          hashPos,
+                                          decomp_idx + threadIdx.x)
+                                    : 0;
+
+        // determine the first thread to find a match
+        const int match = warpBallot(match_found);
+        const int candidate_first_match_thread = __clz(__brev(match));
+
+        assert(candidate_first_match_thread != threadIdx.x || match_found);
+        assert(!match_found || candidate_first_match_thread <= threadIdx.x);
+
+        if (candidate_first_match_thread < first_match_thread) {
+          // if we found a valid match, and it occurs before a previously found
+          // match, use that
+          first_match_thread = candidate_first_match_thread;
+          hashPos = __shfl_sync(0xffffffff, hashPos, first_match_thread);
+          match_location
+              = convertIdx(hashTable[hashPos], decomp_idx + first_match_thread);
+        }
+      }
+
+      if (match_location != length) {
+        // insert up to the match into the hash table
+        insertHashTableWarp(
+            hashTable, decomp_idx + threadIdx.x, next, first_match_thread);
+
+        const position_type pos = decomp_idx + first_match_thread;
+        assert(match_location < pos);
+        assert(pos - match_location <= MAX_OFFSET);
+
+        // we found a match
+        const offset_type match_offset = pos - match_location;
+        assert(match_offset > 0);
+        assert(match_offset <= pos);
+        const position_type num_literals = pos - tokenStart;
+
+        // compute match length
+        const position_type num_matches
+            = lengthOfMatch(decompData, match_location, pos, length);
+
+        // -> write our token and literal length
+        token_type tok;
+        tok.num_literals = num_literals;
+        tok.num_matches = num_matches;
+
+        // update our position
+        decomp_idx = tokenStart + num_matches + num_literals;
+
+        // insert only the literals into the hash table
+        writeSequenceData<COMP_THREADS>(
+            compData, decompData, tok, match_offset, tokenStart, comp_idx);
+        break;
+      }
+
+      // insert everything into hash table
+      insertHashTableWarp(
+          hashTable, decomp_idx + threadIdx.x, next, numValidThreads);
+
+      decomp_idx += numValidThreads;
+    }
+  }
+
+  if (threadIdx.x == 0) {
+    *comp_length = comp_idx;
+  }
+}
+
+inline __device__ void decompressStream(
+    uint8_t* buffer,
+    uint8_t* decompData,
+    const uint8_t* compData,
+    position_type length)
+{
+  position_type comp_end = length;
+
+  BufferControl ctrl(buffer, compData, comp_end);
+  ctrl.loadAt(0);
+
+  position_type decomp_idx = 0;
+  position_type comp_idx = 0;
+  while (comp_idx < comp_end) {
+    if (comp_idx + PREFETCH_DIST > ctrl.end()) {
+      ctrl.loadAt(comp_idx);
+    }
+
+    // read header byte
+    token_type tok = decodePair(*ctrl.rawAt(comp_idx));
+    ++comp_idx;
+
+    // read the length of the literals
+    position_type num_literals = tok.num_literals;
+    if (tok.num_literals == 15) {
+      num_literals += ctrl.readLSIC(comp_idx);
+    }
+    const position_type literalStart = comp_idx;
+
+    // copy the literals to the out stream
+    if (num_literals + comp_idx > ctrl.end()) {
+      coopCopyNoOverlap(
+          decompData + decomp_idx, compData + comp_idx, num_literals);
+    } else {
+      // our buffer can copy
+      coopCopyNoOverlap(
+          decompData + decomp_idx, ctrl.rawAt(comp_idx), num_literals);
+    }
+
+    comp_idx += num_literals;
+    decomp_idx += num_literals;
+
+    // Note that the last sequence stops right after literals field.
+    // There are specific parsing rules to respect to be compatible with the
+    // reference decoder : 1) The last 5 bytes are always literals 2) The last
+    // match cannot start within the last 12 bytes Consequently, a file with
+    // less then 13 bytes can only be represented as literals These rules are in
+    // place to benefit speed and ensure buffer limits are never crossed.
+    if (comp_idx < comp_end) {
+
+      // read the offset
+      offset_type offset;
+      if (comp_idx + sizeof(offset_type) > ctrl.end()) {
+        offset = readWord<offset_type>(compData + comp_idx);
+      } else {
+        offset = readWord<offset_type>(ctrl.rawAt(comp_idx));
+      }
+
+      comp_idx += sizeof(offset_type);
+
+      // read the match length
+      position_type match = 4 + tok.num_matches;
+      if (tok.num_matches == 15) {
+        match += ctrl.readLSIC(comp_idx);
+      }
+
+      // copy match
+      if (offset <= num_literals
+          && (ctrl.begin() <= literalStart
+              && ctrl.end() >= literalStart + num_literals)) {
+        // we are using literals already present in our buffer
+
+        coopCopyOverlap(
+            decompData + decomp_idx,
+            ctrl.rawAt(literalStart + (num_literals - offset)),
+            offset,
+            match);
+        // we need to sync after we copy since we use the buffer
+        syncCTA();
+      } else {
+        // we need to sync before we copy since we use decomp
+        syncCTA();
+
+        coopCopyOverlap(
+            decompData + decomp_idx,
+            decompData + decomp_idx - offset,
+            offset,
+            match);
+      }
+      decomp_idx += match;
+    }
+  }
+  assert(comp_idx == comp_end);
+}
+
+template <typename T>
+struct BlockPrefixCallbackOp
+{
+  T m_running_total;
+
+  __device__ BlockPrefixCallbackOp(const T running_total) :
+      m_running_total(running_total)
+  {
+  }
+
+  __device__ T operator()(const T block_aggregate)
+  {
+    const T old_prefix = m_running_total;
+    m_running_total += block_aggregate;
+    return old_prefix;
+  }
+
+  __device__ T total() const
+  {
+    return m_running_total;
+  }
+};
+
+template <int BLOCK_SIZE>
+inline __device__ void generateItemChunkMappings(
+    const size_t* const decomp_sizes,
+    const size_t target_chunk,
+    const size_t batch_size,
+    const int max_chunk_size,
+    item_type& item,
+    size_t& local_chunk)
+{
+  using BlockScan = typename cub::BlockScan<size_t, BLOCK_SIZE>;
+
+  // each thread is assigned a chunk, and they cooperatively prefix sum
+  // the items, and then write out the their chunk's item. The first thread
+  // assigned to any given item also writes out it's prefix
+
+  __shared__ typename BlockScan::TempStorage temp_space;
+  __shared__ size_t local_prefix[BLOCK_SIZE + 1];
+
+  BlockPrefixCallbackOp<size_t> prefix_op(0);
+
+  item = static_cast<item_type>(-1);
+
+  // we have thread per item computing the prefix sum
+  for (size_t item_start = 0; item_start < batch_size;
+       item_start += BLOCK_SIZE) {
+    const size_t i = item_start + threadIdx.x;
+    const size_t item_chunks
+        = i < batch_size ? roundUpDiv(decomp_sizes[i], max_chunk_size) : 0;
+
+    BlockScan(temp_space)
+        .ExclusiveSum(item_chunks, local_prefix[threadIdx.x], prefix_op);
+    if (threadIdx.x == 0) {
+      local_prefix[BLOCK_SIZE] = prefix_op.total();
+    }
+    __syncthreads();
+
+    // if a thread's chunk lies in this set of items
+    if (target_chunk >= local_prefix[0]
+        && target_chunk < local_prefix[BLOCK_SIZE]) {
+      int beg = item_start;
+      int end = min(item_start + BLOCK_SIZE, batch_size) - 1;
+
+      // Binary search for the right chunk -- we know it exists, so we don't
+      // have to handle cases of before or after the sequence. We find the
+      // first index the target chunk is less than
+      item = (end + beg) / 2;
+      while (beg < end) {
+        const size_t chunk = local_prefix[item + 1 - item_start];
+
+        if (chunk <= target_chunk) {
+          assert(beg != chunk);
+          // the current mid-point works as a lower bound
+          beg = item + 1;
+        } else {
+          // the current mid-point does not work as a lower bound, so it must
+          // work as an upper bound
+          end = item;
+        }
+        item = (end + beg) / 2;
+      }
+
+      // the target for this thread is here
+      local_chunk = target_chunk - local_prefix[item - item_start];
+    }
+
+    __syncthreads();
+  }
+}
+
+template <int BLOCK_SIZE>
+__global__ void lz4CompressGenerateHeaders(
+    const uint8_t* const* const decomp_data,
+    const size_t* const decomp_sizes,
+    uint8_t* const comp_data,
+    size_t* const* const comp_sizes,
+    const size_t batch_size,
+    const int max_chunk_size,
+    const size_t total_chunks,
+    const size_t* const scratch_space_offset,
+    uint8_t* const* const scratch_space,
+    compression_chunk_header* const headers,
+    size_t* const item_prefix,
+    item_type* const item_map)
+{
+  const size_t target_chunk = BLOCK_SIZE * blockIdx.x + threadIdx.x;
+
+  item_type item;
+  size_t local_chunk;
+
+  generateItemChunkMappings<BLOCK_SIZE>(
+      decomp_sizes,
+      target_chunk,
+      batch_size,
+      max_chunk_size,
+      item,
+      local_chunk);
+
+  // write out items and chunk id's
+  if (target_chunk < total_chunks) {
+    if (local_chunk == 0) {
+      item_prefix[item] = target_chunk;
+    }
+
+    assert(item < batch_size);
+    item_map[target_chunk] = item;
+
+    const size_t chunk_offset
+        = local_chunk * static_cast<size_t>(max_chunk_size);
+    const size_t chunk_end = chunk_offset + max_chunk_size;
+
+    const size_t comp_offset = maxSizeOfStream(max_chunk_size) * target_chunk;
+
+    compression_chunk_header h;
+    h.src = decomp_data[item] + chunk_offset;
+    h.dst = comp_data + comp_offset;
+    h.hash = reinterpret_cast<offset_type*>(
+        scratch_space[item] + scratch_space_offset[item]
+        + (HASH_TABLE_SIZE * sizeof(offset_type)) * local_chunk);
+    h.comp_size = comp_sizes[item] + local_chunk;
+    h.size = min(chunk_end, decomp_sizes[item]) - chunk_offset;
+
+    headers[target_chunk] = h;
+  }
+}
+
+__global__ void
+lz4CompressMultistreamKernel(const compression_chunk_header* const headers)
+{
+  const int bidx = blockIdx.x * blockDim.y + threadIdx.y;
+
+  const uint8_t* decomp_ptr = headers[bidx].src;
+  const size_t decomp_length = headers[bidx].size;
+
+  uint8_t* comp_ptr = headers[bidx].dst;
+  size_t* const comp_length = headers[bidx].comp_size;
+
+  compressStream(
+      comp_ptr, decomp_ptr, headers[bidx].hash, decomp_length, comp_length);
+}
+
+template <int BLOCK_SIZE>
+__global__ void lz4CompressSumSizes(
+    size_t* const* const sizes,
+    const size_t* const offsets,
+    const size_t* const decomp_sizes,
+    const size_t chunk_size)
+{
+  using BlockScan = typename cub::BlockScan<size_t, BLOCK_SIZE>;
+
+  __shared__ typename BlockScan::TempStorage temp_space;
+
+  BlockPrefixCallbackOp<size_t> prefix_op(offsets[blockIdx.x]);
+
+  const size_t num = roundUpDiv(decomp_sizes[blockIdx.x], chunk_size);
+
+  size_t size = 0;
+  for (size_t i = 0; i < num; i += BLOCK_SIZE) {
+    const size_t index = i + threadIdx.x;
+    if (index < num) {
+      size = sizes[blockIdx.x][index];
+    } else {
+      size = 0;
+    }
+    BlockScan(temp_space).ExclusiveSum(size, size, prefix_op);
+
+    if (index < num) {
+      sizes[blockIdx.x][index] = size;
+    }
+
+    __syncthreads();
+  }
+
+  if (threadIdx.x == 0) {
+    sizes[blockIdx.x][num] = prefix_op.total();
+  }
+}
+
+template <int BLOCK_SIZE>
+__global__ void copyToContig(
+    const item_type* const item_map,
+    const size_t* const item_prefix,
+    const uint8_t* const temp_data,
+    const int stride,
+    const size_t* const* const comp_prefix,
+    uint8_t* const* const comp_data)
+{
+  const size_t global_chunk = blockIdx.x;
+  const size_t item = item_map[global_chunk];
+
+  // we assume there are no empty items
+  assert(item <= global_chunk);
+
+  const size_t local_chunk = global_chunk - item_prefix[item];
+  const size_t offset = comp_prefix[item][local_chunk];
+  const size_t size = comp_prefix[item][local_chunk + 1] - offset;
+
+  for (size_t i = threadIdx.x; i < size; i += BLOCK_SIZE) {
+    comp_data[item][offset + i] = temp_data[stride * global_chunk + i];
+  }
+}
+
+__global__ void lz4DecompressMultistreamKernel(
+    const chunk_header* const headers, const int num_chunks)
+{
+  const int bid = blockIdx.x * Y_DIM + threadIdx.y;
+
+  __shared__ uint8_t buffer[BUFFER_SIZE * Y_DIM];
+
+  if (bid < num_chunks) {
+    uint8_t* const decomp_ptr = headers[bid].dst;
+    const uint8_t* const comp_ptr = headers[bid].src;
+    const size_t chunk_length = headers[bid].size;
+
+    decompressStream(
+        buffer + threadIdx.y * BUFFER_SIZE, decomp_ptr, comp_ptr, chunk_length);
+  }
+}
+
+__global__ void lz4DecompressGenerateHeaders(
+    uint8_t* const decomp_data,
+    const uint8_t* const comp_data,
+    const size_t* const comp_chunk_prefix,
+    const size_t decomp_chunk_size,
+    const size_t num_chunks,
+    chunk_header* const headers)
+{
+  const int chunk = threadIdx.x + blockIdx.x * blockDim.x;
+
+  if (chunk < num_chunks) {
+    const size_t comp_chunk_offset = comp_chunk_prefix[chunk];
+    const size_t decomp_chunk_offset = chunk * decomp_chunk_size;
+
+    chunk_header h;
+    h.src = comp_data + comp_chunk_offset;
+    h.dst = decomp_data + decomp_chunk_offset;
+    h.size = comp_chunk_prefix[chunk + 1] - comp_chunk_prefix[chunk];
+
+    headers[chunk] = h;
+  }
+}
+
+/******************************************************************************
+ * PUBLIC FUNCTIONS ***********************************************************
+ *****************************************************************************/
+
+void lz4CompressBatch(
+    const uint8_t* const* const decomp_data_device,
+    const size_t* const decomp_prefixes_device,
+    const size_t* const decomp_sizes_host,
+    const size_t batch_size,
+    const size_t max_chunk_size,
+    uint8_t* const temp_data_device,
+    const size_t temp_bytes,
+    uint8_t* const* const comp_data_device,
+    size_t* const* const comp_prefixes_device,
+    const size_t* const comp_prefix_offset_device,
+    cudaStream_t stream)
+{
+  if (max_chunk_size < lz4MinChunkSize()) {
+    throw std::runtime_error(
+        "Minimum chunk size for LZ4 is " + std::to_string(MIN_CHUNK_SIZE));
+  } else if (max_chunk_size > lz4MaxChunkSize()) {
+    throw std::runtime_error(
+        "Maximum chunk size for LZ4 is " + std::to_string(MAX_CHUNK_SIZE));
+  }
+
+  // most of the kernels take a negligible amount of time, so by default we
+  // just use 128 threads. this value, however is choose arbitrarily, and
+  // has not been tuned for any architecture or dataset size.
+  constexpr const int BLOCK_SIZE = 128;
+
+  const size_t stride = lz4ComputeMaxSize(max_chunk_size);
+
+  const size_t chunks_in_batch
+      = lz4ComputeChunksInBatch(decomp_sizes_host, batch_size, max_chunk_size);
+
+  TempSpaceBroker broker(temp_data_device, temp_bytes);
+
+  uint8_t* staging_space;
+  broker.reserve(&staging_space, chunks_in_batch * stride);
+
+  compression_chunk_header* headers;
+  broker.reserve(&headers, chunks_in_batch);
+
+  // look up starting chunk per item
+  size_t* item_prefix;
+  broker.reserve(&item_prefix, batch_size);
+
+  // look up item per chunk
+  item_type* item_map;
+  broker.reserve(&item_map, chunks_in_batch);
+
+  // setup headers
+  {
+    const dim3 grid(roundUpDiv(chunks_in_batch, BLOCK_SIZE));
+    const dim3 block(BLOCK_SIZE);
+
+    lz4CompressGenerateHeaders<BLOCK_SIZE><<<grid, block, 0, stream>>>(
+        decomp_data_device,
+        decomp_prefixes_device,
+        staging_space,
+        comp_prefixes_device,
+        batch_size,
+        max_chunk_size,
+        chunks_in_batch,
+        comp_prefix_offset_device,
+        comp_data_device,
+        headers,
+        item_prefix,
+        item_map);
+    CudaUtils::check_last_error();
+  }
+
+  // perform compression
+  {
+    const dim3 grid(chunks_in_batch);
+    const dim3 block(COMP_THREADS);
+
+    lz4CompressMultistreamKernel<<<grid, block, 0, stream>>>(headers);
+    CudaUtils::check_last_error();
+  }
+
+  // perform prefix sum
+  {
+    const dim3 grid(batch_size);
+    const dim3 block(BLOCK_SIZE);
+
+    lz4CompressSumSizes<BLOCK_SIZE><<<grid, block, 0, stream>>>(
+        comp_prefixes_device,
+        comp_prefix_offset_device,
+        decomp_prefixes_device,
+        max_chunk_size);
+    CudaUtils::check_last_error();
+  }
+
+  {
+    const dim3 grid(chunks_in_batch);
+    // Since we are copying a whole chunk per thread block, maximize the number
+    // of threads we have copying each block
+    const dim3 block(1024);
+
+    // Copy prefix sums values to metadata header and copy compressed data into
+    // contiguous space
+    copyToContig<1024><<<grid, block, 0, stream>>>(
+        item_map,
+        item_prefix,
+        staging_space,
+        stride,
+        comp_prefixes_device,
+        comp_data_device);
+    CudaUtils::check_last_error();
+  }
+}
+
+void lz4DecompressBatches(
+    void* const temp_space,
+    const size_t temp_size,
+    void* const* decompData,
+    const uint8_t* const* compData,
+    int batch_size,
+    const size_t** compPrefix,
+    int chunk_size,
+    int* chunks_in_item,
+    cudaStream_t stream)
+{   
+  TempSpaceBroker broker(temp_space, temp_size);
+
+  int total_chunks=0;
+  for(int i=0; i<batch_size; i++) {
+    total_chunks += chunks_in_item[i];
+  }
+
+  chunk_header* headers;
+  broker.reserve(&headers, total_chunks);
+
+  int chunk_start=0;
+
+  for(int i=0; i<batch_size; i++) {
+
+    const dim3 header_block(128);
+    const dim3 header_grid(roundUpDiv(chunks_in_item[i], header_block.x));
+
+    lz4DecompressGenerateHeaders<<<header_grid, header_block, 0, stream>>>(
+        static_cast<uint8_t*>(decompData[i]),
+        compData[i],
+        compPrefix[i],
+        chunk_size,
+        chunks_in_item[i],
+        &headers[chunk_start]);
+
+    chunk_start += chunks_in_item[i];
+  }
+
+  lz4DecompressMultistreamKernel<<<
+      roundUpDiv(total_chunks, Y_DIM),
+      dim3(DECOMP_THREADS, Y_DIM, 1),
+      0,
+      stream>>>(headers, total_chunks);
+
+
+}
+
+
+size_t lz4ComputeChunksInBatch(
+    const size_t* const decomp_data_size,
+    const size_t batch_size,
+    const size_t chunk_size)
+{
+  size_t num_chunks = 0;
+
+  for (size_t i = 0; i < batch_size; ++i) {
+    num_chunks += roundUpDiv(decomp_data_size[i], chunk_size);
+  }
+
+  return num_chunks;
+}
+
+size_t lz4CompressComputeTempSize(
+    const size_t maxChunksInBatch, const size_t chunkSize)
+{
+  const size_t batch_size = 1;
+
+  size_t prefix_temp_size;
+  cudaError_t err = cub::DeviceScan::InclusiveSum(
+      NULL,
+      prefix_temp_size,
+      static_cast<const size_t*>(nullptr),
+      static_cast<size_t*>(nullptr),
+      maxChunksInBatch + 1);
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        "Failed to get space for cub inclusive sub: " + std::to_string(err));
+  }
+
+  const size_t strideSize = lz4ComputeMaxSize(chunkSize);
+
+  const size_t staging_size
+      = roundUpTo(strideSize * maxChunksInBatch, sizeof(size_t));
+
+  const size_t prefix_out_size = sizeof(size_t) * (maxChunksInBatch + 1);
+  const size_t header_size = roundUpTo(
+      sizeof(compression_chunk_header) * maxChunksInBatch, sizeof(size_t));
+  const size_t map_size
+      = roundUpTo(sizeof(uint32_t) * maxChunksInBatch, sizeof(size_t));
+  const size_t prefix_size = sizeof(size_t) * batch_size;
+
+  return prefix_temp_size + prefix_out_size + staging_size + +header_size
+         + map_size + prefix_size;
+}
+
+size_t lz4DecompressComputeTempSize(
+    const size_t maxChunksInBatch, const size_t /* chunkSize */)
+{
+  const size_t header_size = sizeof(chunk_header) * maxChunksInBatch;
+
+  return roundUpTo(header_size, sizeof(size_t));
+}
+
+size_t lz4ComputeMaxSize(const size_t size)
+{
+  return maxSizeOfStream(size);
+}
+
+size_t lz4MinChunkSize()
+{
+  return MIN_CHUNK_SIZE;
+}
+
+size_t lz4MaxChunkSize()
+{
+  return MAX_CHUNK_SIZE;
+}
+
+} // nvcomp namespace
+

--- a/nvcomp/LZ4CompressionKernels.h
+++ b/nvcomp/LZ4CompressionKernels.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+namespace nvcomp {
+
+/**
+ * @brief Compress a batch of memory locations.
+ *
+ * @param decomp_data The batch items to compress.
+ * @param decomp_sizes The size of each batch item to compress.
+ * @param batch_size The number of items in the batch.
+ * @param max_chunk_size The number of uncompressed bytes per LZ4 compressed
+ * chunk.
+ * @param temp_data The temporary memory to use.
+ * @param temp_bytes The size of the temporary memory.
+ * @param comp_data The output location of each batch item.
+ * @param comp_prefixes The size of each compressed chunk (output).
+ * @param comp_prefix_offset_host
+ * @param stream The stream to operate on.
+ */
+void lz4CompressBatch(
+    const uint8_t* const* decomp_data_device,
+    const size_t* decomp_sizes_device,
+    const size_t* decomp_sizes_host,
+    const size_t batch_size,
+    const size_t max_chunk_size,
+    uint8_t* temp_data,
+    size_t temp_bytes,
+    uint8_t* const* comp_data_device,
+    size_t* const* comp_prefixes_device,
+    const size_t* const comp_prefix_offset_device,
+    cudaStream_t stream);
+
+void lz4DecompressBatches(
+    void* const temp_space,
+    const size_t temp_size,
+    void* const* decompData,
+    const uint8_t* const* compData,
+    int batch_size,
+    const size_t** compPrefix,
+    int chunk_size,
+    int* chunks_in_item,
+    cudaStream_t stream);
+
+size_t lz4ComputeChunksInBatch(
+    const size_t* const decomp_data_size,
+    const size_t batch_size,
+    const size_t chunk_size);
+
+size_t lz4CompressComputeTempSize(
+    const size_t max_chunks_in_batch, const size_t chunk_size);
+
+size_t lz4DecompressComputeTempSize(
+    const size_t max_chunks_in_batch, const size_t chunk_size);
+
+size_t lz4ComputeMaxSize(const size_t chunk_size);
+
+size_t lz4MinChunkSize();
+
+size_t lz4MaxChunkSize();
+}
+

--- a/nvcomp/LZ4Metadata.cpp
+++ b/nvcomp/LZ4Metadata.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "LZ4Metadata.h"
+#include "common.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+#include <iostream>
+
+namespace nvcomp
+{
+
+/******************************************************************************
+ * CONSTANTS ******************************************************************
+ *****************************************************************************/
+
+namespace
+{
+
+constexpr const size_t NULL_OFFSET = static_cast<size_t>(-1);
+}
+
+/******************************************************************************
+ * CONSTRUCTORS / DESTRUCTOR **************************************************
+ *****************************************************************************/
+
+LZ4Metadata::LZ4Metadata(
+    const nvcompType_t type,
+    const size_t uncompChunkBytes,
+    const size_t uncompressedBytes,
+    const size_t compressedBytes) :
+    Metadata(type, uncompressedBytes, compressedBytes, COMPRESSION_ID),
+    m_uncompChunkBytes(uncompChunkBytes),
+    m_metadataBytes(),
+    m_version(0),
+    m_chunkOffsets()
+{
+  // TODO - error checking for byte sizes
+}
+
+LZ4Metadata::LZ4Metadata(const void* const memPtr, size_t compressedBytes) :
+    LZ4Metadata(
+        NVCOMP_TYPE_UCHAR,
+        ((const size_t*)memPtr)[ChunkSize],
+        ((const size_t*)memPtr)[UncompressedSize],
+        compressedBytes)
+{
+  m_chunkOffsets.resize(getNumChunks() + 1);
+  std::copy(
+      static_cast<const size_t*>(memPtr) + OffsetAddr,
+      static_cast<const size_t*>(memPtr) + OffsetAddr + getNumChunks(),
+      m_chunkOffsets.begin());
+  m_chunkOffsets.back() = compressedBytes;
+}
+
+/******************************************************************************
+ * PUBLIC METHODS *************************************************************
+ *****************************************************************************/
+
+size_t LZ4Metadata::getUncompChunkSize() const
+{
+  return m_uncompChunkBytes;
+}
+
+size_t LZ4Metadata::getNumChunks() const
+{
+  return roundUpDiv(getUncompressedSize(), m_uncompChunkBytes);
+}
+
+size_t LZ4Metadata::getChunkOffset(size_t idx)
+{
+  if (idx > roundUpDiv(getUncompressedSize(), m_uncompChunkBytes)) {
+    throw std::runtime_error(
+        "Invalid chunk index: " + std::to_string(idx) + ", total chunks is "
+        + std::to_string(
+              roundUpDiv(getUncompressedSize(), m_uncompChunkBytes)));
+    return 0;
+  } else {
+    return m_chunkOffsets[idx];
+  }
+}
+
+size_t LZ4Metadata::getMetadataSize() const
+{
+  return m_metadataBytes;
+}
+
+size_t* LZ4Metadata::getOffsetArray()
+{
+  return m_chunkOffsets.data();
+}
+
+} // namespace nvcomp

--- a/nvcomp/LZ4Metadata.h
+++ b/nvcomp/LZ4Metadata.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NVCOMP_LZ4METADATA_H
+#define NVCOMP_LZ4METADATA_H
+
+#include "Metadata.h"
+#include "lz4.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#define LZ4_FLAG 4
+
+namespace nvcomp
+{
+
+class LZ4Metadata : public Metadata
+{
+public:
+  constexpr static int COMPRESSION_ID = 0x4000;
+
+  /**
+   * @brief Order of header values stored at the beginning of the metadata. Each
+   * offset is 8 bytes.
+   */
+  enum LZ4MetadataField
+  {
+    Header = 0,
+    MetadataBytes = 1,
+    UncompressedSize = 2,
+    ChunkSize = 3,
+    OffsetAddr = 4
+  };
+
+  /**
+   * @brief Create a new metadta object.
+   *
+   * @param opts The cascaded compression options.
+   * @param type The type of data element to compress.
+   * @param uncompressedBytes The size of the data while uncompressed.
+   * @param compressedBytes The size of the data and metadata compressed.
+   */
+  LZ4Metadata(
+      const nvcompType_t type,
+      const size_t uncompChunkBytes,
+      const size_t uncompressedBytes,
+      const size_t compressedBytes);
+
+  /**
+   * @brief Create metadata object from unformatted metadata memory copied onto
+   * the CPU.
+   *
+   * @param memPtr The memory containing the metadata on the CPU.  This is in
+   * the raw format that is contained at the beginning of any memory compressed
+   * by the nvcomp LZ4 compressor.
+   * @param compressedBytes The total size of the data in memPtr
+   */
+  LZ4Metadata(const void* const memPtr, size_t compressedBytes);
+
+  /**
+   * @brief Get number of bytes per chunk
+   *
+   * @return number of bytes in each chunk (except for the last one
+   */
+  size_t getUncompChunkSize() const;
+
+  /**
+   * @brief Get number of chunks in the entire dataset
+   *
+   * @return number of chunks in the dataset
+   */
+  size_t getNumChunks() const;
+
+  /**
+   * @brief Get offset of a particular chunk
+   *
+   * @return the byte offset of chunk idx in the compressed dataset
+   */
+  size_t getChunkOffset(size_t idx);
+
+  size_t getMetadataSize() const;
+
+  size_t* getOffsetArray();
+
+private:
+  size_t m_uncompChunkBytes;
+  size_t m_metadataBytes;
+  size_t m_version;
+
+  /**
+   * @brief The offsets of each chunk in the compressed dataset
+   */
+  std::vector<size_t> m_chunkOffsets;
+};
+
+} // namespace nvcomp
+
+#endif

--- a/nvcomp/LZ4MetadataOnGPU.cpp
+++ b/nvcomp/LZ4MetadataOnGPU.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "LZ4MetadataOnGPU.h"
+#include "CudaUtils.h"
+
+#include <cassert>
+#include <stdexcept>
+
+namespace nvcomp
+{
+
+/******************************************************************************
+ * PUBLIC STATIC METHODS ******************************************************
+ *****************************************************************************/
+
+size_t LZ4MetadataOnGPU::getSerializedSizeOf(const LZ4Metadata& metadata)
+{
+  return (LZ4Metadata::OffsetAddr + metadata.getNumChunks() + 1)
+         * sizeof(size_t);
+}
+
+size_t LZ4MetadataOnGPU::getCompressedDataOffset(const LZ4Metadata& metadata)
+{
+  return getSerializedSizeOf(metadata);
+}
+
+/******************************************************************************
+ * CONSTRUCTORS / DESTRUCTOR **************************************************
+ *****************************************************************************/
+
+LZ4MetadataOnGPU::LZ4MetadataOnGPU(
+    const void* const ptr, const size_t maxSize) :
+    m_ptr(ptr),
+    m_maxSize(maxSize),
+    m_numChunks(-1),
+    m_serializedSize(0)
+{
+  if (ptr == nullptr) {
+    throw std::runtime_error("Cannot have nullptr for metadata location.");
+  }
+}
+
+LZ4MetadataOnGPU::LZ4MetadataOnGPU(const LZ4MetadataOnGPU& other) :
+    LZ4MetadataOnGPU(other.m_ptr, other.m_maxSize)
+{
+  m_numChunks = other.m_numChunks;
+  m_serializedSize = other.m_serializedSize;
+}
+
+/******************************************************************************
+ * PUBLIC METHODS *************************************************************
+ *****************************************************************************/
+
+LZ4MetadataOnGPU& LZ4MetadataOnGPU::operator=(const LZ4MetadataOnGPU& other)
+{
+  m_ptr = other.m_ptr;
+  m_maxSize = other.m_maxSize;
+  m_numChunks = other.m_numChunks;
+  m_serializedSize = other.m_serializedSize;
+
+  return *this;
+}
+
+size_t LZ4MetadataOnGPU::getSerializedSize() const
+{
+  if (m_serializedSize == 0) {
+    throw std::runtime_error("Serialized size has not been set.");
+  }
+  assert(m_numChunks > 0);
+
+  return m_serializedSize;
+}
+
+const size_t* LZ4MetadataOnGPU::compressed_prefix_ptr() const
+{
+  return static_cast<const size_t*>(m_ptr) + LZ4Metadata::OffsetAddr;
+}
+
+LZ4Metadata LZ4MetadataOnGPU::copyToHost(cudaStream_t stream)
+{
+  size_t metadata_bytes;
+  CudaUtils::copy_async(
+      &metadata_bytes,
+      ((size_t*)m_ptr) + LZ4Metadata::MetadataBytes,
+      1,
+      DEVICE_TO_HOST,
+      stream);
+  CudaUtils::sync(stream);
+
+  if (metadata_bytes > m_maxSize) {
+    throw std::runtime_error(
+        "Compressed data is too small to contain "
+        "metadata of size "
+        + std::to_string(metadata_bytes) + " / " + std::to_string(m_maxSize));
+  }
+
+  std::vector<uint8_t> metadata_buffer(metadata_bytes);
+  CudaUtils::copy_async(
+      metadata_buffer.data(),
+      static_cast<const uint8_t*>(m_ptr),
+      metadata_bytes,
+      DEVICE_TO_HOST,
+      stream);
+  CudaUtils::sync(stream);
+
+  set_serialized_size(metadata_bytes);
+
+  LZ4Metadata metadata
+      = LZ4Metadata(metadata_buffer.data(), metadata_buffer.size());
+  assert(getSerializedSizeOf(metadata) == metadata_bytes);
+
+  return metadata;
+}
+
+/******************************************************************************
+ * PROTECTED METHODS **********************************************************
+ *****************************************************************************/
+
+size_t LZ4MetadataOnGPU::max_size() const
+{
+  return m_maxSize;
+}
+
+void LZ4MetadataOnGPU::set_serialized_size(const size_t size)
+{
+  m_serializedSize = size;
+}
+
+} // namespace nvcomp

--- a/nvcomp/LZ4MetadataOnGPU.h
+++ b/nvcomp/LZ4MetadataOnGPU.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef LZ4METADATAONGPU_H
+#define LZ4METADATAONGPU_H
+
+#include "LZ4Metadata.h"
+
+namespace nvcomp
+{
+
+class LZ4MetadataOnGPU
+{
+public:
+  /**
+   * @brief Get the serialized size a metadata object would occupy on the GPU.
+   *
+   * @param metadata The metadata.
+   *
+   * @return The size in bytes that would be occupied.
+   */
+  static size_t getSerializedSizeOf(const LZ4Metadata& metadata);
+
+  /**
+   * @brief Get the offset from the start of the metadata, to where the first
+   * chunk of compressed data is stored.
+   *
+   * @param metadata The metadata.
+   *
+   * @return The offset in bytes.
+   */
+  static size_t getCompressedDataOffset(const LZ4Metadata& metadata);
+
+  /**
+   * @brief Create a new serialized metadata object. This is used either to
+   * copy metadata to the GPU, or copy it to the CPU from the GPU.
+   *
+   * @param ptr The memory location on the GPU that will be used for the
+   * serialized metadata.
+   * @param maxSize The maximum size the metadata can occupy (the size of the
+   * allocation usually).
+   */
+  LZ4MetadataOnGPU(const void* ptr, size_t maxSize);
+
+  LZ4MetadataOnGPU(const LZ4MetadataOnGPU& other);
+  LZ4MetadataOnGPU& operator=(const LZ4MetadataOnGPU& other);
+
+  virtual ~LZ4MetadataOnGPU() = default;
+
+  /**
+   * @brief Get the size of this metadata on the GPU.
+   *
+   * @return The size in bytes.
+   */
+  size_t getSerializedSize() const;
+
+  const size_t* compressed_prefix_ptr() const;
+
+  /**
+   * @brief Get a copy of the metadata on the CPU. This syncs with this stream.
+   *
+   * @param stream The stream to copy on.
+   *
+   * @return The metadata on the CPU.
+   */
+  LZ4Metadata copyToHost(cudaStream_t stream);
+
+protected:
+  size_t max_size() const;
+
+  void set_serialized_size(const size_t size);
+
+private:
+  const void* m_ptr;
+  size_t m_maxSize;
+  size_t m_numChunks;
+  size_t m_serializedSize;
+};
+
+} // namespace nvcomp
+
+#endif

--- a/nvcomp/Metadata.cpp
+++ b/nvcomp/Metadata.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Metadata.h"
+#include "common.h"
+
+#include <cstddef>
+
+namespace nvcomp
+{
+
+/******************************************************************************
+ * CONSTRUCTORS / DESTRUCTOR **************************************************
+ *****************************************************************************/
+
+Metadata::Metadata(
+    const nvcompType_t type,
+    const size_t uncompressedBytes,
+    const size_t compressedBytes,
+    const int compressionType) :
+    m_type(type),
+    m_uncompressedBytes(uncompressedBytes),
+    m_compressedBytes(compressedBytes),
+    m_compressionType(compressionType)
+{
+  if (m_uncompressedBytes % sizeOfnvcompType(m_type) != 0) {
+    throw std::runtime_error(
+        "Number of uncompressed bytes is not a multiple "
+        " of the size of the type: "
+        + std::to_string(m_uncompressedBytes) + " % "
+        + std::to_string(sizeOfnvcompType(m_type)));
+  }
+}
+
+/******************************************************************************
+ * PUBLIC METHODS *************************************************************
+ *****************************************************************************/
+
+nvcompType_t Metadata::getValueType() const
+{
+  return m_type;
+}
+
+size_t Metadata::getUncompressedSize() const
+{
+  return m_uncompressedBytes;
+}
+
+size_t Metadata::getCompressedSize() const
+{
+  return m_compressedBytes;
+}
+
+size_t Metadata::getNumUncompressedElements() const
+{
+  return getUncompressedSize() / sizeOfnvcompType(m_type);
+}
+
+int Metadata::getCompressionType() const
+{
+  return m_compressionType;
+}
+
+void Metadata::setUncompressedSize(const size_t bytes)
+{
+  m_uncompressedBytes = bytes;
+}
+
+void Metadata::setCompressedSize(const size_t bytes)
+{
+  m_compressedBytes = bytes;
+}
+
+/******************************************************************************
+ * PROTECTED METHODS **********************************************************
+ *****************************************************************************/
+
+} // namespace nvcomp

--- a/nvcomp/Metadata.h
+++ b/nvcomp/Metadata.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NVCOMP_METADATA_H
+#define NVCOMP_METADATA_H
+
+#include "nvcomp.h"
+
+namespace nvcomp
+{
+
+class Metadata
+{
+public:
+  /**
+   * @brief Create a new metadta object.
+   *
+   * @param type The type of data element to compress.
+   * @param uncompressedBytes The size of the data while uncompressed.
+   * @param compressedBytes The size of the data and metadata compressed.
+   * @param compressionType The type of compressed metadata this is.
+   */
+  Metadata(
+      nvcompType_t type,
+      size_t uncompressedBytes,
+      size_t compressedBytes,
+      int compressionType);
+
+  virtual ~Metadata() = default;
+
+  /**
+   * @brief Get the type of value that is compressed.
+   *
+   * @return The value type.
+   */
+  nvcompType_t getValueType() const;
+
+  /**
+   * @brief Get the size of the uncompressed data in bytes.
+   *
+   * @return The size of the uncompressed data.
+   */
+  size_t getUncompressedSize() const;
+
+  /**
+   * @brief Get the size of the compressed data and metadata in bytes.
+   *
+   * @return The size in bytes.
+   */
+  size_t getCompressedSize() const;
+
+  /**
+   * @brief Get the number of uncompressed elements.
+   *
+   * @return The number of elements.
+   */
+  size_t getNumUncompressedElements() const;
+
+  /**
+   * @brief Get the type of compression used.
+   *
+   * @return The type of compression.
+   */
+  int getCompressionType() const;
+
+protected:
+  void setUncompressedSize(size_t bytes);
+
+  void setCompressedSize(size_t bytes);
+
+private:
+  /**
+   * @brief The datatype of decompressed elements.
+   */
+  nvcompType_t m_type;
+
+  /**
+   * @brief The size in bytes of the uncompressed data.
+   */
+  size_t m_uncompressedBytes;
+
+  /**
+   * @brief The size in bytes of the compressed data (including serialized
+   * metadata).
+   */
+  size_t m_compressedBytes;
+
+  int m_compressionType;
+};
+
+} // namespace nvcomp
+
+#endif

--- a/nvcomp/MutableBatchedLZ4MetadataOnGPU.cu
+++ b/nvcomp/MutableBatchedLZ4MetadataOnGPU.cu
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "MutableBatchedLZ4MetadataOnGPU.h"
+
+#include "CudaUtils.h"
+#include "LZ4Metadata.h"
+#include "LZ4MetadataOnGPU.h"
+#include "TempSpaceBroker.h"
+#include "common.h"
+
+namespace nvcomp
+{
+
+/******************************************************************************
+ * TYPES **********************************************************************
+ *****************************************************************************/
+
+namespace
+{
+
+struct temp_metadata_t
+{
+  size_t header;
+  size_t metadata_bytes;
+  size_t uncompressed_size;
+  size_t chunk_size;
+  size_t offset_addr;
+  // used to determine where the metadata goes
+  void* metadata_dest;
+};
+
+} // namespace
+
+/******************************************************************************
+ * KERNELS ********************************************************************
+ *****************************************************************************/
+
+namespace
+{
+
+__global__ void distributeMetadataKernel(
+    const temp_metadata_t* const metadata_device, const size_t batch_size)
+{
+  const int bidx = threadIdx.x + blockDim.x * blockIdx.x;
+
+  if (bidx < batch_size) {
+    size_t* buffer
+        = reinterpret_cast<size_t*>(metadata_device[bidx].metadata_dest);
+    buffer[LZ4Metadata::Header] = metadata_device[bidx].header;
+    buffer[LZ4Metadata::MetadataBytes] = metadata_device[bidx].metadata_bytes;
+    buffer[LZ4Metadata::UncompressedSize]
+        = metadata_device[bidx].uncompressed_size;
+    buffer[LZ4Metadata::ChunkSize] = metadata_device[bidx].chunk_size;
+    buffer[LZ4Metadata::OffsetAddr] = metadata_device[bidx].offset_addr;
+  }
+}
+
+} // namespace
+
+/******************************************************************************
+ * CONSTRUCTORS / DESTRUCTOR **************************************************
+ *****************************************************************************/
+
+MutableBatchedLZ4MetadataOnGPU::MutableBatchedLZ4MetadataOnGPU(
+    void* const* const out_ptrs,
+    const size_t* const max_out_sizes,
+    const size_t batch_size) :
+    m_buffer(),
+    m_batch_size(batch_size),
+    m_out_ptrs(out_ptrs),
+    m_max_out_sizes(max_out_sizes)
+{
+}
+
+/******************************************************************************
+ * PUBLIC METHODS *************************************************************
+ *****************************************************************************/
+
+void MutableBatchedLZ4MetadataOnGPU::copyToGPU(
+    const std::vector<LZ4Metadata>& metadata,
+    void* temp_space,
+    size_t temp_size,
+    size_t* serialized_sizes,
+    cudaStream_t stream)
+{
+  if (metadata.size() != m_batch_size) {
+    throw std::runtime_error(
+        "Mismatch batch size (" + std::to_string(m_batch_size)
+        + ") and number of metadatas (" + std::to_string(metadata.size())
+        + ").");
+  }
+
+  // setup temp space
+  TempSpaceBroker broker(temp_space, temp_size);
+
+  temp_metadata_t* metadata_device;
+  broker.reserve(&metadata_device, m_batch_size);
+
+  m_buffer.resize(sizeof(temp_metadata_t) * m_batch_size);
+  temp_metadata_t* const metadata_host
+      = reinterpret_cast<temp_metadata_t*>(m_buffer.data());
+
+  // copy metadata to buffer
+  for (size_t i = 0; i < m_batch_size; ++i) {
+    serialized_sizes[i] = LZ4MetadataOnGPU::getSerializedSizeOf(metadata[i]);
+    if (serialized_sizes[i] > m_max_out_sizes[i]) {
+      throw std::runtime_error(
+          "Insufficient space for metadata for item " + std::to_string(i)
+          + " : " + std::to_string(m_max_out_sizes[i]) + " / "
+          + std::to_string(serialized_sizes[i]));
+    }
+
+    metadata_host[i].header = LZ4_FLAG;
+    metadata_host[i].metadata_bytes = serialized_sizes[i];
+    metadata_host[i].uncompressed_size = metadata[i].getUncompressedSize();
+    metadata_host[i].chunk_size = metadata[i].getUncompChunkSize();
+    metadata_host[i].offset_addr = metadata_host[i].metadata_bytes;
+    metadata_host[i].metadata_dest = m_out_ptrs[i];
+  }
+
+  // copy buffer to gpu
+  CudaUtils::copy_async(
+      metadata_device, metadata_host, m_batch_size, HOST_TO_DEVICE, stream);
+
+  // distribute metadata
+  const dim3 block(128);
+  const dim3 grid(roundUpDiv(m_batch_size, block.x));
+
+  distributeMetadataKernel<<<grid, block, 0, stream>>>(
+      metadata_device, m_batch_size);
+  CudaUtils::check_last_error();
+}
+
+size_t*
+MutableBatchedLZ4MetadataOnGPU::compressed_prefix_ptr(const size_t index)
+{
+  size_t* const ptr
+      = static_cast<size_t*>(m_out_ptrs[index]) + LZ4Metadata::OffsetAddr;
+
+  return ptr;
+}
+
+} // namespace nvcomp

--- a/nvcomp/MutableBatchedLZ4MetadataOnGPU.h
+++ b/nvcomp/MutableBatchedLZ4MetadataOnGPU.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NVCOMP_MUTABLEBATCHEDLZ4METADATAONGPU_H
+#define NVCOMP_MUTABLEBATCHEDLZ4METADATAONGPU_H
+
+#include "LZ4Metadata.h"
+
+#include "cuda_runtime.h"
+
+#include <cstddef>
+#include <vector>
+
+namespace nvcomp
+{
+
+class MutableBatchedLZ4MetadataOnGPU
+{
+public:
+  MutableBatchedLZ4MetadataOnGPU(
+      void* const* out_ptrs,
+      const size_t* const max_out_sizes,
+      size_t batch_size);
+
+  MutableBatchedLZ4MetadataOnGPU(const MutableBatchedLZ4MetadataOnGPU& other)
+      = delete;
+  MutableBatchedLZ4MetadataOnGPU&
+  operator=(const MutableBatchedLZ4MetadataOnGPU& other)
+      = delete;
+
+  void copyToGPU(
+      const std::vector<LZ4Metadata>& metadata,
+      void* temp_space,
+      size_t temp_size,
+      size_t* serialized_sizes,
+      cudaStream_t stream);
+
+  size_t* compressed_prefix_ptr(const size_t index);
+
+private:
+  std::vector<uint8_t*> m_buffer;
+  size_t m_batch_size;
+  void* const* m_out_ptrs;
+  const size_t* m_max_out_sizes;
+};
+
+} // namespace nvcomp
+
+#endif

--- a/nvcomp/MutableLZ4MetadataOnGPU.cpp
+++ b/nvcomp/MutableLZ4MetadataOnGPU.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "MutableLZ4MetadataOnGPU.h"
+#include "CudaUtils.h"
+
+#include <cassert>
+#include <stdexcept>
+
+namespace nvcomp
+{
+
+/******************************************************************************
+ * CONSTRUCTORS / DESTRUCTOR **************************************************
+ *****************************************************************************/
+
+MutableLZ4MetadataOnGPU::MutableLZ4MetadataOnGPU(
+    void* const ptr, const size_t maxSize) :
+    LZ4MetadataOnGPU(ptr, maxSize),
+    m_mutable_ptr(ptr)
+{
+  if (ptr == nullptr) {
+    throw std::runtime_error("Cannot have nullptr for metadata location.");
+  }
+}
+
+MutableLZ4MetadataOnGPU::MutableLZ4MetadataOnGPU(
+    const MutableLZ4MetadataOnGPU& other) :
+    MutableLZ4MetadataOnGPU(other.m_mutable_ptr, other.max_size())
+{
+}
+
+/******************************************************************************
+ * PUBLIC METHODS *************************************************************
+ *****************************************************************************/
+
+MutableLZ4MetadataOnGPU& MutableLZ4MetadataOnGPU::
+operator=(const MutableLZ4MetadataOnGPU& other)
+{
+  LZ4MetadataOnGPU::operator=(other);
+  m_mutable_ptr = other.m_mutable_ptr;
+
+  return *this;
+}
+
+void MutableLZ4MetadataOnGPU::copyToGPU(
+    const LZ4Metadata& metadata, cudaStream_t stream)
+{
+  const size_t required_size = getSerializedSizeOf(metadata);
+  if (required_size > max_size()) {
+    throw std::runtime_error(
+        "Insufficient space for metadata: " + std::to_string(required_size)
+        + " / " + std::to_string(max_size()));
+  }
+
+  const size_t num_metadata_values = LZ4Metadata::OffsetAddr + 1;
+
+  std::vector<size_t> buffer(num_metadata_values);
+  buffer[LZ4Metadata::Header] = LZ4_FLAG;
+  buffer[LZ4Metadata::MetadataBytes] = required_size;
+  buffer[LZ4Metadata::UncompressedSize] = metadata.getUncompressedSize();
+  buffer[LZ4Metadata::ChunkSize] = metadata.getUncompChunkSize();
+  buffer[LZ4Metadata::OffsetAddr] = buffer[LZ4Metadata::MetadataBytes];
+
+  CudaUtils::copy_async(
+      static_cast<size_t*>(m_mutable_ptr),
+      buffer.data(),
+      buffer.size(),
+      HOST_TO_DEVICE,
+      stream);
+
+  set_serialized_size(required_size);
+}
+
+size_t* MutableLZ4MetadataOnGPU::compressed_prefix_ptr()
+{
+  size_t* const ptr
+      = static_cast<size_t*>(m_mutable_ptr) + LZ4Metadata::OffsetAddr;
+
+  // make sure we're in sync with the const version
+  assert(LZ4MetadataOnGPU::compressed_prefix_ptr() == ptr);
+
+  return ptr;
+}
+
+} // namespace nvcomp

--- a/nvcomp/MutableLZ4MetadataOnGPU.h
+++ b/nvcomp/MutableLZ4MetadataOnGPU.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef MUTABLELZ4LZ4METADATAONGPU_H
+#define MUTABLELZ4LZ4METADATAONGPU_H
+
+#include "LZ4Metadata.h"
+#include "LZ4MetadataOnGPU.h"
+
+namespace nvcomp
+{
+
+class MutableLZ4MetadataOnGPU : public LZ4MetadataOnGPU
+{
+public:
+  /**
+   * @brief Create a new serialized metadata object. This is used either to
+   * copy metadata to the GPU, or copy it to the CPU from the GPU.
+   *
+   * @param ptr The memory location on the GPU that will be used for the
+   * serialized metadata.
+   * @param maxSize The maximum size the metadata can occupy (the size of the
+   * allocation usually).
+   */
+  MutableLZ4MetadataOnGPU(void* ptr, size_t maxSize);
+
+  MutableLZ4MetadataOnGPU(const MutableLZ4MetadataOnGPU& other);
+  MutableLZ4MetadataOnGPU& operator=(const MutableLZ4MetadataOnGPU& other);
+
+  /**
+   * @brief Copy and serialize the given metadata object to to the GPU
+   * asynchronously.
+   *
+   * @param metadata The metadata object to serialize.
+   * @param stream The stream to asynchronously execute on.
+   */
+  void copyToGPU(const LZ4Metadata& metadata, cudaStream_t stream);
+
+  size_t* compressed_prefix_ptr();
+
+private:
+  void* m_mutable_ptr;
+};
+
+} // namespace nvcomp
+
+#endif

--- a/nvcomp/README.md
+++ b/nvcomp/README.md
@@ -1,0 +1,111 @@
+# What is nvcomp?
+nvcomp is a CUDA library that features generic compression interfaces to enable developers to use high-performance GPU compressors in their applications.
+
+nvcomp 1.2 includes Cascaded and LZ4 compression methods. Cascaded compression methods demonstrate high performance with up to 500GB/s throughput and a high compression ratio of up to 80x on numerical data from analytical workloads. LZ4 methods feature up to 60 GB/s decompression throughput and good compression ratios for arbitrary byte streams.
+
+Below are performance vs. compression ratio scatter plots for a few numerical columns from TPC-H and Fanny Mae’s Mortgage datasets for Cascaded compression (R1D1B1), and string columns from TPC-H for LZ4 compression. For the TPC-H dataset we used SF10 lineitem table, and the following columns: column 0 (L_ORDERKEY) as 8B integers, and columns 8, 9, 13, 14, 15 as byte streams. From the Mortgage dataset we used 2009 Q2 performance table: column 0 (LOAN_ID) as 8B integers and column 10 (CURRENT_LOAN_DELINQUENCY_STATUS) as 4B integers. The numbers were collected on a Tesla V100 PCIe card (with ECC on). Note that you can tune the Cascaded format settings (e.g. the number of RLE layers) for even better compression ratio for some of these datasets.  We also provide a fast auto-selector that can be used to quickly determine the best Cascaded format settings to use for your dataset (details are in the [Cascaded Selector Guide](doc/selector-quickstart.md)).
+
+![Cascaded compression performance](/doc/cascaded-perf.png)
+
+![LZ4 performance](/doc/LZ4-perf.png)
+
+The library is designed to be modular with ability to add new implementations without changing the high-level user interface. We’re working on additional schemes, and also on a “how to” guide for developers to add their own custom algorithms. Stay tuned for updates!
+
+Below you can find instructions on how to build the library, reproduce our benchmarking results, a guide on how to integrate into your application and a detailed description of the compression methods. Enjoy!
+
+# Version 1.2 Release
+
+This version of nvcomp adds the
+[Cascaded Selector](/dec/selector-quickstart) set of interfaces,
+for automating the process of configuring Cascaded compression as well as other
+improvements.
+Full details in [CHANGELOG.md](CHANGELOG.md).
+
+## Known issues
+
+* Cascaded compression requires a large amount of temporary workspace to
+operate. Current workaround is to compress/decompress large datasets in pieces,
+re-using temporary workspace for each piece.
+
+# Building the library
+NVComp uses CMake for building. Generally, it is best to do an out of source build:
+```
+mkdir build/
+cd build
+cmake ..
+make
+```
+
+If you're building using CUDA 10 or less, you will need to specify a path to
+[CUB](https://github.com/thrust/cub) on your system, of at least version
+1.9.10.
+
+```
+cmake -DCUB_DIR=<path to cub repository>
+```
+
+# Running benchmarks
+GPU requirement:
+* It's recommended to run on Volta architecture or higher (the library was not tested on Pascal and below, but may work)
+
+To obtain TPC-H data:
+- Clone and compile https://github.com/electrum/tpch-dbgen
+- Run `./dbgen -s <scale factor>`, then grab `lineitem.tbl`
+
+To obtain Mortgage data:
+- Download [16 Years](http://rapidsai-data.s3-website.us-east-2.amazonaws.com/notebook-mortgage-data/mortgage_2000-2015.tgz) archive from https://rapidsai.github.io/demos/datasets/mortgage-data
+- Unpack and copy `mortgage/perf/Perforamnce_2009Q2.txt`
+
+Convert CSV files to binary files:
+- `benchmarks/text_to_binary.py` is provided to read a `.csv` or text file and output a chosen column of data into a binary file
+- For example, run `python benchmarks/text_to_binary.py lineitem.tbl <column number> <datatype> column_data.bin '|'` to generate the binary dataset `column_data.bin` for TPC-H lineitem column `<column number>` using `<datatype>` as the type
+- *Note*: make sure that the delimiter is set correctly, default is `,`
+
+Run tests:
+- Run `./bin/benchmark_cascaded` or `./bin/benchmark_lz4` with `-f column_data.bin <options>` to measure throughput.
+
+Below are some reference benchmark results on a Tesla V100 for TPC-H.
+
+Example of compressing and decompressing TPC-H SF10 lineitem column 0 (L_ORDERKEY) using Cascaded with RLE + Delta + Bit-packing (input stream is treated as 8-byte integers):
+
+```
+$ ./bin/benchmark_cascaded -f /tmp/lineitem-col0-long.bin -t long -r 1 -d 1 -b 1 -m
+----------
+uncompressed (B): 479888416
+compression memory (input+output+temp) (B): 2400694079
+compression temp space (B): 1200972879
+compression output space (B): 719832784
+comp_size: 15000160, compressed ratio: 31.99
+compression throughput (GB/s): 184.06
+decompression memory (input+output+temp) (B): 930155136
+decompression temp space (B): 435266560
+decompression throughput (GB/s): 228.53
+```
+
+Example of compressing and decompressing TPC-H SF10 lineitem column 15 (L_COMMENT) using LZ4:
+
+```
+$ ./bin/benchmark_lz4 -f lineitem-col15-string.bin -m
+----------
+uncompressed (B): 2579400236
+compression memory (input+output+temp) (B): 7761407820
+compression temp space (B): 2591870472
+compression output space (B): 2590137112
+comp_size: 1033546459, compressed ratio: 2.50
+compression throughput (GB/s): 3.00
+decompression memory (input+output+temp) (B): 3613891311
+decompression temp space (B): 944616
+decompression throughput (GB/s): 27.48
+```
+
+*Note*: Your TPC-H performance results may not precisely match the output above, since the TPC-H data generator produces random data - you need to use the same seed to have byte-matching input files.
+
+# How to use the library in your code
+
+* [C++ Quick Start Guide](doc/cpp_quickstart.md)
+* [Batched Compression/Decompression Guide](doc/batched-quickstart.md)
+* [Cascaded Format Selector Guide](doc/selector-quickstart.md)
+
+# Further information about our compression algorithms
+
+* [Algorithms overview](doc/algorithms_overview.md)

--- a/nvcomp/RunLengthEncodeGPU.cu
+++ b/nvcomp/RunLengthEncodeGPU.cu
@@ -1,0 +1,609 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "RunLengthEncodeGPU.h"
+#include "TempSpaceBroker.h"
+#include "common.h"
+#include "CascadedCommon.h"
+#include "nvcomp.hpp"
+#include "type_macros.h"
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weffc++"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
+#include <cub/device/device_run_length_encode.cuh>
+#include <cub/device/device_scan.cuh>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+#include <cassert>
+#include <stdexcept>
+#include <string>
+
+namespace nvcomp
+{
+
+/******************************************************************************
+ * CONSTANTS ******************************************************************
+ *****************************************************************************/
+
+namespace
+{
+constexpr const size_t ALIGN_OFFSET = 256;
+constexpr const int WARP_SIZE = 32;
+constexpr const int GLOBAL_TILE_SIZE = 1024;
+} // namespace
+
+/******************************************************************************
+ * KENRELS ********************************************************************
+ *****************************************************************************/
+
+namespace
+{
+
+template <typename T, int NUM_THREADS>
+__device__ T warpSum(T const initVal)
+{
+  constexpr const uint32_t mask
+      = NUM_THREADS < WARP_SIZE ? (1u << NUM_THREADS) - 1 : 0xffffffff;
+  T val = initVal;
+  for (int d = NUM_THREADS / 2; d > 0; d /= 2) {
+    val += __shfl_down_sync(mask, val, d, NUM_THREADS);
+  }
+
+  return val;
+}
+
+template <typename T, int BLOCK_SIZE>
+__device__ T cooperativeSum(T const initVal, T* const buffer)
+{
+  // first all warps reduce to single value
+  assert(BLOCK_SIZE % WARP_SIZE == 0);
+  assert(BLOCK_SIZE <= WARP_SIZE * WARP_SIZE);
+
+  T val = warpSum<T, WARP_SIZE>(initVal);
+  if (threadIdx.x % WARP_SIZE == 0) {
+    buffer[threadIdx.x / WARP_SIZE] = val;
+  }
+  __syncthreads();
+
+  if (threadIdx.x < (BLOCK_SIZE / WARP_SIZE)) {
+    val = warpSum<T, BLOCK_SIZE / WARP_SIZE>(buffer[threadIdx.x]);
+  }
+
+  return val;
+}
+
+/**
+ * @brief This kernel produces the block sizes for a prefixsum in a subsequent
+ * kernel.
+ *
+ * @tparam VALUE The value type.
+ * @tparam RUN The run count type.
+ * @param in The input data.
+ * @param num The size of the input data.
+ * @param blockSize The location to write the block sizes (output).
+ */
+template <typename VALUE, typename RUN, int BLOCK_SIZE, int TILE_SIZE>
+__global__ void rleInitKernel(
+    const VALUE* const in,
+    const size_t* const numInDevice,
+    RUN* const blockSize)
+{
+  constexpr const int ITEMS_PER_THREAD = TILE_SIZE / BLOCK_SIZE;
+  // the algorithm here is to keep reducing "chunks" to a start and end marker
+
+  const int num = static_cast<int>(*numInDevice);
+
+  if (blockIdx.x * TILE_SIZE < num) {
+    // we load the preceding value in the first spot
+    __shared__ VALUE valBuffer[TILE_SIZE + 1];
+    __shared__ RUN buffer[BLOCK_SIZE / WARP_SIZE];
+
+    if (threadIdx.x == 0) {
+      valBuffer[0]
+          = blockIdx.x > 0 ? in[blockIdx.x * TILE_SIZE - 1] : (in[0] + 1);
+    }
+    for (int tid = threadIdx.x; tid < TILE_SIZE; tid += BLOCK_SIZE) {
+      const int gTid = tid + blockIdx.x * TILE_SIZE;
+      // cooperatively populate valBuffer and runBuffer
+      if (gTid < num) {
+        valBuffer[tid + 1] = in[gTid];
+      } else {
+        valBuffer[tid + 1] = in[num - 1];
+      }
+    }
+
+    __syncthreads();
+
+    // build bit mask
+    VALUE val = valBuffer[threadIdx.x * ITEMS_PER_THREAD];
+    RUN sum = 0;
+    for (int i = 0; i < ITEMS_PER_THREAD; ++i) {
+      const int tid = threadIdx.x * ITEMS_PER_THREAD + i;
+      const VALUE nextVal = valBuffer[tid + 1];
+      sum += nextVal != val;
+      val = nextVal;
+    }
+
+    sum = cooperativeSum<RUN, BLOCK_SIZE>(sum, buffer);
+    if (threadIdx.x == 0) {
+      blockSize[blockIdx.x] = sum;
+    }
+  } else if (threadIdx.x == 0) {
+    blockSize[blockIdx.x] = 0;
+  }
+
+  if (blockIdx.x == gridDim.x - 1 && threadIdx.x == 0) {
+    blockSize[gridDim.x] = 0;
+  }
+}
+
+template <typename VALUE, typename RUN, int BLOCK_SIZE, int TILE_SIZE>
+__global__ void rleReduceKernel(
+    const VALUE* const in,
+    const size_t* const numInDevice,
+    const RUN* const blockPrefix,
+    RUN* const blockStart,
+    VALUE** const valsPtr,
+    RUN** const runsPtr,
+    size_t* const numOutDevice)
+{
+  constexpr const int ITEMS_PER_THREAD = TILE_SIZE / BLOCK_SIZE;
+  // the algorithm here is to keep reducing "chunks" to a start and end marker
+  const int num = static_cast<int>(*numInDevice);
+
+  if (blockIdx.x * TILE_SIZE < num) {
+    VALUE* const vals = *valsPtr;
+    RUN* const runs = *runsPtr;
+
+    // we load the preceding value in the first spot
+    __shared__ VALUE valBuffer[TILE_SIZE + 1];
+
+    // we store the sum in the last spot
+    __shared__ RUN prefix[BLOCK_SIZE + 1];
+
+    if (threadIdx.x == 0) {
+      valBuffer[0]
+          = blockIdx.x > 0 ? in[blockIdx.x * TILE_SIZE - 1] : (in[0] + 1);
+    }
+    for (int tid = threadIdx.x; tid < TILE_SIZE; tid += BLOCK_SIZE) {
+      const int gTid = tid + blockIdx.x * TILE_SIZE;
+      // cooperatively populate valBuffer and runBuffer
+      if (gTid < num) {
+        valBuffer[tid + 1] = in[gTid];
+      } else {
+        valBuffer[tid + 1] = in[num - 1];
+      }
+    }
+
+    __syncthreads();
+
+    // build bit mask
+    RUN sum = 0;
+    {
+      VALUE val = valBuffer[threadIdx.x * ITEMS_PER_THREAD];
+      for (int i = 0; i < ITEMS_PER_THREAD; ++i) {
+        const int tid = threadIdx.x * ITEMS_PER_THREAD + i;
+        const VALUE nextVal = valBuffer[tid + 1];
+        sum += nextVal != val;
+        val = nextVal;
+      }
+    }
+
+    __syncthreads();
+
+    // prefixsum bit mask
+    {
+      typedef cub::BlockScan<RUN, BLOCK_SIZE> BlockScan;
+      __shared__ typename BlockScan::TempStorage temp_storage;
+
+      BlockScan(temp_storage).ExclusiveSum(sum, sum);
+
+      prefix[threadIdx.x] = sum;
+      if (threadIdx.x == 0) {
+        prefix[BLOCK_SIZE]
+            = blockPrefix[blockIdx.x + 1] - blockPrefix[blockIdx.x];
+      }
+    }
+
+    __syncthreads();
+
+    __shared__ RUN runBuffer[TILE_SIZE + 1];
+
+    // do local run length encoding with an undifferentiated run count
+    {
+      int outIdx = prefix[threadIdx.x];
+      VALUE val = valBuffer[threadIdx.x * ITEMS_PER_THREAD];
+      for (int i = 0; i < ITEMS_PER_THREAD; ++i) {
+        const int tid = threadIdx.x * ITEMS_PER_THREAD + i;
+        const VALUE nextVal = valBuffer[tid + 1];
+        if (nextVal != val) {
+          runBuffer[outIdx] = tid;
+
+          val = nextVal;
+          ++outIdx;
+        }
+      }
+    }
+
+    const RUN numCompacted = prefix[BLOCK_SIZE];
+    if (threadIdx.x == 0) {
+      runBuffer[numCompacted] = ((blockIdx.x + 1) * TILE_SIZE >= num)
+                                    ? ((num - 1) % TILE_SIZE) + 1
+                                    : TILE_SIZE;
+    }
+
+    __syncthreads();
+
+    // write back to global memory
+    const RUN offset = blockPrefix[blockIdx.x];
+    for (int tid = threadIdx.x; tid < numCompacted; tid += BLOCK_SIZE) {
+      // runs still need to be differentiated -- the last one will need to the
+      // number of values
+      vals[offset + tid] = valBuffer[runBuffer[tid] + 1];
+      assert(runBuffer[tid + 1] >= runBuffer[tid]);
+      runs[offset + tid] = runBuffer[tid + 1] - runBuffer[tid];
+    }
+
+    if (threadIdx.x == 0) {
+      blockStart[blockIdx.x] = runBuffer[0] + blockIdx.x * TILE_SIZE;
+    }
+  }
+  if (blockIdx.x == gridDim.x - 1 && threadIdx.x == BLOCK_SIZE - 1) {
+    *numOutDevice = blockPrefix[gridDim.x];
+  }
+}
+
+/**
+ * @brief Fix block join gaps, that is where the run count for a given number
+ * fails to account for duplicates in the following block(s). This requires
+ * that the first run in each block's output, not be differentiated.
+ *
+ * @param runs The almost finished runs.
+ * @param blockPrefix The previously calculated block prefix.
+ * @param num The number of entries.
+ */
+template <typename RUN, int BLOCK_SIZE, int TILE_SIZE>
+__global__ void rleFinalizeKernel(
+    RUN** const runsPtr,
+    const RUN* const blockStart,
+    const RUN* const blockPrefix,
+    const size_t* const numInDevice)
+{
+  const int num = roundUpDiv(static_cast<int>(*numInDevice), TILE_SIZE);
+
+  if (blockIdx.x * BLOCK_SIZE < num) {
+    RUN* const runs = *runsPtr;
+
+    // we load the blocks runs plus 1 extra
+    __shared__ RUN prefixBuffer[BLOCK_SIZE + 1];
+
+    int tid = threadIdx.x + blockIdx.x * BLOCK_SIZE;
+
+    const RUN bp = tid < num ? blockPrefix[tid] : blockPrefix[num];
+    prefixBuffer[threadIdx.x] = bp;
+
+    if (threadIdx.x == 0) {
+      prefixBuffer[BLOCK_SIZE] = blockPrefix[(blockIdx.x + 1) * BLOCK_SIZE];
+    }
+
+    __syncthreads();
+
+    if (tid < num) {
+      if (bp > 0 && (tid + 1 == num || bp < prefixBuffer[threadIdx.x + 1])) {
+        // TODO: make this a binary search
+
+        int low = 0;
+        int high = tid;
+        while (high > low) {
+          const int mid = (low + high) / 2;
+          if (blockPrefix[mid] == bp) {
+            // keep searching down
+            high = mid;
+          } else {
+            // start searching up
+            low = mid + 1;
+          }
+        }
+
+        // we need to fix the count for this block
+        runs[bp - 1] += blockStart[tid] - low * TILE_SIZE;
+      }
+    }
+  }
+}
+} // namespace
+
+/******************************************************************************
+ * HELPER FUNCTIONS ***********************************************************
+ *****************************************************************************/
+
+namespace
+{
+
+template <typename T>
+size_t downstreamWorkspaceSize(const size_t num)
+{
+  return sizeof(T) * std::max(1024ULL, 3ULL * roundUpDiv(num, GLOBAL_TILE_SIZE))
+         + sizeof(int);
+}
+
+template <typename T, typename U>
+size_t requiredWorkspaceSizeTyped(const size_t num)
+{
+  // TODO: this assume large datatype
+  T* inPtr = nullptr;
+  T* valsPtr = nullptr;
+  U* runsPtr = nullptr;
+  size_t* numPtr = nullptr;
+
+  size_t workspaceSize = 0;
+  cudaError_t err = cub::DeviceRunLengthEncode::Encode(
+      nullptr,
+      workspaceSize,
+      inPtr,
+      valsPtr,
+      runsPtr,
+      numPtr,
+      static_cast<int>(num),
+      0);
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        "Failed to get workspace size: " + std::to_string(err));
+  }
+
+  workspaceSize = std::max(workspaceSize, downstreamWorkspaceSize<U>(num));
+
+  return ALIGN_OFFSET + workspaceSize;
+}
+
+template <typename VALUE, typename COUNT>
+void compressInternal(
+    void* const workspace,
+    const size_t workspaceSize,
+    void* const outValues,
+    void* const outCounts,
+    size_t* numOutDevice,
+    void const* const in,
+    size_t const num,
+    cudaStream_t stream)
+{
+  VALUE* const outValuesTyped = static_cast<VALUE*>(outValues);
+  COUNT* const outCountsTyped = static_cast<COUNT*>(outCounts);
+  const VALUE* const inTyped = static_cast<const VALUE*>(in);
+
+  const size_t reqWorkspaceSize = RunLengthEncodeGPU::requiredWorkspaceSize(
+      num, getnvcompType<VALUE>(), getnvcompType<COUNT>());
+  if (workspaceSize < reqWorkspaceSize) {
+    throw std::runtime_error(
+        "Invalid workspace size: " + std::to_string(workspaceSize)
+        + ", need at least " + std::to_string(reqWorkspaceSize));
+  }
+
+  void* const alignedWorkspace = align(workspace, ALIGN_OFFSET);
+  size_t alignedWorkspaceSize
+      = workspaceSize - relativeEndOffset(workspace, alignedWorkspace);
+
+  cudaError_t err = cub::DeviceRunLengthEncode::Encode(
+      alignedWorkspace,
+      alignedWorkspaceSize,
+      inTyped,
+      outValuesTyped,
+      outCountsTyped,
+      numOutDevice,
+      static_cast<int>(num),
+      stream);
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        "Failed to schedule cub::DeviceRunLengthEncode::Encode() kernel: "
+        + std::to_string(err));
+  }
+}
+
+template <typename VALUE, typename COUNT>
+void compressDownstreamInternal(
+    void* const workspace,
+    const size_t workspaceSize,
+    void** const outValuesPtr,
+    void** const outCountsPtr,
+    size_t* numOutDevice,
+    void const* const in,
+    size_t const* numInDevice,
+    const size_t maxNum,
+    cudaStream_t stream)
+{
+  VALUE** const outValuesTypedPtr = reinterpret_cast<VALUE**>(outValuesPtr);
+  COUNT** const outCountsTypedPtr = reinterpret_cast<COUNT**>(outCountsPtr);
+  const VALUE* const inTyped = static_cast<const VALUE*>(in);
+
+  const size_t reqWorkspaceSize = downstreamWorkspaceSize<COUNT>(maxNum);
+  if (workspaceSize < reqWorkspaceSize) {
+    throw std::runtime_error(
+        "Invalid workspace size: " + std::to_string(workspaceSize)
+        + ", need at least " + std::to_string(reqWorkspaceSize));
+  }
+
+  constexpr const int BLOCK_SIZE = 128;
+
+  const dim3 grid(roundUpDiv(maxNum, GLOBAL_TILE_SIZE));
+  const dim3 block(BLOCK_SIZE);
+
+  TempSpaceBroker tempSpace(workspace, workspaceSize);
+
+  COUNT* blockSizes;
+  COUNT* blockPrefix;
+  COUNT* blockStart;
+  tempSpace.reserve(&blockSizes, grid.x);
+  tempSpace.reserve(&blockPrefix, grid.x + 1);
+  tempSpace.reserve(&blockStart, grid.x);
+
+  void* const scanWorkspace = tempSpace.next();
+
+  // TODO: expand such that the mask calculation is done across the entire
+  // array, and the the prefixsum, and then reduction
+
+  // get blocks sizes
+  rleInitKernel<VALUE, COUNT, BLOCK_SIZE, GLOBAL_TILE_SIZE>
+      <<<grid, block, 0, stream>>>(inTyped, numInDevice, blockSizes);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        "Failed to launch rleInitKernel: " + std::to_string(err));
+  }
+
+  // get output locations
+  size_t requiredSpace;
+  err = cub::DeviceScan::ExclusiveSum(
+      nullptr, requiredSpace, blockSizes, blockPrefix, grid.x + 1, stream);
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        "Failed to query rleScanKernel: " + std::to_string(err));
+  }
+
+  size_t scanWorkspaceSize
+      = std::max(1024 * sizeof(COUNT), maxNum * sizeof(COUNT));
+  if (requiredSpace > scanWorkspaceSize) {
+    throw std::runtime_error(
+        "Too little workspace: " + std::to_string(scanWorkspaceSize) + ", need "
+        + std::to_string(requiredSpace));
+  }
+
+  err = cub::DeviceScan::ExclusiveSum(
+      scanWorkspace,
+      scanWorkspaceSize,
+      blockSizes,
+      blockPrefix,
+      grid.x + 1,
+      stream);
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        "Failed to launch rleScanKernel: " + std::to_string(err)
+        + ", with "
+          "grid.x = "
+        + std::to_string(grid.x + 1) + " items.");
+  }
+
+  // do actual compaction
+  rleReduceKernel<VALUE, COUNT, BLOCK_SIZE, GLOBAL_TILE_SIZE>
+      <<<grid, block, 0, stream>>>(
+          inTyped,
+          numInDevice,
+          blockPrefix,
+          blockStart,
+          outValuesTypedPtr,
+          outCountsTypedPtr,
+          numOutDevice);
+  err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        "Failed to launch rleReduceKernel: " + std::to_string(err));
+  }
+
+  // fix gaps
+  rleFinalizeKernel<COUNT, BLOCK_SIZE, GLOBAL_TILE_SIZE>
+      <<<dim3(roundUpDiv(grid.x, block.x)), block, 0, stream>>>(
+          outCountsTypedPtr, blockStart, blockPrefix, numInDevice);
+  err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        "Failed to launch rleFinalizeKernel: " + std::to_string(err));
+  }
+}
+
+} // namespace
+
+/******************************************************************************
+ * PUBLIC STATIC FUNCTIONS ****************************************************
+ *****************************************************************************/
+
+void RunLengthEncodeGPU::compress(
+    void* workspace,
+    size_t workspaceSize,
+    nvcompType_t valueType,
+    void* const outValues,
+    nvcompType_t countType,
+    void* const outCounts,
+    size_t* const numOutDevice,
+    const void* const in,
+    const size_t num,
+    cudaStream_t stream)
+{
+  NVCOMP_TYPE_TWO_SWITCH(
+      valueType,
+      countType,
+      compressInternal,
+      workspace,
+      workspaceSize,
+      outValues,
+      outCounts,
+      numOutDevice,
+      in,
+      num,
+      stream);
+}
+
+void RunLengthEncodeGPU::compressDownstream(
+    void* workspace,
+    size_t workspaceSize,
+    nvcompType_t valueType,
+    void** const outValuesPtr,
+    nvcompType_t countType,
+    void** const outCountsPtr,
+    size_t* const numOutDevice,
+    const void* const in,
+    const size_t* numInDevice,
+    const size_t maxNum,
+    cudaStream_t stream)
+{
+  NVCOMP_TYPE_TWO_SWITCH(
+      valueType,
+      countType,
+      compressDownstreamInternal,
+      workspace,
+      workspaceSize,
+      outValuesPtr,
+      outCountsPtr,
+      numOutDevice,
+      in,
+      numInDevice,
+      maxNum,
+      stream);
+}
+
+size_t RunLengthEncodeGPU::requiredWorkspaceSize(
+    const size_t num, const nvcompType_t valueType, const nvcompType_t runType)
+{
+  NVCOMP_TYPE_TWO_SWITCH_RETURN(
+      valueType, runType, requiredWorkspaceSizeTyped, num);
+}
+
+} // namespace nvcomp

--- a/nvcomp/RunLengthEncodeGPU.h
+++ b/nvcomp/RunLengthEncodeGPU.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NVCOMP_RUNLENGTHENCODEGPU_H
+#define NVCOMP_RUNLENGTHENCODEGPU_H
+
+#include "cascaded.h"
+#include "cuda_runtime.h"
+
+#include <cstddef>
+
+namespace nvcomp
+{
+
+class RunLengthEncodeGPU
+{
+public:
+  /**
+   * @brief Encode a set of data using run length encoding.
+   *
+   * @param workspace Temporary workspace to be used by this operation.
+   * @param workspaceSize The size of the workspace in bytes.
+   * @param valueType The type of outValues and in.
+   * @param outValues The location to save the compressed values to.
+   * @param countType The type to use for storing counts.
+   * @param outCounts The location to save the counts to.
+   * @param numOutDevice The size of outValue and outCounts stored on the
+   * device (output).
+   * @param in The location to read the input from.
+   * @param num The number of values to encode.
+   * @param stream The stream to execute the kernel on.
+   */
+  static void compress(
+      void* workspace,
+      size_t workspaceSize,
+      nvcompType_t valueType,
+      void* const outValues,
+      nvcompType_t countType,
+      void* const outCounts,
+      size_t* numOutDevice,
+      const void* in,
+      const size_t num,
+      cudaStream_t stream);
+
+  /**
+   * @brief Encode a set of data using run length encoding.
+   *
+   * @param workspace Temporary workspace to be used by this operation.
+   * @param workspaceSize The size of the workspace in bytes.
+   * @param valueType The type of outValues and in.
+   * @param outValuesPtr The location to save the compressed values to on the
+   * device.
+   * @param countType The type to use for storing counts.
+   * @param outCountsPtr The location to save the counts to on the device.
+   * @param numOut The size of outValue and outCounts.
+   * @param in The location to read the input from.
+   * @param num The number of values to encode, to be .
+   * @param maxNum The maximum number of values to encode.
+   * @param stream The stream to execute the kernel on.
+   */
+  static void compressDownstream(
+      void* workspace,
+      size_t workspaceSize,
+      nvcompType_t valueType,
+      void** const outValuesPtr,
+      nvcompType_t countType,
+      void** const outCountsPtr,
+      size_t* numOutDevice,
+      const void* in,
+      const size_t* numDevice,
+      const size_t maxNum,
+      cudaStream_t stream);
+
+  /**
+   * @brief Get the required size of the workspace in bytes.
+   *
+   * @param num The number of elements to compress.
+   * @param valueType The type of elements.
+   * @param countType The type to accumulate counts in.
+   *
+   * @return The size in bytes of the required workspace.
+   */
+  static size_t requiredWorkspaceSize(
+      size_t num, nvcompType_t valueType, nvcompType_t countType);
+
+private:
+};
+
+} // namespace nvcomp
+
+#endif

--- a/nvcomp/TempSpaceBroker.cpp
+++ b/nvcomp/TempSpaceBroker.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "TempSpaceBroker.h"
+
+#include <cassert>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace nvcomp
+{
+
+/******************************************************************************
+ * CONSTRUCTORS / DESTRUCTOR **************************************************
+ *****************************************************************************/
+
+TempSpaceBroker::TempSpaceBroker(void* const space, const size_t bytes) :
+    m_base(space),
+    m_size(bytes),
+    m_offset(0)
+{
+  assert(space);
+}
+
+/******************************************************************************
+ * PUBLIC METHODS *************************************************************
+ *****************************************************************************/
+
+size_t TempSpaceBroker::spaceLeft() const
+{
+  return m_size - m_offset;
+}
+
+/******************************************************************************
+ * PRIVATE METHODS ************************************************************
+ *****************************************************************************/
+
+void* TempSpaceBroker::reserve(
+    const size_t alignment, const size_t num, const size_t size)
+{
+  const size_t requiredSize = num * size;
+
+  void* destPtr = next();
+
+  size_t remaining = spaceLeft();
+  if (!std::align(alignment, requiredSize, destPtr, remaining)) {
+    throw std::runtime_error(
+        "Not enough temp space left for " + std::to_string(num)
+        + " values aligned to " + std::to_string(alignment) + ". Only "
+        + std::to_string(remaining) + " bytes of " + std::to_string(m_size)
+        + " bytes remain.");
+  }
+
+  const size_t totalSize = spaceLeft() - remaining + requiredSize;
+  m_offset += totalSize;
+
+  return destPtr;
+}
+
+void* TempSpaceBroker::next() const
+{
+  return static_cast<char*>(m_base) + m_offset;
+}
+
+} // namespace nvcomp

--- a/nvcomp/TempSpaceBroker.h
+++ b/nvcomp/TempSpaceBroker.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef TEMPSPACEBROKER_H
+#define TEMPSPACEBROKER_H
+
+#include <cstddef>
+
+namespace nvcomp
+{
+
+class TempSpaceBroker
+{
+public:
+  /**
+   * @brief Create a new temp space broker.
+   *
+   * @param space The start of the region of memory to use.
+   * @param bytes The size of the region of memory.
+   */
+  TempSpaceBroker(void* space, size_t bytes);
+
+  /**
+   * @brief Reserve a chunk of temp space.
+   *
+   * @tparam T The type of object to reserve space for.
+   * @param ptr The pointer to set to the reserved space.
+   * @param num The number of objects to reserve space for.
+   *
+   * @throws An exception if there is no more space left.
+   */
+  template <typename T>
+  void reserve(T** ptr, const size_t num)
+  {
+    *ptr = reinterpret_cast<T*>(reserve(alignof(T), num, sizeof(T)));
+  }
+
+  /**
+   * @brief Get the number of bytes remaining in this temp space.
+   *
+   * @return The number of bytes.
+   */
+  size_t spaceLeft() const;
+
+  /**
+   * @brief Get the next available temp space. Its size is returned by
+   * `spaceLeft()`.
+   *
+   * NOTE: This space does not get reserved, so any further calls to
+   * `reserve()` may use this space.
+   *
+   * @return The next available space.
+   */
+  void* next() const;
+
+private:
+  void* m_base;
+  size_t m_size;
+  size_t m_offset;
+
+  void* reserve(const size_t alignment, const size_t num, const size_t size);
+};
+
+} // namespace nvcomp
+
+#endif

--- a/nvcomp/cascaded.h
+++ b/nvcomp/cascaded.h
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NVCOMP_CASCADED_H
+#define NVCOMP_CASCADED_H
+
+#include "nvcomp.h"
+
+#include <cuda_runtime.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Structure that stores the compression configuration
+ */
+typedef struct
+{
+  /**
+   * @brief The number of Run Length Encodings to perform.
+   */
+  int num_RLEs;
+
+  /**
+   * @brief The number of Delta Encodings to perform.
+   */
+  int num_deltas;
+
+  /**
+   * @brief Whether or not to bitpack the final layers.
+   */
+  int use_bp;
+} nvcompCascadedFormatOpts;
+
+/**
+ * @brief Extracts the metadata from the input in_ptr on the device and copies
+ * it to the host. This function synchronizes on the stream.
+ *
+ * @param in_ptr The compressed memory on the device.
+ * @param in_bytes The size of the compressed memory on the device.
+ * @param metadata_ptr The metadata on the host to create from the compresesd
+ * data.
+ * @param stream The stream to use for copying from the device to the host.
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompCascadedDecompressGetMetadata(
+    const void* in_ptr,
+    size_t in_bytes,
+    void** metadata_ptr,
+    cudaStream_t stream);
+
+/**
+ * @brief Destroys the metadata object and frees the associated memory.
+ *
+ * @param metadata_ptr The pointer to destroy.
+ */
+void nvcompCascadedDecompressDestroyMetadata(void* metadata_ptr);
+
+/**
+ * @brief Computes the temporary storage size needed to decompress.
+ *
+ * @param metadata_ptr The metadata.
+ * @param temp_bytes The size of temporary workspace required to perform
+ * decomrpession, in bytes (output).
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompCascadedDecompressGetTempSize(
+    const void* metadata_ptr, size_t* temp_bytes);
+
+/**
+ * @brief Computes the decompressed size of the data.
+ *
+ * @param metadata_ptr The metadata.
+ * @param output_bytes The size of the decompressed data in bytes (output).
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompCascadedDecompressGetOutputSize(
+    const void* metadata_ptr, size_t* output_bytes);
+
+/**
+ * @brief Perform the asynchronous decompression.
+ *
+ * @param in_ptr The compressed data on the device to decompress.
+ * @param in_bytes The size of the compressed data.
+ * @param temp_ptr The temporary workspace on the device.
+ * @param temp_bytes The size of the temporary workspace.
+ * @param metadata_ptr The metadata.
+ * @param out_ptr The output location on the device.
+ * @param out_bytes The size of the output location.
+ * @param stream The cuda stream to operate on.
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompCascadedDecompressAsync(
+    const void* in_ptr,
+    size_t in_bytes,
+    void* temp_ptr,
+    size_t temp_bytes,
+    const void* metadata_ptr,
+    void* out_ptr,
+    size_t out_bytes,
+    cudaStream_t stream);
+
+/**
+ * @brief Get the temporary workspace size required to perform compression.
+ *
+ * NOTE: Currently, cascaded compression is limited to 2^31-1 bytes. To
+ * compress larger data, break it up into chunks.
+ *
+ * @param in_ptr The uncompressed data on the device.
+ * @param in_bytes The size of the uncompressed data in bytes.
+ * @param in_type The type of the uncompressed data.
+ * @param format_opts The cascaded format options.
+ * @param temp_bytes The size of the required temporary workspace in bytes
+ * (output).
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompCascadedCompressGetTempSize(
+    const void* in_ptr,
+    size_t in_bytes,
+    nvcompType_t in_type,
+    const nvcompCascadedFormatOpts* format_opts,
+    size_t* temp_bytes);
+
+/**
+ * @brief Get the required output size to perform compression.
+ *
+ * NOTE: Currently, cascaded compression is limited to 2^31-1 bytes. To
+ * compress larger data, break it up into chunks.
+ *
+ * @param in_ptr The uncompressed data on the device.
+ * @param in_bytes The size of the uncompressed data in bytes.
+ * @param in_type The type of the uncompressed data.
+ * @param format_opts The cascaded format options.
+ * @param temp_ptr The temporary workspace on the device.
+ * @param temp_bytes The size of the temporary workspace in bytes.
+ * @param out_bytes The required size of the output location in bytes (output).
+ * @param exact_out_bytes Whether or not to compute the exact number of bytes
+ * needed, or quickly compute a loose upper bound.
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompCascadedCompressGetOutputSize(
+    const void* in_ptr,
+    size_t in_bytes,
+    nvcompType_t in_type,
+    const nvcompCascadedFormatOpts* format_opts,
+    void* temp_ptr,
+    size_t temp_bytes,
+    size_t* out_bytes,
+    int exact_out_bytes);
+
+/**
+ * @brief Perform asynchronous compression. The pointer `out_bytes` must be to
+ * pinned memory for this to be asynchronous.
+ *
+ * NOTE: Currently, cascaded compression is limited to 2^31-1 bytes. To
+ * compress larger data, break it up into chunks.
+ *
+ * @param in_ptr The uncompressed data on the device.
+ * @param in_bytes The size of the uncompressed data in bytes.
+ * @param in_type The data type of the uncompressed data.
+ * @param format_opts The cascaded format options.
+ * @param temp_ptr The temporary workspace on the device.
+ * @param temp_bytes The size of the temporary workspace in bytes.
+ * @param out_ptr The location to write compresesd data to on the device.
+ * @param out_bytes The size of the output location on input, and the size of
+ * the compressed data on output. If pinned memory, the stream must be
+ * synchronized with, before reading.
+ * @param stream The cuda stream to operate on.
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompCascadedCompressAsync(
+    const void* in_ptr,
+    size_t in_bytes,
+    nvcompType_t in_type,
+    const nvcompCascadedFormatOpts* format_opts,
+    void* temp_ptr,
+    size_t temp_bytes,
+    void* out_ptr,
+    size_t* out_bytes,
+    cudaStream_t stream);
+
+
+/**************************************************************************
+ *  Automatically configured API calls
+ *************************************************************************/
+/**
+ * @brief Get the temporary workspace size required to perform compression
+ * (and the selector to determine the best configuration)..
+ *
+ * NOTE: Currently, cascaded compression is limited to 2^31-1 bytes. To
+ * compress larger data, break it up into chunks.
+ *
+ * @param in_ptr The uncompressed data on the device.
+ * @param in_bytes The size of the uncompressed data in bytes.
+ * @param in_type The type of the uncompressed data.
+ * @param temp_bytes The size of the required temporary workspace in bytes
+ * (output).
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompCascadedCompressAutoGetTempSize(
+    const void* in_ptr,
+    size_t in_bytes,
+    nvcompType_t in_type,
+    size_t* temp_bytes);
+
+/**
+ * @brief Get the required output size to perform compression using the
+ * automatically selected best configuration..
+ *
+ * NOTE: Currently, cascaded compression is limited to 2^31-1 bytes. To
+ * compress larger data, break it up into chunks.
+ *
+ * @param in_ptr The uncompressed data on the device.
+ * @param in_bytes The size of the uncompressed data in bytes.
+ * @param in_type The type of the uncompressed data.
+ * @param temp_ptr The temporary workspace on the device.
+ * @param temp_bytes The size of the temporary workspace in bytes.
+ * @param out_bytes The required size of the output location in bytes (output).
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompCascadedCompressAutoGetOutputSize(
+    const void* in_ptr,
+    size_t in_bytes,
+    nvcompType_t in_type,
+    void* temp_ptr,
+    size_t temp_bytes,
+    size_t* out_bytes);
+
+/**
+ * @brief Perform compression by first determining the best configuration for
+ * the input.  Runs synchronously because we first find the configuration to use.
+ * Random sampling is performed and selected using random numbers generated using
+ * the seed provided.
+ *
+ * NOTE: Currently, cascaded compression is limited to 2^31-1 bytes. To
+ * compress larger data, break it up into chunks.
+ *
+ * @param in_ptr The uncompressed data on the device.
+ * @param in_bytes The size of the uncompressed data in bytes.
+ * @param in_type The data type of the uncompressed data.
+ * @param temp_ptr The temporary workspace on the device.
+ * @param temp_bytes The size of the temporary workspace in bytes.
+ * @param out_ptr The location to write compresesd data to on the device.
+ * @param out_bytes The size of the output location on input, and the size of
+ * the compressed data on output. If pinned memory, the stream must be
+ * synchronized with, before reading.
+ * @param seed The seed used for the random generator used in sampling
+ * @param stream The cuda stream to operate on.
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompCascadedCompressAuto(
+    const void* in_ptr,
+    size_t in_bytes,
+    nvcompType_t in_type,
+    void* temp_ptr,
+    size_t temp_bytes,
+    void* out_ptr,
+    size_t* out_bytes,
+    unsigned seed,
+    cudaStream_t stream);
+
+
+/**************************************************************************
+ *  Cascaded Selector types and API calls 
+ *************************************************************************/
+
+/**
+ * @brief Structure that stores options to run Cascaded Selector
+ * NOTE: Minimum values for both parameters is 1, maximum for
+ * sample_size is 1024 and is allso limited by the input size:
+ *        (sample_size * num_samples) <= input_size
+ */
+typedef struct
+{
+  /**
+   * @brief The number of elements used in each sample 
+   * minimum value 1, maximum value 1024
+   */
+  size_t sample_size;
+
+  /**
+   * @brief The number of samples used by the selector
+   * minimum value 1
+   */
+  size_t num_samples;
+
+  /**
+   * @brief The seed used for the random sampling
+   */
+  unsigned seed;
+
+}nvcompCascadedSelectorOpts;
+
+/**
+ * @brief Get the required temporary workspace size needed to run the
+ * cascaded selector.
+ *
+ * @param in_bytes The size of the uncompressed data in bytes.
+ * @param in_type The data type of the uncompressed data.
+ * @param opts The configuration options for the selector.
+ * @param temp_bytes The size of the temporary workspace in bytes (output).
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompCascadedSelectorGetTempSize(
+    size_t in_bytes,
+    nvcompType_t in_type,
+    nvcompCascadedSelectorOpts opts,
+    size_t* temp_bytes);
+
+/**
+ * @brief Run the cascaded selector to determine the best cascaded compression
+ * configuration and estimated compression ratio.
+ *
+ * @param in_ptr The uncompressed data on the device.
+ * @param in_bytes The size of the uncompressed data in bytes.
+ * @param in_type The data type of the uncompressed data.
+ * @param opts The configuration options for the selector.
+ * @param temp_ptr The temporary workspace memory on the device
+ * @param temp_bytes The size of the temporary workspace in bytes 
+ * @param format_opts The best cascaded compression configuration (output)
+ * @param est_ratio The estimated compression ratio using the configuration (output)
+ * @param stream The cuda stream to operate on.
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompCascadedSelectorSelectConfig(
+    const void* in_ptr,
+    size_t in_bytes,
+    nvcompType_t in_type,
+    nvcompCascadedSelectorOpts opts,
+    void* temp_ptr,
+    size_t temp_bytes,
+    nvcompCascadedFormatOpts* format_opts,
+    double* est_ratio,
+    cudaStream_t stream);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/nvcomp/cascaded.hpp
+++ b/nvcomp/cascaded.hpp
@@ -1,0 +1,427 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NVCOMP_CASCADED_HPP
+#define NVCOMP_CASCADED_HPP
+
+#include "cascaded.h"
+#include "nvcomp.hpp"
+#include <chrono>
+
+namespace nvcomp
+{
+
+/**
+ * @brief Primary compressor offered by nvcomp: RLE-Delta w/ bit-packing
+ * Compression and decompression run asynchronously, but compress() requires
+ * that the compressed size (*out_btyes) is known and buffers allocated. Can
+ * define synchronous wrapper that includes size estimation kernel + allocation.
+ *
+ * @tparam T The type to compress.
+ */
+template <typename T>
+class CascadedCompressor : public Compressor<T>
+{
+
+public:
+  /**
+   * @brief Create a new CascadedCompressor.
+   *
+   * NOTE: Currently, cascaded compression is limited to 2^31-1 bytes. To
+   * compress larger data, break it up into chunks.
+   *
+   * @param in_ptr The input data on the GPU to compress.
+   * @param num_elements The number of elements to compress.
+   * @param num_RLEs The number of Run Length encodings to perform.
+   * @param num_deltas The number of Deltas to perform.
+   * @param use_bp Whether or not to bitpack the end result.
+   */
+  CascadedCompressor(
+      const T* in_ptr,
+      const size_t num_elements,
+      int num_RLEs,
+      int num_deltas,
+      bool use_bp);
+
+  /**
+   * @brief Create a new CascadedCompressor without defining the configuration (RLE, delta, bp).
+   * Runs the cascaded selector before compression to determine the configuration.
+   *
+   * NOTE: This the do_compress call synchronous on the CUDA stream.  For Asynchronous execution,
+   * you must select the configuration manually.
+   *
+   * @param in_ptr The input data on the GPU to compress.
+   * @param num_elements The number of elements to compress.
+   */
+  CascadedCompressor(
+      const T* in_ptr,
+      const size_t num_elements);
+
+  // disable copying
+  CascadedCompressor(const CascadedCompressor&) = delete;
+  CascadedCompressor& operator=(const CascadedCompressor&) = delete;
+
+  /**
+   * @brief Get size of the temporary worksace in bytes, required to perform
+   * compression.
+   *
+   * @return The size in bytes.
+   */
+  size_t get_temp_size() override;
+
+  /**
+   * @brief Get the exact size the data will compress to. This can be used in
+   * place of `get_max_output_size()` to get the minimum size of the
+   * allocation that should be passed to `compress()`. This however, may take
+   * similar amount of time to compression itself, and may execute synchronously
+   * on the device.
+   *
+   * For Cascaded compression, this is not yet implemented, and will always
+   * throw an exception.
+   *
+   * @param comp_temp The temporary workspace.
+   * @param comp_temp_bytes THe size of the temporary workspace.
+   *
+   * @return The exact size in bytes.
+   *
+   * @throw NVCompressionException Will always be thrown.
+   */
+  size_t
+  get_exact_output_size(void* comp_temp, size_t comp_temp_bytes) override;
+
+  /**
+   * @brief Get the maximum size the data could compressed to. This is the
+   * upper bound of the minimum size of the allocation that should be
+   * passed to `compress()`.
+   *
+   * @param comp_temp The temporary workspace.
+   * @param comp_temp_bytes THe size of the temporary workspace.
+   *
+   * @return The maximum size in bytes.
+   */
+  size_t get_max_output_size(void* comp_temp, size_t comp_temp_bytes) override;
+
+private:
+  /**
+   * @brief Perform compression asynchronously.
+   *
+   * @param temp_ptr The temporary workspace on the device.
+   * @param temp_bytes The size of the temporary workspace.
+   * @param out_ptr The output location the the device (for compressed data).
+   * @param out_bytes The size of the output location on the device on input,
+   * and the size of the compressed data on output.
+   * @param stream The stream to operate on.
+   *
+   * @throw NVCompException If compression fails to launch on the stream.
+   */
+  void do_compress(
+      void* temp_ptr,
+      size_t temp_bytes,
+      void* out_ptr,
+      size_t* out_bytes,
+      cudaStream_t stream) override;
+
+  nvcompCascadedFormatOpts m_opts;
+};
+
+/******************************************************************************
+ * Cascaded Selector **********************************************************
+ *****************************************************************************/
+/**
+ *@brief Primary class for the Cascaded Selector used to determine the
+ * best configuration to run cascaded compression on a given input.
+ *
+ *@param T the datatype of the input
+ */
+template <typename T>
+class CascadedSelector
+{
+private:
+  const void* input_data;
+  size_t input_byte_len;
+  size_t max_temp_size; // Internal variable used to store the temp buffer size
+  nvcompCascadedSelectorOpts opts; // Sampling options
+
+public:
+  /**
+   *@brief Create a new CascadedSelector for the given input data
+   *
+   *@param input The input data device pointer to select a cheme for
+   *@param byte_len The number of bytes of input data
+   *@param num_sample_ele The number of elements in a sample
+   *@param num_sample The number of samples
+   *@param type The type of input data
+   */
+  CascadedSelector(
+      const void* input, size_t byte_len, nvcompCascadedSelectorOpts opts);
+
+  // disable copying
+  CascadedSelector(const CascadedSelector&) = delete;
+  CascadedSelector& operator=(const CascadedSelector&) = delete;
+
+  /*
+   *@brief return the required size of workspace buffer in bytes
+   */
+  size_t get_temp_size() const;
+
+  /*
+   *@brief Select a CascadedSelector compression scheme that can provide the
+   *best compression ratio and reports estimated compression ratio.
+   *
+   *@param d_worksapce The device potiner for the workspace
+   *@param workspace_len The size of workspace buffer in bytes
+   *@param comp_ratio The estimated compssion ratio using the bbest scheme
+   *(output)
+   *@param stream The input stream to run the select function
+   *@return Selected Cascaded options (RLE, Delta encoding, bit packing)
+   */
+  nvcompCascadedFormatOpts select_config(
+      void* d_workspace,
+      size_t workspace_len,
+      double* comp_ratio,
+      cudaStream_t stream);
+
+  /*
+   *@brief Select a CascadedSelector compression scheme that can provide the
+   *best compression ratio - does NOT return estimated compression ratio.
+   *
+   *@param d_worksapce The device potiner for the workspace
+   *@param workspace_len The size of workspace buffer in bytes
+   *@param stream The input stream to run the select function
+   *@return Selected Cascaded options (RLE, Delta encoding, bit packing)
+   */
+  nvcompCascadedFormatOpts
+  select_config(void* d_workspace, size_t workspace_len, cudaStream_t stream);
+};
+
+/******************************************************************************
+ * METHOD IMPLEMENTATIONS *****************************************************
+ *****************************************************************************/
+
+template <typename T>
+inline CascadedCompressor<T>::CascadedCompressor(
+    const T* const in_ptr,
+    const size_t num_elements,
+    const int num_RLEs,
+    const int num_deltas,
+    const bool use_bp) :
+    Compressor<T>(in_ptr, num_elements),
+    m_opts{num_RLEs, num_deltas, use_bp}
+{
+  // do nothing
+}
+
+template <typename T>
+inline CascadedCompressor<T>::CascadedCompressor(
+    const T* const in_ptr,
+    const size_t num_elements) :
+    Compressor<T>(in_ptr, num_elements),
+    m_opts{-1,-1,-1} // Use -1 as a special maker to run selector
+{
+  // do nothing
+}
+
+template <typename T>
+inline size_t CascadedCompressor<T>::get_temp_size()
+{
+  size_t comp_temp_bytes;
+  if(m_opts.num_RLEs == -1) { // If we need to run the selector
+    nvcompError_t status = nvcompCascadedCompressAutoGetTempSize(
+        this->get_uncompressed_data(),
+        this->get_uncompressed_size(),
+        this->get_type(),
+        &comp_temp_bytes);
+    throwExceptionIfError(status, "GetTempSize failed");
+  }
+  else {
+    nvcompError_t status = nvcompCascadedCompressGetTempSize(
+        this->get_uncompressed_data(),
+        this->get_uncompressed_size(),
+        this->get_type(),
+        &m_opts,
+        &comp_temp_bytes);
+    throwExceptionIfError(status, "GetTempSize failed");
+  }
+
+  return comp_temp_bytes;
+}
+
+template <typename T>
+inline size_t CascadedCompressor<T>::get_exact_output_size(
+    void* const comp_temp, const size_t comp_temp_bytes)
+{
+  size_t comp_out_bytes;
+  if(m_opts.num_RLEs == -1) { // If we need to run the selector
+    throw "Exact output size not supported when using Auto Selector";
+    return 0;
+  }
+  nvcompError_t status = nvcompCascadedCompressGetOutputSize(
+      this->get_uncompressed_data(),
+      this->get_uncompressed_size(),
+      this->get_type(),
+      &m_opts,
+      comp_temp,
+      comp_temp_bytes,
+      &comp_out_bytes,
+      true);
+  throwExceptionIfError(
+      status, "nvcompCascadedCompressGetOutputSize() for exact failed");
+
+  return comp_out_bytes;
+}
+
+template <typename T>
+inline size_t CascadedCompressor<T>::get_max_output_size(
+    void* comp_temp, size_t comp_temp_bytes)
+{
+  size_t comp_out_bytes;
+  if(m_opts.num_RLEs == -1) { // If we need to run the selector
+    nvcompError_t status = nvcompCascadedCompressAutoGetOutputSize(
+        this->get_uncompressed_data(),
+        this->get_uncompressed_size(),
+        this->get_type(),
+        comp_temp,
+        comp_temp_bytes,
+        &comp_out_bytes);
+    throwExceptionIfError(
+        status, "nvcompCascadedCompressGetOutputSize() for in exact failed");
+  }
+  else {
+    nvcompError_t status = nvcompCascadedCompressGetOutputSize(
+        this->get_uncompressed_data(),
+        this->get_uncompressed_size(),
+        this->get_type(),
+        &m_opts,
+        comp_temp,
+        comp_temp_bytes,
+        &comp_out_bytes,
+        false);
+    throwExceptionIfError(
+        status, "nvcompCascadedCompressGetOutputSize() for in exact failed");
+  }
+
+  return comp_out_bytes;
+}
+
+template <typename T>
+inline void CascadedCompressor<T>::do_compress(
+    void* temp_ptr,
+    size_t temp_bytes,
+    void* out_ptr,
+    size_t* out_bytes,
+    cudaStream_t stream)
+{
+
+  unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
+
+  if(m_opts.num_RLEs == -1) { // If we need to run the selector
+    nvcompError_t status = nvcompCascadedCompressAuto(
+        this->get_uncompressed_data(),
+        this->get_uncompressed_size(),
+        this->get_type(),
+        temp_ptr,
+        temp_bytes,
+        out_ptr,
+        out_bytes,
+        seed,
+        stream);
+    throwExceptionIfError(status, "nvcompCascadedCompressAsync() failed");
+  }
+  else {
+    nvcompError_t status = nvcompCascadedCompressAsync(
+        this->get_uncompressed_data(),
+        this->get_uncompressed_size(),
+        this->get_type(),
+        &m_opts,
+        temp_ptr,
+        temp_bytes,
+        out_ptr,
+        out_bytes,
+        stream);
+    throwExceptionIfError(status, "nvcompCascadedCompressAsync() failed");
+  }
+}
+
+template <typename T>
+inline CascadedSelector<T>::CascadedSelector(
+    const void* input,
+    const size_t byte_len,
+    nvcompCascadedSelectorOpts selector_opts) :
+    input_data(input),
+    input_byte_len(byte_len),
+    max_temp_size(0),
+    opts(selector_opts)
+{
+  size_t temp;
+  nvcompError_t status = nvcompCascadedSelectorGetTempSize(
+      input_byte_len, getnvcompType<T>(), opts, &temp);
+  throwExceptionIfError(status, "SelectorGetTempSize failed");
+
+  this->max_temp_size = temp;
+}
+
+template <typename T>
+inline size_t CascadedSelector<T>::get_temp_size() const
+
+{
+  return max_temp_size;
+}
+
+template <typename T>
+inline nvcompCascadedFormatOpts CascadedSelector<T>::select_config(
+    void* d_workspace,
+    size_t workspace_size,
+    double* comp_ratio,
+    cudaStream_t stream)
+{
+  nvcompCascadedFormatOpts cascadedOpts;
+  nvcompError_t status = nvcompCascadedSelectorSelectConfig(
+      input_data,
+      input_byte_len,
+      getnvcompType<T>(),
+      opts,
+      d_workspace,
+      workspace_size,
+      &cascadedOpts,
+      comp_ratio,
+      stream);
+  throwExceptionIfError(status, "SelectorSelectConfig failed");
+
+  return cascadedOpts;
+}
+
+template <typename T>
+inline nvcompCascadedFormatOpts CascadedSelector<T>::select_config(
+    void* d_workspace, size_t workspace_size, cudaStream_t stream)
+{
+  double comp_ratio;
+  return select_config(d_workspace, workspace_size, &comp_ratio, stream);
+}
+
+} // namespace nvcomp
+#endif

--- a/nvcomp/common.h
+++ b/nvcomp/common.h
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2018-2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "nvcomp.h"
+
+#include <cassert>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace nvcomp
+{
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+
+// returns nano-seconds
+inline uint64_t get_time(timespec start, timespec end)
+{
+  constexpr const uint64_t BILLION = 1000000000ULL;
+  const uint64_t elapsed_time
+      = BILLION * (end.tv_sec - start.tv_sec) + end.tv_nsec - start.tv_nsec;
+  return elapsed_time;
+}
+
+// size in bytes, returns GB/s
+inline double gibs(struct timespec start, struct timespec end, size_t s)
+{
+  uint64_t t = get_time(start, end);
+  return (double)s / t * 1e9 / 1024 / 1024 / 1024;
+}
+
+// size in bytes, returns GB/s
+inline double gbs(struct timespec start, struct timespec end, size_t s)
+{
+  uint64_t t = get_time(start, end);
+  return (double)s / t;
+}
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+namespace
+{
+template <typename T>
+T* align(T* const ptr, const size_t alignment)
+{
+  const size_t bits = reinterpret_cast<size_t>(ptr);
+  const size_t mask = alignment - 1;
+
+  return reinterpret_cast<T*>(((bits - 1) | mask) + 1);
+}
+
+template <typename T>
+size_t
+relativeEndOffset(const void* start, const T* subsection, const size_t length)
+{
+  std::ptrdiff_t diff = reinterpret_cast<const char*>(subsection)
+                        - static_cast<const char*>(start);
+  return static_cast<size_t>(diff) + length * sizeof(T);
+}
+
+template <typename T = size_t>
+T relativeEndOffset(const void* start, const void* subsection)
+{
+  std::ptrdiff_t diff = reinterpret_cast<const char*>(subsection)
+                        - static_cast<const char*>(start);
+  return static_cast<T>(diff);
+}
+
+template <typename U, typename T>
+constexpr __host__ __device__ U roundUpDiv(U const num, T const chunk)
+{
+  return (num / chunk) + (num % chunk > 0);
+}
+
+template <typename U, typename T>
+constexpr __host__ __device__ U roundDownTo(U const num, T const chunk)
+{
+  return (num / chunk) * chunk;
+}
+
+template <typename U, typename T>
+constexpr __host__ __device__ U roundUpTo(U const num, T const chunk)
+{
+  return roundUpDiv(num, chunk) * chunk;
+}
+
+} // namespace
+
+__inline__ size_t sizeOfnvcompType(nvcompType_t type)
+{
+  switch (type) {
+  case NVCOMP_TYPE_BITS:
+    return 1;
+  case NVCOMP_TYPE_CHAR:
+    return sizeof(int8_t);
+  case NVCOMP_TYPE_UCHAR:
+    return sizeof(uint8_t);
+  case NVCOMP_TYPE_SHORT:
+    return sizeof(int16_t);
+  case NVCOMP_TYPE_USHORT:
+    return sizeof(uint16_t);
+  case NVCOMP_TYPE_INT:
+    return sizeof(int32_t);
+  case NVCOMP_TYPE_UINT:
+    return sizeof(uint32_t);
+  case NVCOMP_TYPE_LONGLONG:
+    return sizeof(int64_t);
+  case NVCOMP_TYPE_ULONGLONG:
+    return sizeof(uint64_t);
+  default:
+    throw std::runtime_error("Unsupported type " + std::to_string(type));
+  }
+}
+
+} // namespace nvcomp

--- a/nvcomp/lz4.h
+++ b/nvcomp/lz4.h
@@ -1,0 +1,378 @@
+/*
+ * Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NVCOMP_LZ4_H
+#define NVCOMP_LZ4_H
+
+#include "nvcomp.h"
+
+#include <cuda_runtime.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Structure for configuring LZ4 compression.
+ */
+typedef struct
+{
+  /**
+   * @brief The size of each chunk of data to decompress indepentently with
+   * LZ4. Must be within the range of [32768, 16777216]. Larger sizes will
+   * result in higher compression, but with decreased parallelism. The
+   * recommended size is 65536.
+   */
+  size_t chunk_size;
+} nvcompLZ4FormatOpts;
+
+/**
+ * @brief Check if a given chunk of compressed data on the GPU is LZ4.
+ *
+ * @param in_ptr The compressed data.
+ * @param in_bytes The size of the compressed data.
+ * @param stream The stream to fetch data from the GPU on.
+ *
+ * @return 1 If the data is compressed via LZ4.
+ */
+int LZ4IsData(const void* const in_ptr, size_t in_bytes, cudaStream_t stream);
+
+/**
+ * @brief Check if the given CPU-accessible metadata is for LZ4.
+ *
+ * @param metadata_ptr The metadata pointer.
+ *
+ * @return 1 if the data is for LZ4.
+ */
+int LZ4IsMetadata(const void* const metadata_ptr);
+
+/**
+ * @brief Extracts the metadata from the input in_ptr on the device and copies
+ * it to the host. This function synchronizes on the stream.
+ *
+ * @param in_ptr The compressed memory on the device.
+ * @param in_bytes The size of the compressed memory on the device.
+ * @param metadata_ptr The metadata on the host to create from the compresesd
+ * data.
+ * @param stream The stream to use for reading memory from the device.
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompLZ4DecompressGetMetadata(
+    const void* in_ptr,
+    size_t in_bytes,
+    void** metadata_ptr,
+    cudaStream_t stream);
+
+/**
+ * @brief Destroys the metadata object and frees the associated memory.
+ *
+ * @para metadata_ptr The metadata to destroy.
+ */
+void nvcompLZ4DecompressDestroyMetadata(void* metadata_ptr);
+
+/**
+ * @brief Computes the temporary storage size needed to decompress.
+ *
+ * @param metadata_ptr The metadata.
+ * @param temp_bytes The size of temporary workspace required to perform
+ * decomrpession, in bytes (output).
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t
+nvcompLZ4DecompressGetTempSize(const void* metadata_ptr, size_t* temp_bytes);
+
+/**
+ * @brief Computes the decompressed size of the data.
+ *
+ * @param metadata_ptr The metadata.
+ * @param output_bytes The size of the decompressed data in bytes (output).
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompLZ4DecompressGetOutputSize(
+    const void* metadata_ptr, size_t* output_bytes);
+
+/**
+ * @brief Perform the asynchronous decompression.
+ *
+ * @param in_ptr The compressed data on the device to decompress.
+ * @param in_bytes The size of the compressed data.
+ * @param temp_ptr The temporary workspace on the device.
+ * @param temp_bytes The size of the temporary workspace.
+ * @param metadata_ptr The metadata.
+ * @param out_ptr The output location on the device.
+ * @param out_bytes The size of the output location.
+ * @param stream The cuda stream to operate on.
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompLZ4DecompressAsync(
+    const void* const in_ptr,
+    const size_t in_bytes,
+    void* const temp_ptr,
+    const size_t temp_bytes,
+    const void* const metadata_ptr,
+    void* const out_ptr,
+    const size_t out_bytes,
+    cudaStream_t stream);
+
+/**
+ * @brief Get the temporary workspace size required to perform compression.
+ *
+ * @param in_ptr The uncompressed data on the device.
+ * @param in_bytes The size of the uncompressed data in bytes.
+ * @param in_type The type of the uncompressed data.
+ * @param format_opts The lz4 format options.
+ * @param temp_bytes The size of the required temporary workspace in bytes
+ * (output).
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompLZ4CompressGetTempSize(
+    const void* in_ptr,
+    size_t in_bytes,
+    nvcompType_t in_type,
+    const nvcompLZ4FormatOpts* format_opts,
+    size_t* temp_bytes);
+
+/**
+ * @brief Get the required output size to perform compression.
+ *
+ * @param in_ptr The uncompressed data on the device.
+ * @param in_bytes The size of the uncompressed data in bytes.
+ * @param in_type The type of the uncompressed data.
+ * @param format_opts The lz4 format options.
+ * @param temp_ptr The temporary workspace on the device.
+ * @param temp_bytes The size of the temporary workspace in bytes.
+ * @param out_bytes The required size of the output location in bytes (output).
+ * @param exact_out_bytes Whether or not to compute the exact number of bytes
+ * needed, or quickly compute a loose upper bound.
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompLZ4CompressGetOutputSize(
+    const void* in_ptr,
+    size_t in_bytes,
+    nvcompType_t in_type,
+    const nvcompLZ4FormatOpts* format_opts,
+    void* temp_ptr,
+    size_t temp_bytes,
+    size_t* out_bytes,
+    int exact_out_bytes);
+
+/**
+ * @brief Perform asynchronous compression. The pointer `out_bytes` must be to
+ * pinned memory for this to be asynchronous.
+ *
+ * @param in_ptr The uncompressed data on the device.
+ * @param in_bytes The size of the uncompressed data in bytes.
+ * @param in_type The data type of the uncompressed data.
+ * @param format_opts The lz4 format options.
+ * @param temp_ptr The temporary workspace on the device.
+ * @param temp_bytes The size of the temporary workspace in bytes.
+ * @param out_ptr The location to write compresesd data to on the device.
+ * @param out_bytes The size of the output location on input, and the size of
+ * the compressed data on output. If pinned memory, the stream must be
+ * synchronized with, before reading.
+ * @param stream The cuda stream to operate on.
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompLZ4CompressAsync(
+    const void* in_ptr,
+    size_t in_bytes,
+    nvcompType_t in_type,
+    const nvcompLZ4FormatOpts* format_opts,
+    void* temp_ptr,
+    size_t temp_bytes,
+    void* out_ptr,
+    size_t* out_bytes,
+    cudaStream_t stream);
+
+
+/**************************************************************************
+ *  - Experimental - Subject to change -
+ * Batched compression/decompression interface for LZ4
+ * ************************************************************************/
+
+/**
+ * @brief Extracts the metadata from all the input baches in_ptr on the device and copies
+ * them to the host. This function synchronizes on the stream.
+ *
+ * @param in_ptr Array of compressed chunks on the device.
+ * @param in_bytes Array of sizes of the compressed chunks on the device.
+ * @param batch_size Number of chunks in the batch (cardinality of in_bytes and in_ptr)
+ * @param metadata_ptr The batch of metadata on the host to create from all the compresesed
+ * data chunks in the batch.
+ * @param stream The stream to use for reading memory from the device.
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompBatchedLZ4DecompressGetMetadata(
+    const void** in_ptr,
+    const size_t* in_bytes,
+    size_t batch_size,
+    void** metadata_ptr,
+    cudaStream_t stream);
+
+/**
+ * @brief Destroys metadata and frees the associated memory.
+ *
+ * @para metadata_ptr List of metadata to destroy.
+ */
+void nvcompBatchedLZ4DecompressDestroyMetadata(void* metadata_ptr);
+
+/**
+ * @brief Computes the temporary storage size needed to decompress the batch of data.
+ *
+ * @param metadata_ptr The metadata for all compressed chunks in the batch.
+ * @param temp_bytes The size of temporary workspace required to perform
+ * decomrpession of all chunks in the batch, in bytes (output).
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t
+nvcompBatchedLZ4DecompressGetTempSize(const void* metadata_ptr, size_t* temp_bytes);
+
+/**
+ * @brief Computes the decompressed size of each chunk of in the batch.
+ *
+ * @param metadata_ptr The metadata for all compressed chunks.
+ * @param batch_size The number of chunks in the batch (cardinality of output_bytes).
+ * @param output_bytes Array of sizes of the decompressed data in bytes (output).
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompBatchedLZ4DecompressGetOutputSize(
+    const void* metadata_ptr, size_t batch_size, size_t* output_bytes);
+
+/**
+ * @brief Perform the asynchronous decompression on batch of compressed chunks of data.
+ *
+ * @param in_ptr Array of compressed data chunks on the device to decompress.
+ * @param in_bytes The sizes of each chunk of compressed data.
+ * @param batch_size The number of chunks in the batch (cardinality of other inputs).
+ * @param temp_ptr The temporary workspace on the device.
+ * @param temp_bytes The size of the temporary workspace.
+ * @param metadata_ptr The metadata of all chunks in the batch.
+ * @param out_ptr The output location on the device.
+ * @param out_bytes The sizes of each decompressed chunk.
+ * @param stream The cuda stream to operate on.
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompBatchedLZ4DecompressAsync(
+    const void* const* in_ptr,
+    const size_t* in_bytes,
+    size_t batch_size,
+    void* const temp_ptr,
+    const size_t temp_bytes,
+    const void* metadata_ptr,
+    void* const* out_ptr,
+    const size_t* out_bytes,
+    cudaStream_t stream);
+
+/**
+ * @brief Get the temporary workspace size required to perform compression of entire batch.
+ *
+ * @param in_ptr Array of uncompressed data chunks on the device.
+ * @param in_bytes The sizes of each uncompressed data chunk in bytes.
+ * @param batch_size The number of chunks in the batch.
+ * @param format_opts The lz4 format options.
+ * @param temp_bytes The size of the required temporary workspace in bytes to
+ * compress the entire batch (output).
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompBatchedLZ4CompressGetTempSize(
+    const void* const* in_ptr,
+    const size_t* in_bytes,
+    size_t batch_size,
+    const nvcompLZ4FormatOpts* format_opts,
+    size_t* temp_bytes);
+
+/**
+ * @brief Get the required output sizes of each chunk to perform compression.
+ *
+ * @param in_ptr Array of uncompressed chunks on the device.
+ * @param in_bytes The sizes of each uncompressed chunk data in bytes.
+ * @param batch_size The number of chunks in the batch (cardinality of in_ptr and in_bytes).
+ * @param format_opts The lz4 format options.
+ * @param temp_ptr The temporary workspace on the device.
+ * @param temp_bytes The size of the temporary workspace in bytes.
+ * @param out_bytes The required sizes of the output location for each chunk in bytes (output).
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompBatchedLZ4CompressGetOutputSize(
+    const void* const* in_ptr,
+    const size_t* in_bytes,
+    size_t batch_size, 
+    const nvcompLZ4FormatOpts* format_opts,
+    void* temp_ptr,
+    size_t temp_bytes,
+    size_t* out_bytes);
+
+/**
+ * @brief Perform asynchronous compression. The pointer `out_bytes` must be to
+ * pinned memory for this to be asynchronous.
+ *
+ * @param in_ptr Array of uncompressed chunks that make up the batch, on the device.
+ * @param in_bytes The sizes of each chunk of uncompressed data in bytes.
+ * @param batch_size The number of chunks in the entire batch.
+ * @param format_opts The lz4 format options.
+ * @param temp_ptr The temporary workspace on the device.
+ * @param temp_bytes The size of the temporary workspace in bytes.
+ * @param out_ptr The starting location to write all the compresesd chunks to on the device.
+ * @param out_bytes The sizes of each compressed chunk of data, summed up totals the size of
+ * the compressed data on output. If pinned memory, the stream must be
+ * synchronized with, before reading.
+ * @param stream The cuda stream to operate on.
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompBatchedLZ4CompressAsync(
+    const void* const* in_ptr,
+    const size_t* in_bytes,
+    size_t batch_size,
+    const nvcompLZ4FormatOpts* format_opts,
+    void* temp_ptr,
+    size_t temp_bytes,
+    void* const* out_ptr,
+    size_t* out_bytes,
+    cudaStream_t stream);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/nvcomp/lz4.hpp
+++ b/nvcomp/lz4.hpp
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NVCOMP_LZ4_HPP
+#define NVCOMP_LZ4_HPP
+
+#include "lz4.h"
+#include "nvcomp.hpp"
+
+namespace nvcomp
+{
+/**
+ * @brief Alternate compressor offered by nvcomp: LZ4
+ * Compression and decompression run asynchronously, but compress() requires
+ * that the compressed size (*out_bytes) is known and buffers are allocated. Can
+ * define synchronous wrapper that includes size estimation kernel + allocation.
+ * 
+ * @param T the type of element to compress.
+ */
+template <typename T>
+class LZ4Compressor : public Compressor<T>
+{
+public:
+  /**
+   * @brief Default constructor that sets the format opts for the compression
+   * and saves the pointer to the input data to compress
+   *
+   * @param in_ptr The input array to be compressed
+   * @param num_elements size of the input array
+   * @param chunk_size size of chunks that are eached compressed separately.
+   * Controls the temporary storage needed.
+   */
+  LZ4Compressor(const T* in_ptr, size_t num_elements, size_t chunk_size);
+
+  // disable copying
+  LZ4Compressor(const LZ4Compressor&) = delete;
+  LZ4Compressor& operator=(const LZ4Compressor&) = delete;
+
+  /**
+   * @brief Get the size of the temporary buffer required for decompression.
+   *
+   * @return The size in bytes.
+   */
+  size_t get_temp_size() override;
+
+  /**
+   * @brief Get the exact size the data will compress to. This can be used in
+   * place of `get_max_output_size()` to get the minimum size of the
+   * allocation that should be passed to `compress()`. This however, may take
+   * similar amount of time to compression itself, and may execute synchronously
+   * on the device.
+   *
+   * For LZ4Compression, this is not yet implemented, and will always
+   * throw an exception.
+   *
+   * @param comp_temp The temporary workspace.
+   * @param comp_temp_bytes THe size of the temporary workspace.
+   *
+   * @return The exact size in bytes.
+   *
+   * @throw NVCompressionException Will always be thrown.
+   */
+  size_t
+  get_exact_output_size(void* comp_temp, size_t comp_temp_bytes) override;
+
+  /**
+   * @brief Get the maximum size the data could compressed to. This is the
+   * upper bound of the minimum size of the allocation that should be
+   * passed to `compress()`.
+   *
+   * @param comp_temp The temporary workspace.
+   * @param comp_temp_bytes THe size of the temporary workspace.
+   *
+   * @return The maximum size in bytes.
+   */
+  size_t get_max_output_size(void* comp_temp, size_t comp_temp_bytes) override;
+
+private:
+  /**
+   * @brief Perform compression asynchronously.
+   *
+   * @param temp_ptr The temporary workspace on the device.
+   * @param temp_bytes The size of the temporary workspace.
+   * @param out_ptr The output location the the device (for compressed data).
+   * @param out_bytes The size of the output location on the device on input,
+   * and the size of the compressed data on output.
+   * @param stream The stream to operate on.
+   *
+   * @throw NVCompException If compression fails to launch on the stream.
+   */
+  void do_compress(
+      void* temp_ptr,
+      size_t temp_bytes,
+      void* out_ptr,
+      size_t* out_bytes,
+      cudaStream_t stream) override;
+
+  nvcompLZ4FormatOpts m_opts;
+};
+
+/******************************************************************************
+ * METHOD IMPLEMENTATIONS *****************************************************
+ *****************************************************************************/
+
+template <typename T>
+inline LZ4Compressor<T>::LZ4Compressor(
+    const T* in_ptr, const size_t num_elements, const size_t chunk_size) :
+    Compressor<T>(in_ptr, num_elements),
+    m_opts{chunk_size}
+{
+  // do nothing
+}
+
+template <typename T>
+inline size_t LZ4Compressor<T>::get_temp_size()
+{
+  size_t comp_temp_bytes;
+  nvcompError_t status = nvcompLZ4CompressGetTempSize(
+      this->get_uncompressed_data(),
+      this->get_uncompressed_size(),
+      this->get_type(),
+      &m_opts,
+      &comp_temp_bytes);
+  throwExceptionIfError(status, "GetTempSize failed");
+
+  return comp_temp_bytes;
+}
+
+template <typename T>
+inline size_t LZ4Compressor<T>::get_exact_output_size(
+    void* const comp_temp, const size_t comp_temp_bytes)
+{
+  size_t comp_out_bytes;
+  nvcompError_t status = nvcompLZ4CompressGetOutputSize(
+      this->get_uncompressed_data(),
+      this->get_uncompressed_size(),
+      this->get_type(),
+      &m_opts,
+      comp_temp,
+      comp_temp_bytes,
+      &comp_out_bytes,
+      true);
+  throwExceptionIfError(status, "LZ4CompressGetOutputSize() for exact failed");
+
+  return comp_out_bytes;
+}
+
+template <typename T>
+inline size_t LZ4Compressor<T>::get_max_output_size(
+    void* const comp_temp, const size_t comp_temp_bytes)
+{
+  size_t comp_out_bytes;
+  nvcompError_t status = nvcompLZ4CompressGetOutputSize(
+      this->get_uncompressed_data(),
+      this->get_uncompressed_size(),
+      this->get_type(),
+      &m_opts,
+      comp_temp,
+      comp_temp_bytes,
+      &comp_out_bytes,
+      false);
+  throwExceptionIfError(
+      status, "LZ4CompressGetOutputSize() for in exact failed");
+
+  return comp_out_bytes;
+}
+
+template <typename T>
+inline void LZ4Compressor<T>::do_compress(
+    void* const temp_ptr,
+    const size_t temp_bytes,
+    void* const out_ptr,
+    size_t* const out_bytes,
+    cudaStream_t stream)
+{
+  nvcompError_t status = nvcompLZ4CompressAsync(
+      this->get_uncompressed_data(),
+      this->get_uncompressed_size(),
+      this->get_type(),
+      &m_opts,
+      temp_ptr,
+      temp_bytes,
+      out_ptr,
+      out_bytes,
+      stream);
+  throwExceptionIfError(status, "LZ4CompressAsync() failed");
+}
+
+} // namespace nvcomp
+#endif

--- a/nvcomp/nvcomp.h
+++ b/nvcomp/nvcomp.h
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NVCOMP_H
+#define NVCOMP_H
+
+#include <cuda_runtime.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/******************************************************************************
+ * CONSTANTS ******************************************************************
+ *****************************************************************************/
+
+#define NVCOMP_MAJOR_VERSION 1
+#define NVCOMP_MINOR_VERSION 2
+#define NVCOMP_PATCH_VERSION 2
+
+typedef enum nvcompError_t
+{
+  nvcompSuccess = 0,
+  nvcompErrorInvalidValue = 10,
+  nvcompErrorNotSupported = 11,
+  nvcompErrorCudaError = 1000,
+  nvcompErrorInternal = 10000
+} nvcompError_t;
+
+/* Supported datatypes */
+typedef enum nvcompType_t
+{
+  NVCOMP_TYPE_CHAR = 0,      // 1B
+  NVCOMP_TYPE_UCHAR = 1,     // 1B
+  NVCOMP_TYPE_SHORT = 2,     // 2B
+  NVCOMP_TYPE_USHORT = 3,    // 2B
+  NVCOMP_TYPE_INT = 4,       // 4B
+  NVCOMP_TYPE_UINT = 5,      // 4B
+  NVCOMP_TYPE_LONGLONG = 6,  // 8B
+  NVCOMP_TYPE_ULONGLONG = 7, // 8B
+  NVCOMP_TYPE_BITS = 0xff    // 1b
+} nvcompType_t;
+
+/******************************************************************************
+ * FUNCTION PROTOTYPES ********************************************************
+ *****************************************************************************/
+
+/**
+ * @brief Extracts the metadata from the input in_ptr on the device and copies
+ *it to the host.
+ *
+ * @param in_ptr The compressed memory on the device.
+ * @param in_bytes The size of the compressed memory on the device.
+ * @param metadata_ptr The metadata on the host to create from the compresesd
+ * data.
+ * @param stream The stream to use for reading memory from the device.
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompDecompressGetMetadata(
+    const void* in_ptr,
+    size_t in_bytes,
+    void** metadata_ptr,
+    cudaStream_t stream);
+
+/**
+ * @brief Destroys the metadata object and frees the associated memory.
+ *
+ * @param metadata_ptr The pointer to destroy.
+ */
+void nvcompDecompressDestroyMetadata(void* metadata_ptr);
+
+/**
+ * @brief Computes the required temporary workspace required to perform
+ * decompression.
+ *
+ * @para metadata_ptr The metadata.
+ * @param temp_bytes The size of the required temporary workspace in bytes
+ * (output).
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t
+nvcompDecompressGetTempSize(const void* metadata_ptr, size_t* temp_bytes);
+
+/**
+ * @brief Computes the size of the uncompressed data in bytes.
+ *
+ * @para metadata_ptr The metadata.
+ * @param output_bytes The size of the uncompressed data (output).
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t
+nvcompDecompressGetOutputSize(const void* metadata_ptr, size_t* output_bytes);
+
+/**
+ * @brief Get the type of the compressed data.
+ *
+ * @param metadata_ptr The metadata.
+ * @param type The data type (output).
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t
+nvcompDecompressGetType(const void* metadata_ptr, nvcompType_t* type);
+
+/**
+ * @brief Check if the compressed data must be decompressed to the same data
+ * type from which was compressed.
+ *
+ * @param metadata_ptr The metadata.
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+int nvcompDecompressIsTypeSensitive(const void* metadata_ptr);
+
+/**
+ * @brief Perform the asynchronous decompression.
+ *
+ * @param in_ptr The compressed data on the device to decompress.
+ * @param in_bytes The size of the compressed data.
+ * @param temp_ptr The temporary workspace on the device.
+ * @param temp_bytes The size of the temporary workspace.
+ * @param metadata_ptr The metadata.
+ * @param out_ptr The output location on the device.
+ * @param out_bytes The size of the output location.
+ * @param stream The cuda stream to operate on.
+ *
+ * @return nvcompSuccess if successful, and an error code otherwise.
+ */
+nvcompError_t nvcompDecompressAsync(
+    const void* in_ptr,
+    size_t in_bytes,
+    void* temp_ptr,
+    size_t temp_bytes,
+    const void* metadata_ptr,
+    void* out_ptr,
+    size_t out_bytes,
+    cudaStream_t stream);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/nvcomp/nvcomp.hpp
+++ b/nvcomp/nvcomp.hpp
@@ -1,0 +1,462 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NVCOMP_API_HPP
+#define NVCOMP_API_HPP
+
+#include "nvcomp.h"
+#include "lz4.h"
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace nvcomp
+{
+
+/******************************************************************************
+ * CLASSES ********************************************************************
+ *****************************************************************************/
+
+/**
+ * @brief The top-level exception throw by nvcomp C++ methods.
+ */
+class NVCompException : public std::runtime_error
+{
+public:
+  /**
+   * @brief Create a new NVCompException.
+   *
+   * @param err The error associated with the exception.
+   * @param msg The error message.
+   */
+  NVCompException(nvcompError_t err, const std::string& msg) :
+      std::runtime_error(msg + " : code=" + std::to_string(err) + "."),
+      m_err(err)
+  {
+    // do nothing
+  }
+
+  nvcompError_t get_error() const
+  {
+    return m_err;
+  }
+
+private:
+  nvcompError_t m_err;
+};
+
+/**
+ * @brief Top-level compressor class. This class takes in data on the device,
+ * and compresses it to another location on the device.
+ *
+ * @tparam T The type of element to compress.
+ */
+template <typename T>
+class Compressor
+{
+public:
+  /**
+   * @brief Create a new compressor with the given input elements. The input
+   * elements must remain available at the given memory location until
+   * compression is finished executing.
+   *
+   * @param in_elements The input elements on the device.
+   * @param num_in_elements The number of input elements.
+   *
+   * @throw NVCompressionExcpetion If `in_elements` is null.
+   */
+  Compressor(const T* in_elements, const size_t num_in_elements);
+
+  // disable copying
+  Compressor(const Compressor& other) = delete;
+  Compressor& operator=(const Compressor& other) = delete;
+
+  /**
+   * @brief Virtual destructor.
+   */
+  virtual ~Compressor() = default;
+
+  /**
+   * @brief Launch asynchronous compression. If the `out_bytes` is pageable
+   * memory, this method will block.
+   *
+   * @param temp_ptr The temporary workspace on the device.
+   * @param temp_bytes The size of the temporary workspace.
+   * @param out_ptr The output location the the device (for compressed data).
+   * @param out_bytes The size of the output location on the device on input,
+   * and the size of the compressed data on output.
+   * @param stream The stream to operate on.
+   *
+   * @throw NVCompException If compression fails to launch on the stream.
+   */
+  void compress_async(
+      void* temp_ptr,
+      size_t temp_bytes,
+      void* out_ptr,
+      size_t* out_bytes,
+      cudaStream_t stream);
+
+  /**
+   * @brief Get the data type being compressed by this compressor.
+   *
+   * @return The data type.
+   */
+  nvcompType_t get_type() const;
+
+  /**
+   * @brief Get the size of the uncompressed data in bytes.
+   *
+   * @return The size in bytes.
+   */
+  size_t get_uncompressed_size() const;
+
+  /**
+   * @brief Get the memory location of the uncompressed data.
+   *
+   * @return The uncompressed data.
+   */
+  const T* get_uncompressed_data() const;
+
+  /**
+   * @brief Get size of the temporary worksace in bytes, required to perform
+   * compression.
+   *
+   * @return The size in bytes.
+   */
+  virtual size_t get_temp_size() = 0;
+
+  /**
+   * @brief Get the maximum size the data could compressed to. This is the
+   * minimum size of the allocation that should be passed to `compress()`.
+   *
+   * @param comp_temp The temporary workspace.
+   * @param comp_temp_bytes THe size of the temporary workspace.
+   *
+   * @return The maximum size in bytes.
+   */
+  virtual size_t get_max_output_size(void* comp_temp, size_t comp_temp_bytes)
+      = 0;
+
+  /**
+   * @brief Get the exact size the data will compress to. This can be used in
+   * place of `get_max_output_size()` to get the minimum size of the
+   * allocation that should be passed to `compress()`. This however, may take
+   * similar amount of time to compression itself, and may execute synchronously
+   * on the device.
+   *
+   * NOTE: Some compression implementation may choose not to implement this, and
+   * instead this method will throw an exception.
+   *
+   * @param comp_temp The temporary workspace.
+   * @param comp_temp_bytes THe size of the temporary workspace.
+   *
+   * @return The exact size in bytes.
+   *
+   * @throw NVCompressionException If the exact output size cannot be
+   * determined.
+   */
+  virtual size_t get_exact_output_size(void* comp_temp, size_t comp_temp_bytes);
+
+private:
+  /**
+   * @brief Child classes implementing compression, should implement this
+   * method, rather than the `compress()` method.
+   *
+   * @param temp_ptr The temporary workspace on the device.
+   * @param temp_bytes The size of the temporary workspace.
+   * @param out_ptr The output location the the device (for compressed data).
+   * @param out_bytes The size of the output location on the device on input,
+   * and the size of the compressed data on output.
+   * @param stream The stream to operate on.
+   *
+   * @throw NVCompException If compression fails to launch on the stream.
+   */
+  virtual void do_compress(
+      void* temp_ptr,
+      size_t temp_bytes,
+      void* out_ptr,
+      size_t* out_bytes,
+      cudaStream_t stream)
+      = 0;
+
+  // Member variables
+  const T* m_in_elements;
+  size_t m_num_in_elements;
+};
+
+/**
+ * @brief Top-level decompress class. The compression type is read from the
+ * metadata at the start of the compressed data.
+ *
+ * @tparam T The type to decompress to.
+ */
+template <typename T>
+class Decompressor
+{
+
+public:
+  /**
+   * @brief Create a new Decompressor object. This method synchronizes with the
+   * passed in stream.
+   *
+   * @param compressed_data The compressed data on the device to decompress.
+   * @param compressed_data_size The size of the compressed data.
+   * @param stream The stream to use to retrieve metadata from the device.
+   *
+   * @throw NVCompressionExcpetion If the metadata cannot be read from the
+   * device.
+   */
+  Decompressor(
+      const void* const compressed_data,
+      const size_t compressed_data_size,
+      cudaStream_t stream);
+
+  // disable copying
+  Decompressor(const Decompressor& other) = delete;
+  Decompressor& operator=(const Decompressor& other) = delete;
+
+  /**
+   * @brief Decompress the given data asynchronously.
+   *
+   * @param temp_ptr The temporary workspace on the device to use.
+   * @param temp_bytes The size of the temporary workspace.
+   * @param out_ptr The location to write the uncompressed data to on the
+   * device.
+   * @param out_num_elements The size of the output location in number of
+   * elements.
+   * @param stream The stream to operate on.
+   *
+   * @throw NVCompException If decompression fails to launch on the stream.
+   */
+  void decompress_async(
+      void* const temp_ptr,
+      const size_t temp_bytes,
+      T* const out_ptr,
+      const size_t out_num_elements,
+      cudaStream_t stream);
+
+  /**
+   * @brief Get the size of the temporary buffer required for decompression.
+   *
+   * @return The size in bytes.
+   */
+  size_t get_temp_size();
+
+  /**
+   * @brief Get the size of the output buffer in bytes.
+   *
+   * @return The size in bytes.
+   */
+  size_t get_output_size();
+
+  /**
+   * @brief Get the number of elements that will be decompressed.
+   *
+   * @return The number of elements.
+   */
+  size_t get_num_elements();
+
+private:
+  std::unique_ptr<void, void (*)(void*)> m_metadata;
+  const void* m_compressed_data;
+  size_t m_compressed_data_size;
+};
+
+/******************************************************************************
+ * INLINE DEFINITIONS AND HELPER FUNCTIONS ************************************
+ *****************************************************************************/
+
+template <typename T>
+inline nvcompType_t getnvcompType()
+{
+  if (std::is_same<T, int8_t>::value) {
+    return NVCOMP_TYPE_CHAR;
+  } else if (std::is_same<T, uint8_t>::value) {
+    return NVCOMP_TYPE_UCHAR;
+  } else if (std::is_same<T, int16_t>::value) {
+    return NVCOMP_TYPE_SHORT;
+  } else if (std::is_same<T, uint16_t>::value) {
+    return NVCOMP_TYPE_USHORT;
+  } else if (std::is_same<T, int32_t>::value) {
+    return NVCOMP_TYPE_INT;
+  } else if (std::is_same<T, uint32_t>::value) {
+    return NVCOMP_TYPE_UINT;
+  } else if (std::is_same<T, int64_t>::value) {
+    return NVCOMP_TYPE_LONGLONG;
+  } else if (std::is_same<T, uint64_t>::value) {
+    return NVCOMP_TYPE_ULONGLONG;
+  } else {
+    throw NVCompException(
+        nvcompErrorNotSupported, "nvcomp does not support the given type.");
+  }
+}
+
+inline void throwExceptionIfError(nvcompError_t error, const std::string& msg)
+{
+  if (error != nvcompSuccess) {
+    throw NVCompException(error, msg);
+  }
+}
+
+template <typename T>
+inline Compressor<T>::Compressor(
+    const T* const in_elements, const size_t num_in_elements) :
+    m_in_elements(in_elements),
+    m_num_in_elements(num_in_elements)
+{
+  // do nothing
+}
+
+template <typename T>
+inline void Compressor<T>::compress_async(
+    void* const temp_ptr,
+    const size_t temp_bytes,
+    void* const out_ptr,
+    size_t* const out_bytes,
+    cudaStream_t stream)
+{
+  // Splitting into compress/do_compress allows putting extra logic in the
+  // base class that all derived types should have, e.g., logging.
+  return do_compress(temp_ptr, temp_bytes, out_ptr, out_bytes, stream);
+}
+
+template <typename T>
+inline nvcompType_t Compressor<T>::get_type() const
+{
+  return getnvcompType<T>();
+}
+
+template <typename T>
+inline size_t Compressor<T>::get_uncompressed_size() const
+{
+  return sizeof(*m_in_elements) * m_num_in_elements;
+}
+
+template <typename T>
+inline const T* Compressor<T>::get_uncompressed_data() const
+{
+  return m_in_elements;
+}
+
+template <typename T>
+inline size_t Compressor<T>::get_exact_output_size(
+    void* const /* comp_temp */, const size_t /* comp_temp_bytes */)
+{
+  throw NVCompException(
+      nvcompErrorNotSupported,
+      "Getting the exact output "
+      "buffer size is not supported by this compressor.");
+}
+
+template <typename T>
+inline Decompressor<T>::Decompressor(
+    const void* const compressed_data,
+    const size_t compressed_data_size,
+    cudaStream_t stream) :
+    m_metadata(nullptr, nvcompDecompressDestroyMetadata),
+    m_compressed_data(compressed_data),
+    m_compressed_data_size(compressed_data_size)
+{
+  void* ptr;
+  nvcompError_t err = nvcompDecompressGetMetadata(
+      m_compressed_data, m_compressed_data_size, &ptr, stream);
+  throwExceptionIfError(err, "Failed to get metadata");
+
+  m_metadata.reset(ptr);
+
+  // verify template type compatibility
+  if (!LZ4IsMetadata(m_metadata.get())) {
+    // lz4 is type independent
+    nvcompType_t type;
+    err = nvcompDecompressGetType(m_metadata.get(), &type);
+    throwExceptionIfError(err, "Failed to get metadata");
+
+    if (type != getnvcompType<T>()) {
+      throw NVCompException(
+          nvcompErrorInvalidValue,
+          "Template type is "
+          "not compatible with compressed type.");
+    }
+  }
+}
+
+template <typename T>
+inline void Decompressor<T>::decompress_async(
+    void* const temp_ptr,
+    const size_t temp_bytes,
+    T* const out_ptr,
+    const size_t out_num_elements,
+    cudaStream_t stream)
+{
+  const size_t num_bytes = out_num_elements * sizeof(*out_ptr);
+
+  nvcompError_t err = nvcompDecompressAsync(
+      m_compressed_data,
+      m_compressed_data_size,
+      temp_ptr,
+      temp_bytes,
+      m_metadata.get(),
+      out_ptr,
+      num_bytes,
+      stream);
+  throwExceptionIfError(err, "Failed to launch async decompression");
+}
+
+template <typename T>
+inline size_t Decompressor<T>::get_temp_size()
+{
+  size_t bytes;
+  nvcompError_t err = nvcompDecompressGetTempSize(m_metadata.get(), &bytes);
+  throwExceptionIfError(
+      err,
+      "Failed to get temporary workspace size needed "
+      "to decompress data: ");
+
+  return bytes;
+}
+
+template <typename T>
+inline size_t Decompressor<T>::get_output_size()
+{
+  size_t bytes;
+  nvcompError_t err = nvcompDecompressGetOutputSize(m_metadata.get(), &bytes);
+  throwExceptionIfError(err, "Failed to get decompressed size of data");
+
+  return bytes;
+}
+
+template <typename T>
+inline size_t Decompressor<T>::get_num_elements()
+{
+  return get_output_size() / sizeof(T);
+}
+
+} // namespace nvcomp
+
+#endif

--- a/nvcomp/nvcomp_api.cpp
+++ b/nvcomp/nvcomp_api.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Metadata.h"
+#include "cascaded.h"
+#include "lz4.h"
+#include "nvcomp.h"
+
+#include <iostream>
+
+// TODO: these all assume cascaded is being used
+
+using namespace nvcomp;
+
+nvcompError_t nvcompDecompressGetMetadata(
+    const void* const in_ptr,
+    const size_t in_bytes,
+    void** const metadata_ptr,
+    cudaStream_t stream)
+{
+  if (LZ4IsData(in_ptr, in_bytes, stream)) {
+    return nvcompLZ4DecompressGetMetadata(
+        in_ptr, in_bytes, metadata_ptr, stream);
+  }
+  else {
+    return nvcompCascadedDecompressGetMetadata(
+        in_ptr, in_bytes, metadata_ptr, stream);
+  }
+}
+
+void nvcompDecompressDestroyMetadata(void* const metadata_ptr)
+{
+  if (LZ4IsMetadata(metadata_ptr)) {
+    nvcompLZ4DecompressDestroyMetadata(metadata_ptr);
+  } else {
+    nvcompCascadedDecompressDestroyMetadata(metadata_ptr);
+  }
+}
+
+nvcompError_t nvcompDecompressGetTempSize(
+    const void* const metadata_ptr, size_t* const temp_bytes)
+{
+  if (LZ4IsMetadata(metadata_ptr)) {
+    return nvcompLZ4DecompressGetTempSize(metadata_ptr, temp_bytes);
+  }
+  return nvcompCascadedDecompressGetTempSize(metadata_ptr, temp_bytes);
+}
+
+nvcompError_t nvcompDecompressGetOutputSize(
+    const void* const metadata_ptr, size_t* const output_bytes)
+{
+  if (metadata_ptr == nullptr) {
+    std::cerr << "Cannot get the output size from a null metadata."
+              << std::endl;
+    return nvcompErrorInvalidValue;
+  }
+  if (output_bytes == nullptr) {
+    std::cerr << "Cannot write the output size to a null location."
+              << std::endl;
+    return nvcompErrorInvalidValue;
+  }
+
+  const Metadata* const metadata = static_cast<const Metadata*>(metadata_ptr);
+  *output_bytes = metadata->getUncompressedSize();
+
+  return nvcompSuccess;
+}
+
+nvcompError_t nvcompDecompressGetType(
+    const void* const metadata_ptr, nvcompType_t* const type)
+{
+  if (metadata_ptr == nullptr) {
+    std::cerr << "Cannot get the type from a null metadata." << std::endl;
+    return nvcompErrorInvalidValue;
+  }
+  if (type == nullptr) {
+    std::cerr << "Cannot write the typeto a null location." << std::endl;
+    return nvcompErrorInvalidValue;
+  }
+
+  if (LZ4IsMetadata(metadata_ptr)) {
+    // LZ4 always operates on bytes
+    *type = NVCOMP_TYPE_CHAR;
+  }
+  else {
+    const Metadata* const metadata = static_cast<const Metadata*>(metadata_ptr);
+    *type = metadata->getValueType();
+  }
+
+  return nvcompSuccess;
+}
+
+nvcompError_t nvcompDecompressAsync(
+    const void* const in_ptr,
+    const size_t in_bytes,
+    void* const temp_ptr,
+    const size_t temp_bytes,
+    const void* const metadata_ptr,
+    void* const out_ptr,
+    const size_t out_bytes,
+    cudaStream_t stream)
+{
+  if (LZ4IsMetadata(metadata_ptr)) {
+    return nvcompLZ4DecompressAsync(
+        in_ptr,
+        in_bytes,
+        temp_ptr,
+        temp_bytes,
+        metadata_ptr,
+        out_ptr,
+        out_bytes,
+        stream);
+  }
+  else {
+    return nvcompCascadedDecompressAsync(
+        in_ptr,
+        in_bytes,
+        temp_ptr,
+        temp_bytes,
+        metadata_ptr,
+        out_ptr,
+        out_bytes,
+        stream);
+  }
+}

--- a/nvcomp/type_macros.h
+++ b/nvcomp/type_macros.h
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NVCOMP_TYPEMACROS_H
+#define NVCOMP_TYPEMACROS_H
+
+#include <stdexcept>
+#include <string>
+
+/******************************************************************************
+ * DEFINES ********************************************************************
+ *****************************************************************************/
+
+#define NVCOMP_TYPE_TWO_SWITCH_FIRST_ONLY(type_var, second_type, func, ...)    \
+  do {                                                                         \
+    switch (type_var) {                                                        \
+    case NVCOMP_TYPE_CHAR:                                                     \
+      func<int8_t, second_type>(__VA_ARGS__);                                  \
+      break;                                                                   \
+    case NVCOMP_TYPE_UCHAR:                                                    \
+      func<uint8_t, second_type>(__VA_ARGS__);                                 \
+      break;                                                                   \
+    case NVCOMP_TYPE_SHORT:                                                    \
+      func<int16_t, second_type>(__VA_ARGS__);                                 \
+      break;                                                                   \
+    case NVCOMP_TYPE_USHORT:                                                   \
+      func<uint16_t, second_type>(__VA_ARGS__);                                \
+      break;                                                                   \
+    case NVCOMP_TYPE_INT:                                                      \
+      func<int32_t, second_type>(__VA_ARGS__);                                 \
+      break;                                                                   \
+    case NVCOMP_TYPE_UINT:                                                     \
+      func<uint32_t, second_type>(__VA_ARGS__);                                \
+      break;                                                                   \
+    case NVCOMP_TYPE_LONGLONG:                                                 \
+      func<int64_t, second_type>(__VA_ARGS__);                                 \
+      break;                                                                   \
+    case NVCOMP_TYPE_ULONGLONG:                                                \
+      func<uint64_t, second_type>(__VA_ARGS__);                                \
+      break;                                                                   \
+    default:                                                                   \
+      throw std::runtime_error("Unknown type: " + std::to_string(type_var));   \
+    }                                                                          \
+  } while (0)
+
+#define NVCOMP_TYPE_TWO_SWITCH(type1_var, type2_var, func, ...)                \
+  do {                                                                         \
+    switch (type2_var) {                                                       \
+    case NVCOMP_TYPE_CHAR:                                                     \
+      NVCOMP_TYPE_TWO_SWITCH_FIRST_ONLY(type1_var, int8_t, func, __VA_ARGS__); \
+      break;                                                                   \
+    case NVCOMP_TYPE_UCHAR:                                                    \
+      NVCOMP_TYPE_TWO_SWITCH_FIRST_ONLY(                                       \
+          type1_var, uint8_t, func, __VA_ARGS__);                              \
+      break;                                                                   \
+    case NVCOMP_TYPE_SHORT:                                                    \
+      NVCOMP_TYPE_TWO_SWITCH_FIRST_ONLY(                                       \
+          type1_var, int16_t, func, __VA_ARGS__);                              \
+      break;                                                                   \
+    case NVCOMP_TYPE_USHORT:                                                   \
+      NVCOMP_TYPE_TWO_SWITCH_FIRST_ONLY(                                       \
+          type1_var, uint16_t, func, __VA_ARGS__);                             \
+      break;                                                                   \
+    case NVCOMP_TYPE_INT:                                                      \
+      NVCOMP_TYPE_TWO_SWITCH_FIRST_ONLY(                                       \
+          type1_var, int32_t, func, __VA_ARGS__);                              \
+      break;                                                                   \
+    case NVCOMP_TYPE_UINT:                                                     \
+      NVCOMP_TYPE_TWO_SWITCH_FIRST_ONLY(                                       \
+          type1_var, uint32_t, func, __VA_ARGS__);                             \
+      break;                                                                   \
+    case NVCOMP_TYPE_LONGLONG:                                                 \
+      NVCOMP_TYPE_TWO_SWITCH_FIRST_ONLY(                                       \
+          type1_var, int64_t, func, __VA_ARGS__);                              \
+      break;                                                                   \
+    case NVCOMP_TYPE_ULONGLONG:                                                \
+      NVCOMP_TYPE_TWO_SWITCH_FIRST_ONLY(                                       \
+          type1_var, uint64_t, func, __VA_ARGS__);                             \
+      break;                                                                   \
+    default:                                                                   \
+      throw std::runtime_error("Unknown type: " + std::to_string(type2_var));  \
+    }                                                                          \
+  } while (0)
+
+#define NVCOMP_TYPE_TWO_SWITCH_FIRST_ONLY_RETURN(                              \
+    type_var, second_type, func, ...)                                          \
+  do {                                                                         \
+    switch (type_var) {                                                        \
+    case NVCOMP_TYPE_CHAR:                                                     \
+      return func<int8_t, second_type>(__VA_ARGS__);                           \
+    case NVCOMP_TYPE_UCHAR:                                                    \
+      return func<uint8_t, second_type>(__VA_ARGS__);                          \
+    case NVCOMP_TYPE_SHORT:                                                    \
+      return func<int16_t, second_type>(__VA_ARGS__);                          \
+    case NVCOMP_TYPE_USHORT:                                                   \
+      return func<uint16_t, second_type>(__VA_ARGS__);                         \
+    case NVCOMP_TYPE_INT:                                                      \
+      return func<int32_t, second_type>(__VA_ARGS__);                          \
+    case NVCOMP_TYPE_UINT:                                                     \
+      return func<uint32_t, second_type>(__VA_ARGS__);                         \
+    case NVCOMP_TYPE_LONGLONG:                                                 \
+      return func<int64_t, second_type>(__VA_ARGS__);                          \
+    case NVCOMP_TYPE_ULONGLONG:                                                \
+      return func<uint64_t, second_type>(__VA_ARGS__);                         \
+    default:                                                                   \
+      throw std::runtime_error("Unknown type: " + std::to_string(type_var));   \
+    }                                                                          \
+  } while (0)
+
+#define NVCOMP_TYPE_TWO_SWITCH_RETURN(type1_var, type2_var, func, ...)         \
+  do {                                                                         \
+    switch (type2_var) {                                                       \
+    case NVCOMP_TYPE_CHAR:                                                     \
+      NVCOMP_TYPE_TWO_SWITCH_FIRST_ONLY_RETURN(                                \
+          type1_var, int8_t, func, __VA_ARGS__);                               \
+    case NVCOMP_TYPE_UCHAR:                                                    \
+      NVCOMP_TYPE_TWO_SWITCH_FIRST_ONLY_RETURN(                                \
+          type1_var, uint8_t, func, __VA_ARGS__);                              \
+    case NVCOMP_TYPE_SHORT:                                                    \
+      NVCOMP_TYPE_TWO_SWITCH_FIRST_ONLY_RETURN(                                \
+          type1_var, int16_t, func, __VA_ARGS__);                              \
+    case NVCOMP_TYPE_USHORT:                                                   \
+      NVCOMP_TYPE_TWO_SWITCH_FIRST_ONLY_RETURN(                                \
+          type1_var, uint16_t, func, __VA_ARGS__);                             \
+    case NVCOMP_TYPE_INT:                                                      \
+      NVCOMP_TYPE_TWO_SWITCH_FIRST_ONLY_RETURN(                                \
+          type1_var, int32_t, func, __VA_ARGS__);                              \
+    case NVCOMP_TYPE_UINT:                                                     \
+      NVCOMP_TYPE_TWO_SWITCH_FIRST_ONLY_RETURN(                                \
+          type1_var, uint32_t, func, __VA_ARGS__);                             \
+    case NVCOMP_TYPE_LONGLONG:                                                 \
+      NVCOMP_TYPE_TWO_SWITCH_FIRST_ONLY_RETURN(                                \
+          type1_var, int64_t, func, __VA_ARGS__);                              \
+    case NVCOMP_TYPE_ULONGLONG:                                                \
+      NVCOMP_TYPE_TWO_SWITCH_FIRST_ONLY_RETURN(                                \
+          type1_var, uint64_t, func, __VA_ARGS__);                             \
+    default:                                                                   \
+      throw std::runtime_error("Unknown type: " + std::to_string(type2_var));  \
+    }                                                                          \
+  } while (0)
+
+#define NVCOMP_TYPE_ONE_SWITCH(type_var, func, ...)                            \
+  do {                                                                         \
+    switch (type_var) {                                                        \
+    case NVCOMP_TYPE_CHAR:                                                     \
+      func<int8_t>(__VA_ARGS__);                                               \
+      break;                                                                   \
+    case NVCOMP_TYPE_UCHAR:                                                    \
+      func<uint8_t>(__VA_ARGS__);                                              \
+      break;                                                                   \
+    case NVCOMP_TYPE_SHORT:                                                    \
+      func<int16_t>(__VA_ARGS__);                                              \
+      break;                                                                   \
+    case NVCOMP_TYPE_USHORT:                                                   \
+      func<uint16_t>(__VA_ARGS__);                                             \
+      break;                                                                   \
+    case NVCOMP_TYPE_INT:                                                      \
+      func<int32_t>(__VA_ARGS__);                                              \
+      break;                                                                   \
+    case NVCOMP_TYPE_UINT:                                                     \
+      func<uint32_t>(__VA_ARGS__);                                             \
+      break;                                                                   \
+    case NVCOMP_TYPE_LONGLONG:                                                 \
+      func<int64_t>(__VA_ARGS__);                                              \
+      break;                                                                   \
+    case NVCOMP_TYPE_ULONGLONG:                                                \
+      func<uint64_t>(__VA_ARGS__);                                             \
+      break;                                                                   \
+    default:                                                                   \
+      throw std::runtime_error("Unknown type: " + std::to_string(type_var));   \
+    }                                                                          \
+  } while (0)
+
+#define NVCOMP_TYPE_ONE_SWITCH_RETURN(type_var, func, ...)                     \
+  do {                                                                         \
+    switch (type_var) {                                                        \
+    case NVCOMP_TYPE_CHAR:                                                     \
+      return func<int8_t>(__VA_ARGS__);                                        \
+    case NVCOMP_TYPE_UCHAR:                                                    \
+      return func<uint8_t>(__VA_ARGS__);                                       \
+    case NVCOMP_TYPE_SHORT:                                                    \
+      return func<int16_t>(__VA_ARGS__);                                       \
+    case NVCOMP_TYPE_USHORT:                                                   \
+      return func<uint16_t>(__VA_ARGS__);                                      \
+    case NVCOMP_TYPE_INT:                                                      \
+      return func<int32_t>(__VA_ARGS__);                                       \
+    case NVCOMP_TYPE_UINT:                                                     \
+      return func<uint32_t>(__VA_ARGS__);                                      \
+    case NVCOMP_TYPE_LONGLONG:                                                 \
+      return func<int64_t>(__VA_ARGS__);                                       \
+    case NVCOMP_TYPE_ULONGLONG:                                                \
+      return func<uint64_t>(__VA_ARGS__);                                      \
+    default:                                                                   \
+      throw std::runtime_error("Unknown type: " + std::to_string(type_var));   \
+    }                                                                          \
+  } while (0)
+
+#endif

--- a/nvcomp/unpack.h
+++ b/nvcomp/unpack.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2018-2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NVCOMP_UNPACK_H
+#define NVCOMP_UNPACK_H
+
+#include <limits>
+#include <cstdint>
+#include <cstdio>
+#include <cassert>
+
+#ifdef __CUDACC__
+#define NVCOMP_HOST_DEVICE __device__ __host__
+#else
+#define NVCOMP_HOST_DEVICE
+#endif
+
+namespace nvcomp
+{
+  
+template <typename T>
+NVCOMP_HOST_DEVICE T unpackBytes(
+    const void* data, const uint8_t numBits, const T minValue, const size_t i)
+{
+  using U = typename std::make_unsigned<T>::type;
+
+  if (numBits == 0) {
+    return minValue;
+  } else {
+    // enough space to hold 64 bits with up to 7 bit offset
+    uint8_t scratch[9];
+
+    // shifting by width of the type is UB
+    const U mask = numBits < sizeof(T)*8U ? static_cast<U>((1ULL << numBits) -
+        1) : static_cast<U>(-1);
+    const uint8_t* byte_data = reinterpret_cast<decltype(byte_data)>(data);
+
+    // Specialized
+    // Need to copy into scratch because
+    // GPU can only address n byte datatype on multiple of n address
+    // TODO: add an optimized version in case numBits aligns to word size
+    //       boundaries (1,2,4,8,16,32 and 64 bits)
+    size_t start_byte = (i * numBits) / 8;
+    // end_byte needed so we don't attempt to read from illegal memory
+    size_t end_byte = ((i + 1) * numBits - 1) / 8;
+    assert(end_byte - start_byte <= sizeof(scratch));
+
+    for (size_t j = start_byte, k = 0; j <= end_byte; ++j, ++k) {
+      scratch[k] = byte_data[j];
+    }
+
+    const int bitOffset = (i * numBits) % 8;
+    U baseValue = 0;
+    for (size_t k = 0; k <= end_byte - start_byte; ++k) {
+      U shifted;
+      if (k > 0) {
+        shifted = static_cast<U>(scratch[k]) << ((k * 8) - bitOffset);
+      } else {
+        shifted = static_cast<U>(scratch[k]) >> bitOffset;
+      }
+      baseValue |= mask & shifted;
+    }
+
+    const T value = baseValue + minValue;
+    return value;
+  }
+}
+
+}
+
+#undef NVCOMP_HOST_DEVICE
+
+#endif


### PR DESCRIPTION
This PR implements support for CUDA and for the on-GPU LZ4 nvcomp compressor.

If CUDA is available, add two CUDA-based compressors:
  - `cudaMemcpy`: a benchmark similar to the `memcpy` reference, that copies the input data to the output via GPU memory;
  - `nvcomp` 1.2.2: a GPU-only implementation of the LZ4 algorithm.
