### PR TITLE
add cpuid to title screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,7 @@ _visual/
 # Linux
 lzbench
 
+# backups, old versions
+*~
+
 todo.txt

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ ifeq (1,$(filter 1,$(shell [ "$(COMPILER)" = "gcc" ] && expr $(GCC_VERSION) \< 6
   DONT_BUILD_ZLING ?= 1
 endif
 
+
 # detect Windows
 ifneq (,$(filter Windows%,$(OS)))
 	ifeq ($(COMPILER),clang)
@@ -61,7 +62,7 @@ else
 		DONT_BUILD_CSC ?= 1
 	endif
 
-	LDFLAGS	+= -pthread
+	LDFLAGS	+= -pthread -lrt
 
 	ifeq ($(BUILD_STATIC),1)
 		LDFLAGS	+= -lrt -static
@@ -139,7 +140,6 @@ ZSTD_FILES += zstd/lib/common/entropy_common.o
 ZSTD_FILES += zstd/lib/common/pool.o
 ZSTD_FILES += zstd/lib/common/debug.o
 ZSTD_FILES += zstd/lib/common/threading.o
-ZSTD_FILES += zstd/lib/common/zstd_trace.o
 ZSTD_FILES += zstd/lib/compress/zstd_compress.o
 ZSTD_FILES += zstd/lib/compress/zstd_compress_literals.o
 ZSTD_FILES += zstd/lib/compress/zstd_compress_sequences.o
@@ -157,10 +157,7 @@ ZSTD_FILES += zstd/lib/decompress/zstd_decompress.o
 ZSTD_FILES += zstd/lib/decompress/huf_decompress.o
 ZSTD_FILES += zstd/lib/decompress/zstd_ddict.o
 ZSTD_FILES += zstd/lib/decompress/zstd_decompress_block.o
-ZSTD_FILES += zstd/lib/dictBuilder/cover.o
 ZSTD_FILES += zstd/lib/dictBuilder/divsufsort.o
-ZSTD_FILES += zstd/lib/dictBuilder/fastcover.o
-ZSTD_FILES += zstd/lib/dictBuilder/zdict.o
 
 BRIEFLZ_FILES = brieflz/brieflz.o brieflz/depack.o brieflz/depacks.o
 
@@ -282,31 +279,7 @@ ifeq "$(BENCH_HAS_NAKAMICHI)" "1"
     MISC_FILES += nakamichi/Nakamichi_Okamigan.o
 endif
 
-CUDA_BASE ?= /usr/local/cuda
-LIBCUDART=$(wildcard $(CUDA_BASE)/lib64/libcudart.so)
 
-ifneq "$(LIBCUDART)" ""
-    DEFINES += -DBENCH_HAS_CUDA -I$(CUDA_BASE)/include
-    LDFLAGS += -L$(CUDA_BASE)/lib64 -lcudart -Wl,-rpath=$(CUDA_BASE)/lib64
-    CUDA_COMPILER = nvcc
-    CUDA_CC = $(CUDA_BASE)/bin/nvcc --compiler-bindir $(CXX)
-    CUDA_ARCH = 50 60 70 80
-    CUDA_CFLAGS = -x cu -std=c++14 -O3 $(foreach ARCH, $(CUDA_ARCH), --generate-code=arch=compute_$(ARCH),code=[compute_$(ARCH),sm_$(ARCH)]) --expt-extended-lambda -forward-unknown-to-host-compiler -Wno-deprecated-gpu-targets
-else
-    CUDA_BASE =
-    LIBCUDART =
-endif
-
-ifneq "$(LIBCUDART)" ""
-ifneq "$(DONT_BUILD_NVCOMP)" "1"
-    DEFINES += -DBENCH_HAS_NVCOMP
-    NVCOMP_CPP_SRC = $(wildcard nvcomp/*.cpp)
-    NVCOMP_CPP_OBJ = $(NVCOMP_CPP_SRC:%=%.o)
-    NVCOMP_CU_SRC  = $(wildcard nvcomp/*.cu)
-    NVCOMP_CU_OBJ  = $(NVCOMP_CU_SRC:%=%.o)
-    NVCOMP_FILES   = $(NVCOMP_CU_OBJ) $(NVCOMP_CPP_OBJ)
-endif
-endif
 
 all: lzbench
 
@@ -337,21 +310,10 @@ nakamichi/Nakamichi_Okamigan.o: nakamichi/Nakamichi_Okamigan.c
 	@$(MKDIR) $(dir $@)
 	$(CC) $(CFLAGS) -mavx $< -c -o $@
 
-$(NVCOMP_CU_OBJ): %.cu.o: %.cu
-	@$(MKDIR) $(dir $@)
-	$(CUDA_CC) $(CUDA_CFLAGS) $(CFLAGS) -c $< -o $@
-
-$(NVCOMP_CPP_OBJ): %.cpp.o: %.cpp
-	@$(MKDIR) $(dir $@)
-	$(CXX) $(CFLAGS) -c $< -o $@
-
-# disable the implicit rule for making a binary out of a single object file
-%: %.o
-
 
 _lzbench/lzbench.o: _lzbench/lzbench.cpp _lzbench/lzbench.h
 
-lzbench: $(BZIP2_FILES) $(DENSITY_FILES) $(FASTLZMA2_OBJ) $(ZSTD_FILES) $(GLZA_FILES) $(LZSSE_FILES) $(LZFSE_FILES) $(XPACK_FILES) $(GIPFELI_FILES) $(XZ_FILES) $(LIBLZG_FILES) $(BRIEFLZ_FILES) $(LZF_FILES) $(LZRW_FILES) $(BROTLI_FILES) $(CSC_FILES) $(LZMA_FILES) $(ZLING_FILES) $(QUICKLZ_FILES) $(SNAPPY_FILES) $(ZLIB_FILES) $(LZHAM_FILES) $(LZO_FILES) $(UCL_FILES) $(LZMAT_FILES) $(LZ4_FILES) $(LIBDEFLATE_FILES) $(MISC_FILES) $(NVCOMP_FILES) $(LZBENCH_FILES)
+lzbench: $(BZIP2_FILES) $(DENSITY_FILES) $(FASTLZMA2_OBJ) $(ZSTD_FILES) $(GLZA_FILES) $(LZSSE_FILES) $(LZFSE_FILES) $(XPACK_FILES) $(GIPFELI_FILES) $(XZ_FILES) $(LIBLZG_FILES) $(BRIEFLZ_FILES) $(LZF_FILES) $(LZRW_FILES) $(BROTLI_FILES) $(CSC_FILES) $(LZMA_FILES) $(ZLING_FILES) $(QUICKLZ_FILES) $(SNAPPY_FILES) $(ZLIB_FILES) $(LZHAM_FILES) $(LZO_FILES) $(UCL_FILES) $(LZMAT_FILES) $(LZ4_FILES) $(LIBDEFLATE_FILES) $(MISC_FILES) $(LZBENCH_FILES)
 	$(CXX) $^ -o $@ $(LDFLAGS)
 	@echo Linked GCC_VERSION=$(GCC_VERSION) CLANG_VERSION=$(CLANG_VERSION) COMPILER=$(COMPILER)
 
@@ -368,4 +330,4 @@ lzbench: $(BZIP2_FILES) $(DENSITY_FILES) $(FASTLZMA2_OBJ) $(ZSTD_FILES) $(GLZA_F
 	$(CXX) $(CFLAGS) $< -c -o $@
 
 clean:
-	rm -rf lzbench lzbench.exe *.o _lzbench/*.o bzip2/*.o fast-lzma2/*.o slz/*.o zstd/lib/*.o zstd/lib/*.a zstd/lib/common/*.o zstd/lib/compress/*.o zstd/lib/decompress/*.o zstd/lib/dictBuilder/*.o lzsse/lzsse2/*.o lzsse/lzsse4/*.o lzsse/lzsse8/*.o lzfse/*.o xpack/lib/*.o blosclz/*.o gipfeli/*.o xz/*.o xz/common/*.o xz/check/*.o xz/lzma/*.o xz/lz/*.o xz/rangecoder/*.o liblzg/*.o lzlib/*.o brieflz/*.o brotli/common/*.o brotli/enc/*.o brotli/dec/*.o libcsc/*.o wflz/*.o lzjb/*.o lzma/*.o density/buffers/*.o density/algorithms/*.o density/algorithms/cheetah/core/*.o density/algorithms/*.o density/algorithms/lion/forms/*.o density/algorithms/lion/core/*.o density/algorithms/chameleon/core/*.o density/*.o density/structure/*.o pithy/*.o glza/*.o libzling/*.o yappy/*.o shrinker/*.o fastlz/*.o ucl/*.o zlib/*.o lzham/*.o lzmat/*.o lizard/*.o lz4/*.o crush/*.o lzf/*.o lzrw/*.o lzo/*.o snappy/*.o quicklz/*.o tornado/*.o libdeflate/*.o libdeflate/x86/*.o libdeflate/arm/*.o nakamichi/*.o nvcomp/*.o
+	rm -rf lzbench lzbench.exe *.o _lzbench/*.o bzip2/*.o fast-lzma2/*.o slz/*.o zstd/lib/*.o zstd/lib/*.a zstd/lib/common/*.o zstd/lib/compress/*.o zstd/lib/decompress/*.o zstd/lib/dictBuilder/*.o lzsse/lzsse2/*.o lzsse/lzsse4/*.o lzsse/lzsse8/*.o lzfse/*.o xpack/lib/*.o blosclz/*.o gipfeli/*.o xz/*.o xz/common/*.o xz/check/*.o xz/lzma/*.o xz/lz/*.o xz/rangecoder/*.o liblzg/*.o lzlib/*.o brieflz/*.o brotli/common/*.o brotli/enc/*.o brotli/dec/*.o libcsc/*.o wflz/*.o lzjb/*.o lzma/*.o density/buffers/*.o density/algorithms/*.o density/algorithms/cheetah/core/*.o density/algorithms/*.o density/algorithms/lion/forms/*.o density/algorithms/lion/core/*.o density/algorithms/chameleon/core/*.o density/*.o density/structure/*.o pithy/*.o glza/*.o libzling/*.o yappy/*.o shrinker/*.o fastlz/*.o ucl/*.o zlib/*.o lzham/*.o lzmat/*.o lizard/*.o lz4/*.o crush/*.o lzf/*.o lzrw/*.o lzo/*.o snappy/*.o quicklz/*.o tornado/*.o libdeflate/*.o libdeflate/x86/*.o libdeflate/arm/*.o nakamichi/*.o

--- a/_lzbench/cpuid1.h
+++ b/_lzbench/cpuid1.h
@@ -1,6 +1,7 @@
-#ifndef __CPUID1_H__
-#define __CPUID1_H__
+#ifndef CPUID1_H
+#define CPUID1_H
 
+#if (defined(__i386__) || defined(__x86_64__))
 //#include <cpuid.h>
 #include <stdint.h>
 
@@ -17,7 +18,7 @@ enum cpuid_requests {
   CPUID_BRANDSTRINGEND,
 };
 
-/** issue a single request to CPUID. Fits 'intel features', for instance
+/*  single request to CPUID. Fits 'intel features', for instance
  *  note that even if only "eax" and "edx" are of interest, other registers
  *  will be modified by the operation, so we need to tell the compiler about it.
  */
@@ -26,7 +27,7 @@ inline void cpuid2(int code, uint32_t *a, uint32_t *d)
     asm volatile("cpuid":"=a"(*a),"=d"(*d):"a"(code):"ecx","ebx");
     }
 
-/** issue a complete request, storing general registers output as a string
+/*  issue a complete request, storing general registers output as a string
  */
 inline int cpuid_string(int code, uint32_t where[4])
     {
@@ -35,4 +36,17 @@ inline int cpuid_string(int code, uint32_t where[4])
     return (int)where[0];
     }
 
-#endif // #ifndef __CPUID1_H__
+#else
+/*  non x86; other architectures lack of cpu brand string feature, even if they have cpuid
+    there is still space for this feature, maybe based on different mechanism/s */
+inline void cpuid2(int code, uint32_t *a, uint32_t *d)
+    {
+    }
+
+inline int cpuid_string(int code, uint32_t where[4])
+    {
+    return (int)where[0];
+    }
+
+#endif /* #if (defined(__i386__) || defined(__x86_64__)) */
+#endif /* #ifndef CPUID1_H */

--- a/_lzbench/cpuid1.h
+++ b/_lzbench/cpuid1.h
@@ -1,8 +1,12 @@
 #ifndef CPUID1_H
 #define CPUID1_H
 
+#ifndef __GNUC__
+#define asm __asm__
+#endif
+
 #if (defined(__i386__) || defined(__x86_64__))
-//#include <cpuid.h>
+#include <cpuid.h>
 #include <stdint.h>
 
 enum cpuid_requests {
@@ -18,35 +22,14 @@ enum cpuid_requests {
   CPUID_BRANDSTRINGEND,
 };
 
-/*  single request to CPUID. Fits 'intel features', for instance
- *  note that even if only "eax" and "edx" are of interest, other registers
- *  will be modified by the operation, so we need to tell the compiler about it.
- */
-inline void cpuid2(int code, uint32_t *a, uint32_t *d)
-    {
-    asm volatile("cpuid":"=a"(*a),"=d"(*d):"a"(code):"ecx","ebx");
-    }
-
-/*  issue a complete request, storing general registers output as a string
- */
-inline int cpuid_string(int code, uint32_t where[4])
-    {
-    asm volatile("cpuid":"=a"(*where),"=b"(*(where+1)),
-               "=c"(*(where+2)),"=d"(*(where+3)):"a"(code));
-    return (int)where[0];
-    }
-
-#else
-/*  non x86; other architectures lack of cpu brand string feature, even if they have cpuid
-    there is still space for this feature, maybe based on different mechanism/s */
-inline void cpuid2(int code, uint32_t *a, uint32_t *d)
-    {
-    }
 
 inline int cpuid_string(int code, uint32_t where[4])
-    {
+{
+    //asm volatile("cpuid":"=a"(*where),"=b"(*(where+1)),
+    //           "=c"(*(where+2)),"=d"(*(where+3)):"a"(code));
+    __cpuid(code, (*where), *(where+1), *(where+2), *(where+3));
     return (int)where[0];
-    }
-
+}
 #endif /* #if (defined(__i386__) || defined(__x86_64__)) */
 #endif /* #ifndef CPUID1_H */
+

--- a/_lzbench/cpuid1.h
+++ b/_lzbench/cpuid1.h
@@ -1,0 +1,38 @@
+#ifndef __CPUID1_H__
+#define __CPUID1_H__
+
+//#include <cpuid.h>
+#include <stdint.h>
+
+enum cpuid_requests {
+  CPUID_GETVENDORSTRING,
+  CPUID_GETFEATURES,
+  CPUID_GETTLB,
+  CPUID_GETSERIAL,
+
+  CPUID_EXTENDED = 0x80000000,
+  CPUID_FEATURES,
+  CPUID_BRANDSTRING,
+  CPUID_BRANDSTRINGMORE,
+  CPUID_BRANDSTRINGEND,
+};
+
+/** issue a single request to CPUID. Fits 'intel features', for instance
+ *  note that even if only "eax" and "edx" are of interest, other registers
+ *  will be modified by the operation, so we need to tell the compiler about it.
+ */
+inline void cpuid2(int code, uint32_t *a, uint32_t *d)
+    {
+    asm volatile("cpuid":"=a"(*a),"=d"(*d):"a"(code):"ecx","ebx");
+    }
+
+/** issue a complete request, storing general registers output as a string
+ */
+inline int cpuid_string(int code, uint32_t where[4])
+    {
+    asm volatile("cpuid":"=a"(*where),"=b"(*(where+1)),
+               "=c"(*(where+2)),"=d"(*(where+3)):"a"(code));
+    return (int)where[0];
+    }
+
+#endif // #ifndef __CPUID1_H__

--- a/_lzbench/lzbench.cpp
+++ b/_lzbench/lzbench.cpp
@@ -419,7 +419,7 @@ void lzbench_test(lzbench_params_t *params, std::vector<size_t> &file_sizes, con
         LZBENCH_PRINT(9, "%s dnanosec=%d\n", desc->name, (int)nanosec);
 
         if (insize != decomplen)
-        {   
+        {
             decomp_error = true;
             LZBENCH_PRINT(5, "ERROR: inlen[%d] != outlen[%d]\n", (int32_t)insize, (int32_t)decomplen);
         }
@@ -468,7 +468,7 @@ void lzbench_test_with_params(lzbench_params_t *params, std::vector<size_t> &fil
 {
     std::vector<std::string> cnames, cparams;
 
-	if (!namesWithParams) return;
+    if (!namesWithParams) return;
 
     LZBENCH_PRINT(5, "*** lzbench_test_with_params insize=%d comprsize=%d\n", (int)insize, (int)comprsize);
 
@@ -502,7 +502,7 @@ void lzbench_test_with_params(lzbench_params_t *params, std::vector<size_t> &fil
                         found = true;
                        // printf("%s %s %s\n", cparams[0].c_str(), comp_desc[i].version, cparams[j].c_str());
                         if (j >= cparams.size())
-                        {                          
+                        {
                             for (int level=comp_desc[i].first_level; level<=comp_desc[i].last_level; level++)
                                 lzbench_test(params, file_sizes, &comp_desc[i], level, inbuf, insize, compbuf, comprsize, decomp, rate, level);
                         }
@@ -750,7 +750,7 @@ char* cpu_brand_string(void)
     uint32_t mx[4], i, a, b, c, d;
 
     #if (defined(__i386__) || defined(__x86_64__))
-    char* cpu_brand_str = (char*)malloc(3*sizeof(mx)+1);
+    char* cpu_brand_str = (char*)calloc(1, 3*sizeof(mx)+1);
     if (!cpu_brand_str)
         return NULL;
 
@@ -997,6 +997,7 @@ _clean:
     else
 #endif
         free((void*)inFileNames);
-        free(cpu_brand);
+        if (cpu_brand)
+            free(cpu_brand);
     return result;
 }

--- a/_lzbench/lzbench.cpp
+++ b/_lzbench/lzbench.cpp
@@ -748,8 +748,8 @@ void usage(lzbench_params_t* params)
 char* cpu_brand_string(void)
 {
     uint32_t mx[4], i, a, d;
-    //static char cpu_brand_string[3*sizeof(mx)+1];
 
+    #if (defined(__i386__) || defined(__x86_64__))
     char* cpu_brand_string = (char*)malloc(3*sizeof(mx)+1);
     if (!cpu_brand_string)
         return NULL;
@@ -767,6 +767,9 @@ char* cpu_brand_string(void)
 
     cpu_brand_string[3*sizeof(mx)+1] = '\0'; // in case string was not null terminated
     return cpu_brand_string;
+    #else
+    return NULL;
+    #endif // (defined(__i386__) || defined(__x86_64__))
 }
 
 
@@ -921,7 +924,7 @@ int main( int argc, char** argv)
         argc--;
     }
 
-    LZBENCH_PRINT(2, PROGNAME " " PROGVERSION " (%d-bit " PROGOS ")  @%s\nAssembled by P.Skibinski\n", (uint32_t)(8 * sizeof(uint8_t*)), cpu_brand_string());
+    LZBENCH_PRINT(2, PROGNAME " " PROGVERSION " (%d-bit " PROGOS ")  %s\nAssembled by P.Skibinski\n\n", (uint32_t)(8 * sizeof(uint8_t*)), cpu_brand_string());
     LZBENCH_PRINT(5, "params: chunk_size=%d c_iters=%d d_iters=%d cspeed=%d cmintime=%d dmintime=%d encoder_list=%s\n", (int)params->chunk_size, params->c_iters, params->d_iters, params->cspeed, params->cmintime, params->dmintime, encoder_list);
 
     if (ifnIdx < 1)  { usage(params); goto _clean; }


### PR DESCRIPTION
I was annoyed by noting processor type every time I test bench on different computer so I added cpuid brand string to the title screen. Now it's clear what configuration is used every time one tests.
For example:
```
$ ./lzbench
lzbench 1.8 (64-bit Linux)  @Intel(R) Core(TM) i7-6800K  @ 3.4GHz
Assembled by P.Skibinski
```
