### PR TITLE
Make CUDA support more robust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,6 +293,8 @@ ifneq "$(LIBCUDART)" ""
     CUDA_ARCH = 50 60 70 80
     CUDA_CFLAGS = -x cu -std=c++14 -O3 $(foreach ARCH, $(CUDA_ARCH), --generate-code=arch=compute_$(ARCH),code=[compute_$(ARCH),sm_$(ARCH)]) --expt-extended-lambda -forward-unknown-to-host-compiler -Wno-deprecated-gpu-targets
 else
+    $(info CUDA Toolkit not found at $(CUDA_BASE), CUDA support will be disabled.)
+    $(info Run "make CUDA_BASE=..." to use a different path.)
     CUDA_BASE =
     LIBCUDART =
 endif

--- a/_lzbench/compressors.cpp
+++ b/_lzbench/compressors.cpp
@@ -1802,6 +1802,11 @@ int64_t lzbench_cuda_memcpy(char *inbuf, size_t insize, char *outbuf, size_t out
     return insize;
 }
 
+int64_t lzbench_cuda_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char* )
+{
+    return 0;
+}
+
 #ifdef BENCH_HAS_NVCOMP
 #include "nvcomp/lz4.h"
 

--- a/_lzbench/compressors.h
+++ b/_lzbench/compressors.h
@@ -509,10 +509,12 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
         char* lzbench_cuda_init(size_t insize, size_t, size_t);
         void lzbench_cuda_deinit(char* workmem);
         int64_t lzbench_cuda_memcpy(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char* workmem);
+        int64_t lzbench_cuda_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char* );
 #else
         #define lzbench_cuda_init NULL
         #define lzbench_cuda_deinit NULL
         #define lzbench_cuda_memcpy NULL
+        #define lzbench_cuda_return_0 NULL
 #endif
 
 #ifdef BENCH_HAS_NVCOMP


### PR DESCRIPTION
Completely disable the CUDA backends and the "cuda" alias, if CUDA support is not available.