### PR TITLE
Fix broken builds on aarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ else
 
 	ifeq ($(BUILD_STATIC),1)
 		LDFLAGS	+= -lrt -static
-		ifeq (1, $(shell [ "$(COMPILER)" = "gcc" ] && expr $(GCC_VERSION) \>= 80000))
+		ifeq (1, $(shell [ "$(COMPILER)" = "gcc" ] && [ "$(shell uname -m)" != "aarch64" ] && expr $(GCC_VERSION) \>= 80000 ))
 		  LDFLAGS += -lmvec
 		endif
 	endif


### PR DESCRIPTION
prevents using libmvec on gcc on aarch64 for static builds, as this library has [not been implemented](https://patches-gcc.linaro.org/patch/2457/).

It appears that the tests for this pass due to an old version of gcc.
Trying to compile on aarch64 architecture (Raspberry Pi 4) with modern gcc (`gcc (Debian 8.3.0-6) 8.3.0`) breaks due to the `-lmvec` flag requesting to load libmvec which is not available.