### PR TITLE
print decimal %.1 place for de/compression speed > 10 < 100 [MB]

### DIFF
--- a/_lzbench/lzbench.cpp
+++ b/_lzbench/lzbench.cpp
@@ -114,11 +114,15 @@ void print_speed(lzbench_params_t *params, string_table_t& row)
         case TEXT:
         case TEXT_FULL:
             printf("%-23s", row.col1_algname.c_str());
-            if (cspeed < 10) printf("%6.2f MB/s", cspeed); else printf("%6d MB/s", (int)cspeed);
+            if (cspeed < 10) printf("%6.2f MB/s", cspeed);
+            else if (cspeed < 100) printf("%6.1f MB/s", cspeed);
+            else printf("%6d MB/s", (int)cspeed);
             if (!dspeed)
                 printf("      ERROR");
             else
-                if (dspeed < 10) printf("%6.2f MB/s", dspeed); else printf("%6d MB/s", (int)dspeed);
+                if (dspeed < 10) printf("%6.2f MB/s", dspeed);
+                else if (dspeed < 100) printf("%6.1f MB/s", dspeed);
+                else printf("%6d MB/s", (int)dspeed);
             if (params->textformat == TEXT_FULL)
                 printf("%12llu %12llu %6.2f %s\n", (unsigned long long) row.col5_origsize, (unsigned long long)row.col4_comprsize, ratio, row.col6_filename.c_str());
             else
@@ -126,21 +130,29 @@ void print_speed(lzbench_params_t *params, string_table_t& row)
             break;
         case MARKDOWN:
             printf("| %-23s ", row.col1_algname.c_str());
-            if (cspeed < 10) printf("|%6.2f MB/s ", cspeed); else printf("|%6d MB/s ", (int)cspeed);
+            if (cspeed < 10) printf("|%6.2f MB/s ", cspeed);
+            else if (cspeed < 100) printf("|%6.1f MB/s ", cspeed);
+            else printf("|%6d MB/s ", (int)cspeed);
             if (!dspeed)
                 printf("|      ERROR ");
             else
-                if (dspeed < 10) printf("|%6.2f MB/s ", dspeed); else printf("|%6d MB/s ", (int)dspeed);
+                if (dspeed < 10) printf("|%6.2f MB/s ", dspeed);
+                else if (dspeed < 100) printf("|%6.1f MB/s ", dspeed);
+                else printf("|%6d MB/s ", (int)dspeed);
             printf("|%12llu |%6.2f | %-s|\n", (unsigned long long)row.col4_comprsize, ratio, row.col6_filename.c_str());
             break;
         case MARKDOWN2:
             ratio = 1.0*row.col5_origsize / row.col4_comprsize;
             printf("| %-23s |%6.3f ", row.col1_algname.c_str(), ratio);
-            if (cspeed < 10) printf("|%6.2f MB/s ", cspeed); else printf("|%6d MB/s ", (int)cspeed);
+            if (cspeed < 10) printf("|%6.2f MB/s ", cspeed);
+            else if (cspeed < 100) printf("|%6.1f MB/s ", cspeed);
+            else printf("|%6d MB/s ", (int)cspeed);
             if (!dspeed)
                 printf("|      ERROR ");
             else
-                if (dspeed < 10) printf("|%6.2f MB/s ", dspeed); else printf("|%6d MB/s ", (int)dspeed);
+                if (dspeed < 10) printf("|%6.2f MB/s ", dspeed);
+                else if (dspeed < 100) printf("|%6.1f MB/s ", dspeed);
+                else printf("|%6d MB/s ", (int)dspeed);
             printf("|\n");
             break;
     }
@@ -990,14 +1002,15 @@ int main( int argc, char** argv)
     }
 
 _clean:
-    if (encoder_list) free(encoder_list);
+    if (encoder_list)
+        free(encoder_list);
 #ifdef UTIL_HAS_CREATEFILELIST
     if (extendedFileList)
         UTIL_freeFileList(extendedFileList, fileNamesBuf);
     else
 #endif
-        free((void*)inFileNames);
-        if (cpu_brand)
-            free(cpu_brand);
+    free((void*)inFileNames);
+    if (cpu_brand)
+        free(cpu_brand);
     return result;
 }


### PR DESCRIPTION
When displaying speeds > 10MB and < 100MB there is a significant error associated with it as it cuts off all fractional part of it. This error can approach 10%, for example: if there is a speed of 10.000 and 10.999 [MB] they will both be displayed as 10 when actual difference is 0.999, and an error is 9.99% ( |10.999-10.000|/10.000 = 0.0999 = 9.99% ). Similarly if those speed were 10.999 and 11.000 then they wold be displayed as 10 and 11, with a difference of 1 when actually it is 0.001. Again error would be 9.99% ( |1-0.001|/10 = 0.0999 = 9.99% ).

So I increased displayed accuracy for speeds > 10MB and < 100MB to one decimal point which reduces the error below 1%.


Here simple sample:

(from:)
`$ ./lzbench -o1 -ezlib,1,5,9/bzip2,1,5,9 lzbench`

| Compressor name         | Compression| Decompress.| Compr. size | Ratio | Filename |
| ---------------         | -----------| -----------| ----------- | ----- | -------- |
| memcpy                  |  1269 MB/s |  1295 MB/s |     3967061 |100.00 | lzbench|
| zlib 1.2.11 -1          |    19 MB/s |    84 MB/s |     1719310 | 43.34 | lzbench|
| zlib 1.2.11 -5          |    10 MB/s |    91 MB/s |     1573155 | 39.66 | lzbench|
| zlib 1.2.11 -9          |  2.55 MB/s |    94 MB/s |     1547454 | 39.01 | lzbench|
| bzip2 1.0.8 -1          |  4.97 MB/s |    13 MB/s |     1516333 | 38.22 | lzbench|
| bzip2 1.0.8 -5          |  4.87 MB/s |    12 MB/s |     1460530 | 36.82 | lzbench|
| bzip2 1.0.8 -9          |  4.54 MB/s |    10 MB/s |     1470290 | 37.06 | lzbench|

(To:)
`$ ./lzbench-print_10m0 -o1 -ezlib,1,5,9/bzip2,1,5,9 lzbench`

| Compressor name         | Compression| Decompress.| Compr. size | Ratio | Filename |
| ---------------         | -----------| -----------| ----------- | ----- | -------- |
| memcpy                  |  1218 MB/s |  1289 MB/s |     3968202 |100.00 | lzbench|
| zlib 1.2.11 -1          |  19.5 MB/s |  84.7 MB/s |     1719672 | 43.34 | lzbench|
| zlib 1.2.11 -5          |  10.4 MB/s |  91.9 MB/s |     1573515 | 39.65 | lzbench|
| zlib 1.2.11 -9          |  2.55 MB/s |  94.1 MB/s |     1547770 | 39.00 | lzbench|
| bzip2 1.0.8 -1          |  4.96 MB/s |  13.4 MB/s |     1516247 | 38.21 | lzbench|
| bzip2 1.0.8 -5          |  4.86 MB/s |  12.1 MB/s |     1461230 | 36.82 | lzbench|
| bzip2 1.0.8 -9          |  4.54 MB/s |  10.9 MB/s |     1472172 | 37.10 | lzbench|


Hope you find it reasonable and useful.

