### PR TITLE
feature: compress/decompress with dictionaries and stream mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,7 +350,9 @@ $(NVCOMP_CPP_OBJ): %.cpp.o: %.cpp
 %: %.o
 
 
-_lzbench/lzbench.o: _lzbench/lzbench.cpp _lzbench/lzbench.h
+_lzbench/lzbench.o: %.o : %.cpp
+	@$(MKDIR) $(dir $@)
+	$(CXX) $(CFLAGS) -std=gnu++11 $< -c -o $@
 
 lzbench: $(BZIP2_FILES) $(DENSITY_FILES) $(FASTLZMA2_OBJ) $(ZSTD_FILES) $(GLZA_FILES) $(LZSSE_FILES) $(LZFSE_FILES) $(XPACK_FILES) $(GIPFELI_FILES) $(XZ_FILES) $(LIBLZG_FILES) $(BRIEFLZ_FILES) $(LZF_FILES) $(LZRW_FILES) $(BROTLI_FILES) $(CSC_FILES) $(LZMA_FILES) $(ZLING_FILES) $(QUICKLZ_FILES) $(SNAPPY_FILES) $(ZLIB_FILES) $(LZHAM_FILES) $(LZO_FILES) $(UCL_FILES) $(LZMAT_FILES) $(LZ4_FILES) $(LIBDEFLATE_FILES) $(MISC_FILES) $(NVCOMP_FILES) $(LZBENCH_FILES)
 	$(CXX) $^ -o $@ $(LDFLAGS)

--- a/_lzbench/compressors.cpp
+++ b/_lzbench/compressors.cpp
@@ -11,13 +11,13 @@
 #endif
 
 
-int64_t lzbench_memcpy(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char* )
+int64_t lzbench_memcpy(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char*, bool)
 {
     memcpy(outbuf, inbuf, insize);
     return insize;
 }
 
-int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char* )
+int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char*, bool)
 {
     return 0;
 }
@@ -26,12 +26,12 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 #ifndef BENCH_REMOVE_BLOSCLZ
 #include "blosclz/blosclz.h"
 
-int64_t lzbench_blosclz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_blosclz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
     return blosclz_compress(level, inbuf, insize, outbuf, outsize, 1);
 }
 
-int64_t lzbench_blosclz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char*)
+int64_t lzbench_blosclz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char*, bool)
 {
     return blosclz_decompress(inbuf, insize, outbuf, outsize);
 }
@@ -42,7 +42,7 @@ int64_t lzbench_blosclz_decompress(char *inbuf, size_t insize, char *outbuf, siz
 #ifndef BENCH_REMOVE_BRIEFLZ
 #include "brieflz/brieflz.h"
 
-char* lzbench_brieflz_init(size_t insize, size_t level, size_t)
+char* lzbench_brieflz_init(size_t insize, size_t level, size_t, const std::string&)
 {
     return (char*) malloc(blz_workmem_size_level(insize, level));
 }
@@ -52,7 +52,7 @@ void lzbench_brieflz_deinit(char* workmem)
     free(workmem);
 }
 
-int64_t lzbench_brieflz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem)
+int64_t lzbench_brieflz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool)
 {
     if (!workmem)
         return 0;
@@ -62,7 +62,7 @@ int64_t lzbench_brieflz_compress(char *inbuf, size_t insize, char *outbuf, size_
     return res;
 }
 
-int64_t lzbench_brieflz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_brieflz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
     return blz_depack(inbuf, outbuf, outsize);
 }
@@ -75,14 +75,13 @@ int64_t lzbench_brieflz_decompress(char *inbuf, size_t insize, char *outbuf, siz
 #include "brotli/encode.h"
 #include "brotli/decode.h"
 
-int64_t lzbench_brotli_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t windowLog, char*)
+int64_t lzbench_brotli_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t windowLog, char*, bool)
 {
-    if (!windowLog) windowLog = BROTLI_DEFAULT_WINDOW; // sliding window size. Range is 10 to 24.
-
     size_t actual_osize = outsize;
     return BrotliEncoderCompress(level, windowLog, BROTLI_DEFAULT_MODE, insize, (const uint8_t*)inbuf, &actual_osize, (uint8_t*)outbuf) == 0 ? 0 : actual_osize;
 }
-int64_t lzbench_brotli_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+
+int64_t lzbench_brotli_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
     size_t actual_osize = outsize;
     return BrotliDecoderDecompress(insize, (const uint8_t*)inbuf, &actual_osize, (uint8_t*)outbuf) == BROTLI_DECODER_RESULT_ERROR ? 0 : actual_osize;
@@ -95,13 +94,13 @@ int64_t lzbench_brotli_decompress(char *inbuf, size_t insize, char *outbuf, size
 #ifndef BENCH_REMOVE_BZIP2
 #include "bzip2/bzlib.h"
 
-int64_t lzbench_bzip2_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t windowLog, char*)
+int64_t lzbench_bzip2_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t windowLog, char*, bool)
 {
    unsigned int a_outsize = outsize;
    return BZ2_bzBuffToBuffCompress((char *)outbuf, &a_outsize, (char *)inbuf, (unsigned int)insize, level, 0, 0)==BZ_OK?a_outsize:-1;
 }
 
-int64_t lzbench_bzip2_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_bzip2_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
    unsigned int a_outsize = outsize;
    return BZ2_bzBuffToBuffDecompress((char *)outbuf, &a_outsize, (char *)inbuf, (unsigned int)insize, 0, 0)==BZ_OK?a_outsize:-1;
@@ -114,12 +113,12 @@ int64_t lzbench_bzip2_decompress(char *inbuf, size_t insize, char *outbuf, size_
 #ifndef BENCH_REMOVE_CRUSH
 #include "crush/crush.hpp"
 
-int64_t lzbench_crush_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_crush_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	return crush::compress(level, (uint8_t*)inbuf, insize, (uint8_t*)outbuf);
 }
 
-int64_t lzbench_crush_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_crush_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	return crush::decompress((uint8_t*)inbuf, (uint8_t*)outbuf, outsize);
 }
@@ -135,7 +134,7 @@ extern "C"
 	#include "density/density_api.h"
 }
 
-char* lzbench_density_init(size_t insize, size_t level, size_t)
+char* lzbench_density_init(size_t insize, size_t level, size_t, const std::string&)
 {
     return (char*) malloc(MAX(density_compress_safe_size(insize), density_decompress_safe_size(insize)));
 }
@@ -145,7 +144,7 @@ void lzbench_density_deinit(char* workmem)
     free(workmem);
 }
 
-int64_t lzbench_density_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_density_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	density_processing_result result = density_compress((uint8_t *)inbuf, insize, (uint8_t *)outbuf, density_compress_safe_size(outsize), (DENSITY_ALGORITHM)level);
 	if (result.state) 
@@ -154,7 +153,7 @@ int64_t lzbench_density_compress(char *inbuf, size_t insize, char *outbuf, size_
 	return result.bytesWritten;
 }
 
-int64_t lzbench_density_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_density_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	density_processing_result result = density_decompress((uint8_t *)inbuf, insize, (uint8_t *)outbuf, density_decompress_safe_size(outsize));
 	if (result.state) 
@@ -173,12 +172,12 @@ extern "C"
 	#include "fastlz/fastlz.h"
 }
 
-int64_t lzbench_fastlz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_fastlz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	return fastlz_compress_level(level, inbuf, insize, outbuf);
 }
 
-int64_t lzbench_fastlz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_fastlz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	return fastlz_decompress(inbuf, insize, outbuf, outsize);
 }
@@ -190,14 +189,14 @@ int64_t lzbench_fastlz_decompress(char *inbuf, size_t insize, char *outbuf, size
 #ifndef BENCH_REMOVE_FASTLZMA2
 #include "fast-lzma2/fast-lzma2.h"
 
-int64_t lzbench_fastlzma2_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t windowLog, char* workmem)
+int64_t lzbench_fastlzma2_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t windowLog, char* workmem, bool)
 {
     size_t ret = FL2_compress(outbuf, outsize, inbuf, insize, level);
     if (FL2_isError(ret)) return 0;
     return ret;
 }
 
-int64_t lzbench_fastlzma2_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char* workmem)
+int64_t lzbench_fastlzma2_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char* workmem, bool)
 {
     size_t ret = FL2_decompress(outbuf, outsize, inbuf, insize);
     if (FL2_isError(ret)) return 0;
@@ -209,7 +208,7 @@ int64_t lzbench_fastlzma2_decompress(char *inbuf, size_t insize, char *outbuf, s
 #ifndef BENCH_REMOVE_GIPFELI
 #include "gipfeli/gipfeli.h"
 
-int64_t lzbench_gipfeli_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_gipfeli_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
     int64_t res;
     util::compression::Compressor *gipfeli = util::compression::NewGipfeliCompressor();
@@ -224,7 +223,7 @@ int64_t lzbench_gipfeli_compress(char *inbuf, size_t insize, char *outbuf, size_
     return res;
 }
 
-int64_t lzbench_gipfeli_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_gipfeli_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
     int64_t res = 0;
     util::compression::Compressor *gipfeli = util::compression::NewGipfeliCompressor();
@@ -247,13 +246,13 @@ int64_t lzbench_gipfeli_decompress(char *inbuf, size_t insize, char *outbuf, siz
 #include "glza/GLZAcomp.h"
 #include "glza/GLZAdecode.h"
 
-int64_t lzbench_glza_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_glza_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	if (GLZAcomp(insize, (uint8_t *)inbuf, &outsize, (uint8_t *)outbuf, (FILE *)0, NULL) == 0) return(0);
 	return outsize;
 }
 
-int64_t lzbench_glza_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_glza_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	if (GLZAdecode(insize, (uint8_t *)inbuf, &outsize, (uint8_t *)outbuf, (FILE *)0) == 0) return(0);
 	return outsize;
@@ -265,7 +264,7 @@ int64_t lzbench_glza_decompress(char *inbuf, size_t insize, char *outbuf, size_t
 
 #ifndef BENCH_REMOVE_LIBDEFLATE
 #include "libdeflate/libdeflate.h"
-int64_t lzbench_libdeflate_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_libdeflate_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
     struct libdeflate_compressor *compressor = libdeflate_alloc_compressor(level);
     if (!compressor)
@@ -274,7 +273,7 @@ int64_t lzbench_libdeflate_compress(char *inbuf, size_t insize, char *outbuf, si
     libdeflate_free_compressor(compressor);
     return res;
 }
-int64_t lzbench_libdeflate_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_libdeflate_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
     struct libdeflate_decompressor *decompressor = libdeflate_alloc_decompressor();
     if (!decompressor)
@@ -293,12 +292,12 @@ int64_t lzbench_libdeflate_decompress(char *inbuf, size_t insize, char *outbuf, 
 #include "lizard/lizard_compress.h"
 #include "lizard/lizard_decompress.h"
 
-int64_t lzbench_lizard_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_lizard_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	return Lizard_compress(inbuf, outbuf, insize, outsize, level);
 }
 
-int64_t lzbench_lizard_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_lizard_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	return Lizard_decompress_safe(inbuf, outbuf, insize, outsize);
 }
@@ -311,22 +310,22 @@ int64_t lzbench_lizard_decompress(char *inbuf, size_t insize, char *outbuf, size
 #include "lz4/lz4.h"
 #include "lz4/lz4hc.h"
 
-int64_t lzbench_lz4_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_lz4_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	return LZ4_compress_default(inbuf, outbuf, insize, outsize);
 }
 
-int64_t lzbench_lz4fast_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_lz4fast_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	return LZ4_compress_fast(inbuf, outbuf, insize, outsize, level);
 }
 
-int64_t lzbench_lz4hc_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_lz4hc_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	return LZ4_compress_HC(inbuf, outbuf, insize, outsize, level);
 }
 
-int64_t lzbench_lz4_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_lz4_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	return LZ4_decompress_safe(inbuf, outbuf, insize, outsize);
 }
@@ -341,14 +340,14 @@ extern "C"
 	#include "lzf/lzf.h"
 }
 
-int64_t lzbench_lzf_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_lzf_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	if (level == 0)
 		return lzf_compress(inbuf, insize, outbuf, outsize);
 	return lzf_compress_very(inbuf, insize, outbuf, outsize);
 }
 
-int64_t lzbench_lzf_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_lzf_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	return lzf_decompress(inbuf, insize, outbuf, outsize);
 }
@@ -363,7 +362,7 @@ extern "C"
 	#include "lzfse/lzfse.h"
 }
 
-char* lzbench_lzfse_init(size_t insize, size_t level, size_t)
+char* lzbench_lzfse_init(size_t insize, size_t level, size_t, const std::string&)
 {
     return (char*) malloc(MAX(lzfse_encode_scratch_size(), lzfse_decode_scratch_size()));
 }
@@ -373,12 +372,12 @@ void lzbench_lzfse_deinit(char* workmem)
     free(workmem);
 }
 
-int64_t lzbench_lzfse_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem)
+int64_t lzbench_lzfse_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool)
 {
 	return lzfse_encode_buffer((uint8_t*)outbuf, outsize, (uint8_t*)inbuf, insize, workmem);
 }
 
-int64_t lzbench_lzfse_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char* workmem)
+int64_t lzbench_lzfse_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char* workmem, bool)
 {
 	return lzfse_decode_buffer((uint8_t*)outbuf, outsize, (uint8_t*)inbuf, insize, workmem);
 }
@@ -393,7 +392,7 @@ extern "C"
 	#include "lzfse/lzvn.h"
 }
 
-char* lzbench_lzvn_init(size_t insize, size_t level, size_t)
+char* lzbench_lzvn_init(size_t insize, size_t level, size_t, const std::string&)
 {
     return (char*) malloc(MAX(lzvn_encode_scratch_size(), lzvn_decode_scratch_size()));
 }
@@ -403,12 +402,12 @@ void lzbench_lzvn_deinit(char* workmem)
     free(workmem);
 }
 
-int64_t lzbench_lzvn_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem)
+int64_t lzbench_lzvn_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool)
 {
 	return lzvn_encode_buffer((uint8_t*)outbuf, outsize, (uint8_t*)inbuf, insize, workmem);
 }
 
-int64_t lzbench_lzvn_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char* workmem)
+int64_t lzbench_lzvn_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char* workmem, bool)
 {
 	return lzvn_decode_buffer_scratch((uint8_t*)outbuf, outsize, (uint8_t*)inbuf, insize, workmem);
 }
@@ -420,7 +419,7 @@ int64_t lzbench_lzvn_decompress(char *inbuf, size_t insize, char *outbuf, size_t
 #ifndef BENCH_REMOVE_LZG
 #include "liblzg/lzg.h"
 
-int64_t lzbench_lzg_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_lzg_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
     lzg_encoder_config_t cfg;
     cfg.level = level;
@@ -430,7 +429,7 @@ int64_t lzbench_lzg_compress(char *inbuf, size_t insize, char *outbuf, size_t ou
     return LZG_Encode((const unsigned char*)inbuf, insize, (unsigned char*)outbuf, outsize, &cfg);
 }
 
-int64_t lzbench_lzg_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_lzg_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
     return LZG_Decode((const unsigned char*)inbuf, insize, (unsigned char*)outbuf, outsize);
 }
@@ -443,7 +442,7 @@ int64_t lzbench_lzg_decompress(char *inbuf, size_t insize, char *outbuf, size_t 
 #include "lzham/lzham.h"
 #include <memory.h>
 
-int64_t lzbench_lzham_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t dict_size_log, char*)
+int64_t lzbench_lzham_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t dict_size_log, char*, bool)
 {
 	lzham_compress_params comp_params;
 	memset(&comp_params, 0, sizeof(comp_params));
@@ -464,7 +463,7 @@ int64_t lzbench_lzham_compress(char *inbuf, size_t insize, char *outbuf, size_t 
 	return outsize;
 }
 
-int64_t lzbench_lzham_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t dict_size_log, char*)
+int64_t lzbench_lzham_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t dict_size_log, char*, bool)
 {
 	lzham_uint32 comp_adler32 = 0;
 	lzham_decompress_params decomp_params;
@@ -484,12 +483,12 @@ int64_t lzbench_lzham_decompress(char *inbuf, size_t insize, char *outbuf, size_
 #ifndef BENCH_REMOVE_LZJB
 #include "lzjb/lzjb2010.h"
 
-int64_t lzbench_lzjb_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_lzjb_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	return lzjb_compress2010((uint8_t*)inbuf, (uint8_t*)outbuf, insize, outsize, 0); 
 }
 
-int64_t lzbench_lzjb_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_lzjb_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	return lzjb_decompress2010((uint8_t*)inbuf, (uint8_t*)outbuf, insize, outsize, 0);
 }
@@ -501,7 +500,7 @@ int64_t lzbench_lzjb_decompress(char *inbuf, size_t insize, char *outbuf, size_t
 #ifndef BENCH_REMOVE_LZLIB
 #include "lzlib/lzlib.h"
 
-int64_t lzbench_lzlib_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_lzlib_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
   struct Lzma_options
   {
@@ -565,7 +564,7 @@ int64_t lzbench_lzlib_compress(char *inbuf, size_t insize, char *outbuf, size_t 
 }
  
 
-int64_t lzbench_lzlib_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_lzlib_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
   struct LZ_Decoder * const decoder = LZ_decompress_open();
   uint8_t * new_data = (uint8_t*)outbuf;
@@ -622,7 +621,7 @@ static void SzFree(ISzAllocPtr p, void *address) { (void)p; MyFree(address); }
 const ISzAlloc g_Alloc = { SzAlloc, SzFree };
 #endif
 
-int64_t lzbench_lzma_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_lzma_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	CLzmaEncProps props;
 	int res;
@@ -647,7 +646,7 @@ int64_t lzbench_lzma_compress(char *inbuf, size_t insize, char *outbuf, size_t o
 	return LZMA_PROPS_SIZE + out_len;
 }
 
-int64_t lzbench_lzma_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_lzma_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	int res;
 	SizeT out_len = outsize;
@@ -669,7 +668,7 @@ int64_t lzbench_lzma_decompress(char *inbuf, size_t insize, char *outbuf, size_t
 #ifndef BENCH_REMOVE_LZMAT
 #include "lzmat/lzmat.h"
 
-int64_t lzbench_lzmat_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_lzmat_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	uint32_t complen = outsize;
 	if (lzmat_encode((uint8_t*)outbuf, &complen, (uint8_t*)inbuf, insize) != 0)
@@ -677,7 +676,7 @@ int64_t lzbench_lzmat_compress(char *inbuf, size_t insize, char *outbuf, size_t 
 	return complen;
 }
 
-int64_t lzbench_lzmat_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_lzmat_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	uint32_t decomplen = outsize;
 	if (lzmat_decode((uint8_t*)outbuf, &decomplen, (uint8_t*)inbuf, insize) != 0)
@@ -701,7 +700,7 @@ int64_t lzbench_lzmat_decompress(char *inbuf, size_t insize, char *outbuf, size_
 #include "lzo/lzo1z.h"
 #include "lzo/lzo2a.h"
 
-char* lzbench_lzo_init(size_t, size_t, size_t)
+char* lzbench_lzo_init(size_t, size_t, size_t, const std::string&)
 {
 	lzo_init();
 
@@ -713,7 +712,7 @@ void lzbench_lzo_deinit(char* workmem)
     free(workmem);
 }
 
-int64_t lzbench_lzo1_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem)
+int64_t lzbench_lzo1_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool)
 {
 	lzo_uint lzo_complen = 0;
 	int res;
@@ -731,7 +730,7 @@ int64_t lzbench_lzo1_compress(char *inbuf, size_t insize, char *outbuf, size_t o
 	return lzo_complen; 
 }
 
-int64_t lzbench_lzo1_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_lzo1_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	lzo_uint decomplen = 0;
 
@@ -740,7 +739,7 @@ int64_t lzbench_lzo1_decompress(char *inbuf, size_t insize, char *outbuf, size_t
 	return decomplen; 
 }
 
-int64_t lzbench_lzo1a_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem)
+int64_t lzbench_lzo1a_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool)
 {
 	lzo_uint lzo_complen = 0;
 	int res;
@@ -758,7 +757,7 @@ int64_t lzbench_lzo1a_compress(char *inbuf, size_t insize, char *outbuf, size_t 
 	return lzo_complen; 
 }
 
-int64_t lzbench_lzo1a_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_lzo1a_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	lzo_uint decomplen = 0;
 
@@ -767,7 +766,7 @@ int64_t lzbench_lzo1a_decompress(char *inbuf, size_t insize, char *outbuf, size_
 	return decomplen; 
 }
 
-int64_t lzbench_lzo1b_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem)
+int64_t lzbench_lzo1b_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool)
 {
 	lzo_uint lzo_complen = 0;
 	int res;
@@ -796,7 +795,7 @@ int64_t lzbench_lzo1b_compress(char *inbuf, size_t insize, char *outbuf, size_t 
 	return lzo_complen; 
 }
 
-int64_t lzbench_lzo1b_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_lzo1b_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	lzo_uint decomplen = 0;
 
@@ -805,7 +804,7 @@ int64_t lzbench_lzo1b_decompress(char *inbuf, size_t insize, char *outbuf, size_
 	return decomplen; 
 }
 
-int64_t lzbench_lzo1c_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem)
+int64_t lzbench_lzo1c_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool)
 {
 	lzo_uint lzo_complen = 0;
 	int res;
@@ -834,7 +833,7 @@ int64_t lzbench_lzo1c_compress(char *inbuf, size_t insize, char *outbuf, size_t 
 	return lzo_complen; 
 }
 
-int64_t lzbench_lzo1c_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_lzo1c_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	lzo_uint decomplen = 0;
 
@@ -843,7 +842,7 @@ int64_t lzbench_lzo1c_decompress(char *inbuf, size_t insize, char *outbuf, size_
 	return decomplen; 
 }
 
-int64_t lzbench_lzo1f_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem)
+int64_t lzbench_lzo1f_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool)
 {
 	lzo_uint lzo_complen = 0;
 	int res;
@@ -861,7 +860,7 @@ int64_t lzbench_lzo1f_compress(char *inbuf, size_t insize, char *outbuf, size_t 
 	return lzo_complen; 
 }
 
-int64_t lzbench_lzo1f_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_lzo1f_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	lzo_uint decomplen = 0;
 
@@ -870,7 +869,7 @@ int64_t lzbench_lzo1f_decompress(char *inbuf, size_t insize, char *outbuf, size_
 	return decomplen; 
 }
 
-int64_t lzbench_lzo1x_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem)
+int64_t lzbench_lzo1x_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool)
 {
 	lzo_uint lzo_complen = 0;
 	int res;
@@ -893,7 +892,7 @@ int64_t lzbench_lzo1x_compress(char *inbuf, size_t insize, char *outbuf, size_t 
 	return lzo_complen; 
 }
 
-int64_t lzbench_lzo1x_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_lzo1x_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	lzo_uint decomplen = 0;
 
@@ -902,7 +901,7 @@ int64_t lzbench_lzo1x_decompress(char *inbuf, size_t insize, char *outbuf, size_
 	return decomplen; 
 }
 
-int64_t lzbench_lzo1y_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem)
+int64_t lzbench_lzo1y_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool)
 {
 	lzo_uint lzo_complen = 0;
 	int res;
@@ -920,7 +919,7 @@ int64_t lzbench_lzo1y_compress(char *inbuf, size_t insize, char *outbuf, size_t 
 	return lzo_complen; 
 }
 
-int64_t lzbench_lzo1y_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_lzo1y_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	lzo_uint decomplen = 0;
 
@@ -929,7 +928,7 @@ int64_t lzbench_lzo1y_decompress(char *inbuf, size_t insize, char *outbuf, size_
 	return decomplen; 
 }
 
-int64_t lzbench_lzo1z_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem)
+int64_t lzbench_lzo1z_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool)
 {
 	lzo_uint lzo_complen = 0;
 	int res;
@@ -944,7 +943,7 @@ int64_t lzbench_lzo1z_compress(char *inbuf, size_t insize, char *outbuf, size_t 
 	return lzo_complen; 
 }
 
-int64_t lzbench_lzo1z_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_lzo1z_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	lzo_uint decomplen = 0;
 
@@ -954,7 +953,7 @@ int64_t lzbench_lzo1z_decompress(char *inbuf, size_t insize, char *outbuf, size_
 }
 
 
-int64_t lzbench_lzo2a_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem)
+int64_t lzbench_lzo2a_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool)
 {
 	lzo_uint lzo_complen = 0;
 	int res;
@@ -969,7 +968,7 @@ int64_t lzbench_lzo2a_compress(char *inbuf, size_t insize, char *outbuf, size_t 
 	return lzo_complen; 
 }
 
-int64_t lzbench_lzo2a_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_lzo2a_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	lzo_uint decomplen = 0;
 
@@ -990,7 +989,7 @@ extern "C"
 	#include "lzrw/lzrw.h"
 }
 
-char* lzbench_lzrw_init(size_t, size_t, size_t)
+char* lzbench_lzrw_init(size_t, size_t, size_t, const std::string&)
 {
     return (char*) malloc(lzrw2_req_mem());
 }
@@ -1000,7 +999,7 @@ void lzbench_lzrw_deinit(char* workmem)
     free(workmem);
 }
 
-int64_t lzbench_lzrw_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem)
+int64_t lzbench_lzrw_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool)
 {
     if (!workmem)
         return 0;
@@ -1019,7 +1018,7 @@ int64_t lzbench_lzrw_compress(char *inbuf, size_t insize, char *outbuf, size_t o
 	return complen;
 }
 
-int64_t lzbench_lzrw_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem)
+int64_t lzbench_lzrw_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool)
 {
     if (!workmem)
         return 0;
@@ -1045,7 +1044,7 @@ int64_t lzbench_lzrw_decompress(char *inbuf, size_t insize, char *outbuf, size_t
 #ifndef BENCH_REMOVE_LZSSE
 #include "lzsse/lzsse2/lzsse2.h"
 
-char* lzbench_lzsse2_init(size_t insize, size_t, size_t)
+char* lzbench_lzsse2_init(size_t insize, size_t, size_t, const std::string&)
 {
     return (char*) LZSSE2_MakeOptimalParseState(insize);
 }
@@ -1056,14 +1055,14 @@ void lzbench_lzsse2_deinit(char* workmem)
     LZSSE2_FreeOptimalParseState((LZSSE2_OptimalParseState*) workmem);
 }
 
-int64_t lzbench_lzsse2_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem)
+int64_t lzbench_lzsse2_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool)
 {
     if (!workmem) return 0;
 
     return LZSSE2_CompressOptimalParse((LZSSE2_OptimalParseState*) workmem, inbuf, insize, outbuf, outsize, level);
 }
 
-int64_t lzbench_lzsse2_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_lzsse2_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	return LZSSE2_Decompress(inbuf, insize, outbuf, outsize);
 }
@@ -1071,7 +1070,7 @@ int64_t lzbench_lzsse2_decompress(char *inbuf, size_t insize, char *outbuf, size
 
 #include "lzsse/lzsse4/lzsse4.h"
 
-char* lzbench_lzsse4_init(size_t insize, size_t, size_t)
+char* lzbench_lzsse4_init(size_t insize, size_t, size_t, const std::string&)
 {
     return (char*) LZSSE4_MakeOptimalParseState(insize);
 }
@@ -1082,19 +1081,19 @@ void lzbench_lzsse4_deinit(char* workmem)
     LZSSE4_FreeOptimalParseState((LZSSE4_OptimalParseState*) workmem);
 }
 
-int64_t lzbench_lzsse4_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem)
+int64_t lzbench_lzsse4_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool)
 {
     if (!workmem) return 0;
 
     return LZSSE4_CompressOptimalParse((LZSSE4_OptimalParseState*) workmem, inbuf, insize, outbuf, outsize, level);
 }
 
-int64_t lzbench_lzsse4_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_lzsse4_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
     return LZSSE4_Decompress(inbuf, insize, outbuf, outsize);
 }
 
-char* lzbench_lzsse4fast_init(size_t, size_t, size_t)
+char* lzbench_lzsse4fast_init(size_t, size_t, size_t, const std::string&)
 {
     return (char*) LZSSE4_MakeFastParseState();
 }
@@ -1105,7 +1104,7 @@ void lzbench_lzsse4fast_deinit(char* workmem)
     LZSSE4_FreeFastParseState((LZSSE4_FastParseState*) workmem);
 }
 
-int64_t lzbench_lzsse4fast_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char* workmem)
+int64_t lzbench_lzsse4fast_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char* workmem, bool)
 {
     if (!workmem) return 0;
 
@@ -1115,7 +1114,7 @@ int64_t lzbench_lzsse4fast_compress(char *inbuf, size_t insize, char *outbuf, si
 
 #include "lzsse/lzsse8/lzsse8.h"
 
-char* lzbench_lzsse8_init(size_t insize, size_t, size_t)
+char* lzbench_lzsse8_init(size_t insize, size_t, size_t, const std::string&)
 {
     return (char*) LZSSE8_MakeOptimalParseState(insize);
 }
@@ -1126,19 +1125,19 @@ void lzbench_lzsse8_deinit(char* workmem)
     LZSSE8_FreeOptimalParseState((LZSSE8_OptimalParseState*) workmem);
 }
 
-int64_t lzbench_lzsse8_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem)
+int64_t lzbench_lzsse8_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool)
 {
     if (!workmem) return 0;
 
     return LZSSE8_CompressOptimalParse((LZSSE8_OptimalParseState*) workmem, inbuf, insize, outbuf, outsize, level);
 }
 
-int64_t lzbench_lzsse8_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_lzsse8_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
     return LZSSE8_Decompress(inbuf, insize, outbuf, outsize);
 }
 
-char* lzbench_lzsse8fast_init(size_t, size_t, size_t)
+char* lzbench_lzsse8fast_init(size_t, size_t, size_t, const std::string&)
 {
     return (char*) LZSSE8_MakeFastParseState();
 }
@@ -1149,7 +1148,7 @@ void lzbench_lzsse8fast_deinit(char* workmem)
     LZSSE8_FreeFastParseState((LZSSE8_FastParseState*) workmem);
 }
 
-int64_t lzbench_lzsse8fast_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char* workmem)
+int64_t lzbench_lzsse8fast_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char* workmem, bool)
 {
     if (!workmem) return 0;
 
@@ -1163,12 +1162,12 @@ int64_t lzbench_lzsse8fast_compress(char *inbuf, size_t insize, char *outbuf, si
 #ifndef BENCH_REMOVE_PITHY
 #include "pithy/pithy.h"
 
-int64_t lzbench_pithy_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_pithy_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	return pithy_Compress(inbuf, insize, outbuf, outsize, level);
 }
 
-int64_t lzbench_pithy_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_pithy_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	size_t res = pithy_Decompress(inbuf, insize, outbuf, outsize);
 //	printf("insize=%lld outsize=%lld res=%lld\n", insize, outsize, res);
@@ -1185,7 +1184,7 @@ int64_t lzbench_pithy_decompress(char *inbuf, size_t insize, char *outbuf, size_
 #include "quicklz/quicklz.h"
 #define MAX(a,b) ((a)>(b))?(a):(b) 
 
-int64_t lzbench_quicklz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t , char*)
+int64_t lzbench_quicklz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t , char*, bool)
 {
     int64_t res;
     qlz150_state_compress* state = (qlz150_state_compress*) calloc(1, MAX(qlz_get_setting_3(1),MAX(qlz_get_setting_1(1), qlz_get_setting_2(1))));
@@ -1206,7 +1205,7 @@ int64_t lzbench_quicklz_compress(char *inbuf, size_t insize, char *outbuf, size_
     return res;
 }
 
-int64_t lzbench_quicklz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t , char*)
+int64_t lzbench_quicklz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t , char*, bool)
 {
     int64_t res;
     qlz150_state_compress* dstate = (qlz150_state_compress*) calloc(1, MAX(qlz_get_setting_3(2),MAX(qlz_get_setting_1(2), qlz_get_setting_2(2))));
@@ -1233,12 +1232,12 @@ int64_t lzbench_quicklz_decompress(char *inbuf, size_t insize, char *outbuf, siz
 #ifndef BENCH_REMOVE_SHRINKER
 #include "shrinker/shrinker.h"
 
-int64_t lzbench_shrinker_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_shrinker_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	return shrinker_compress(inbuf, outbuf, insize); 
 }
 
-int64_t lzbench_shrinker_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_shrinker_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	return shrinker_decompress(inbuf, outbuf, outsize); 
 }
@@ -1249,13 +1248,13 @@ int64_t lzbench_shrinker_decompress(char *inbuf, size_t insize, char *outbuf, si
 #ifndef BENCH_REMOVE_SNAPPY
 #include "snappy/snappy.h"
 
-int64_t lzbench_snappy_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_snappy_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	snappy::RawCompress(inbuf, insize, outbuf, &outsize);
 	return outsize;
 }
 
-int64_t lzbench_snappy_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_snappy_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	snappy::RawUncompress(inbuf, insize, outbuf);
 	return outsize;
@@ -1269,12 +1268,12 @@ int64_t lzbench_snappy_decompress(char *inbuf, size_t insize, char *outbuf, size
 #ifndef BENCH_REMOVE_TORNADO
 #include "tornado/tor_test.h"
 
-int64_t lzbench_tornado_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_tornado_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	return tor_compress(level, (uint8_t*)inbuf, insize, (uint8_t*)outbuf, outsize); 
 }
 
-int64_t lzbench_tornado_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_tornado_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	return tor_decompress((uint8_t*)inbuf, insize, (uint8_t*)outbuf, outsize); 
 }
@@ -1286,7 +1285,7 @@ int64_t lzbench_tornado_decompress(char *inbuf, size_t insize, char *outbuf, siz
 #ifndef BENCH_REMOVE_UCL
 #include "ucl/ucl.h"
 
-int64_t lzbench_ucl_nrv2b_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_ucl_nrv2b_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	ucl_uint complen;
 	int res = ucl_nrv2b_99_compress((uint8_t*)inbuf, insize, (uint8_t*)outbuf, &complen, NULL, level, NULL, NULL);
@@ -1295,7 +1294,7 @@ int64_t lzbench_ucl_nrv2b_compress(char *inbuf, size_t insize, char *outbuf, siz
 	return complen;
 }
 
-int64_t lzbench_ucl_nrv2b_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_ucl_nrv2b_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	ucl_uint decomplen;
 	int res = ucl_nrv2b_decompress_8((uint8_t*)inbuf, insize, (uint8_t*)outbuf, &decomplen, NULL);
@@ -1304,7 +1303,7 @@ int64_t lzbench_ucl_nrv2b_decompress(char *inbuf, size_t insize, char *outbuf, s
 	return decomplen;
 }
 
-int64_t lzbench_ucl_nrv2d_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_ucl_nrv2d_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	ucl_uint complen;
 	int res = ucl_nrv2d_99_compress((uint8_t*)inbuf, insize, (uint8_t*)outbuf, &complen, NULL, level, NULL, NULL);
@@ -1313,7 +1312,7 @@ int64_t lzbench_ucl_nrv2d_compress(char *inbuf, size_t insize, char *outbuf, siz
 	return complen;
 }
 
-int64_t lzbench_ucl_nrv2d_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_ucl_nrv2d_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	ucl_uint decomplen;
 	int res = ucl_nrv2d_decompress_8((uint8_t*)inbuf, insize, (uint8_t*)outbuf, &decomplen, NULL);
@@ -1322,7 +1321,7 @@ int64_t lzbench_ucl_nrv2d_decompress(char *inbuf, size_t insize, char *outbuf, s
 	return decomplen;
 }
 
-int64_t lzbench_ucl_nrv2e_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_ucl_nrv2e_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	ucl_uint complen;
 	int res = ucl_nrv2e_99_compress((uint8_t*)inbuf, insize, (uint8_t*)outbuf, &complen, NULL, level, NULL, NULL);
@@ -1331,7 +1330,7 @@ int64_t lzbench_ucl_nrv2e_compress(char *inbuf, size_t insize, char *outbuf, siz
 	return complen;
 }
 
-int64_t lzbench_ucl_nrv2e_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_ucl_nrv2e_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	ucl_uint decomplen;
 	int res = ucl_nrv2e_decompress_8((uint8_t*)inbuf, insize, (uint8_t*)outbuf, &decomplen, NULL);
@@ -1347,7 +1346,7 @@ int64_t lzbench_ucl_nrv2e_decompress(char *inbuf, size_t insize, char *outbuf, s
 #ifndef BENCH_REMOVE_WFLZ
 #include "wflz/wfLZ.h"
 
-char* lzbench_wflz_init(size_t, size_t, size_t)
+char* lzbench_wflz_init(size_t, size_t, size_t, const std::string&)
 {
     return (char*) malloc(wfLZ_GetWorkMemSize());
 }
@@ -1357,7 +1356,7 @@ void lzbench_wflz_deinit(char* workmem)
     free(workmem);
 }
 
-int64_t lzbench_wflz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem)
+int64_t lzbench_wflz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool)
 {
     int64_t res;
     if (!workmem)
@@ -1371,7 +1370,7 @@ int64_t lzbench_wflz_compress(char *inbuf, size_t insize, char *outbuf, size_t o
     return res;
 }
 
-int64_t lzbench_wflz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_wflz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
     wfLZ_Decompress((const uint8_t*)inbuf, (uint8_t*)outbuf);
     return outsize;
@@ -1389,7 +1388,7 @@ typedef struct {
     struct xpack_decompressor *xpackd;
 } xpack_params_s;
 
-char* lzbench_xpack_init(size_t insize, size_t level, size_t)
+char* lzbench_xpack_init(size_t insize, size_t level, size_t, const std::string&)
 {
     xpack_params_s* xpack_params = (xpack_params_s*) malloc(sizeof(xpack_params_s));
     if (!xpack_params) return NULL;
@@ -1408,7 +1407,7 @@ void lzbench_xpack_deinit(char* workmem)
     free(workmem);
 }
 
-int64_t lzbench_xpack_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem)
+int64_t lzbench_xpack_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool)
 {
     xpack_params_s* xpack_params = (xpack_params_s*) workmem;
     if (!xpack_params || !xpack_params->xpackc) return 0;
@@ -1416,7 +1415,7 @@ int64_t lzbench_xpack_compress(char *inbuf, size_t insize, char *outbuf, size_t 
     return xpack_compress(xpack_params->xpackc, inbuf, insize, outbuf, outsize);
 }
 
-int64_t lzbench_xpack_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char* workmem)
+int64_t lzbench_xpack_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char* workmem, bool)
 {
     xpack_params_s* xpack_params = (xpack_params_s*) workmem;
     if (!xpack_params || !xpack_params->xpackd) return 0;
@@ -1434,12 +1433,12 @@ int64_t lzbench_xpack_decompress(char *inbuf, size_t insize, char *outbuf, size_
 #ifndef BENCH_REMOVE_XZ
 #include "xz/alone.h" 
 
-int64_t lzbench_xz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_xz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
     return xz_alone_compress(inbuf, insize, outbuf, outsize, level, 0, 0);
 }
 
-int64_t lzbench_xz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_xz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
     return xz_alone_decompress(inbuf, insize, outbuf, outsize, 0, 0, 0);
 }
@@ -1451,7 +1450,7 @@ int64_t lzbench_xz_decompress(char *inbuf, size_t insize, char *outbuf, size_t o
 #ifndef BENCH_REMOVE_YALZ77
 #include "yalz77/lz77.h"
 
-int64_t lzbench_yalz77_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_yalz77_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
   lz77::compress_t compress(level, lz77::DEFAULT_BLOCKSIZE);
   std::string compressed = compress.feed((unsigned char*)inbuf, (unsigned char*)inbuf+insize);
@@ -1460,7 +1459,7 @@ int64_t lzbench_yalz77_compress(char *inbuf, size_t insize, char *outbuf, size_t
   return compressed.size();
 }
 
-int64_t lzbench_yalz77_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_yalz77_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
   lz77::decompress_t decompress;
   std::string temp;
@@ -1478,18 +1477,18 @@ int64_t lzbench_yalz77_decompress(char *inbuf, size_t insize, char *outbuf, size
 #ifndef BENCH_REMOVE_YAPPY
 #include "yappy/yappy.hpp"
 
-char* lzbench_yappy_init(size_t insize, size_t level, size_t)
+char* lzbench_yappy_init(size_t insize, size_t level, size_t, const std::string&)
 {
 	YappyFillTables();
     return NULL;
 }
 
-int64_t lzbench_yappy_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_yappy_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	return YappyCompress((uint8_t*)inbuf, (uint8_t*)outbuf, insize, level) - (uint8_t*)outbuf; 
 }
 
-int64_t lzbench_yappy_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_yappy_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	return YappyUnCompress((uint8_t*)inbuf, (uint8_t*)inbuf+insize, (uint8_t*)outbuf) - (uint8_t*)outbuf; 
 }
@@ -1501,7 +1500,7 @@ int64_t lzbench_yappy_decompress(char *inbuf, size_t insize, char *outbuf, size_
 #ifndef BENCH_REMOVE_ZLIB
 #include "zlib/zlib.h"
 
-int64_t lzbench_zlib_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_zlib_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	uLongf zcomplen = insize;
 	int err = compress2((uint8_t*)outbuf, &zcomplen, (uint8_t*)inbuf, insize, level);
@@ -1510,7 +1509,7 @@ int64_t lzbench_zlib_compress(char *inbuf, size_t insize, char *outbuf, size_t o
 	return zcomplen;
 }
 
-int64_t lzbench_zlib_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_zlib_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	uLongf zdecomplen = outsize;
 	int err = uncompress((uint8_t*)outbuf, &zdecomplen, (uint8_t*)inbuf, insize); 
@@ -1529,7 +1528,7 @@ extern "C"
 	#include "slz/slz.h"
 }
 
-int64_t lzbench_slz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t param2, char*)
+int64_t lzbench_slz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t param2, char*, bool)
 {
 	struct slz_stream strm;
 	size_t outlen = 0;
@@ -1559,7 +1558,7 @@ int64_t lzbench_slz_compress(char *inbuf, size_t insize, char *outbuf, size_t ou
 }
 
 /* uses zlib to perform the decompression */
-int64_t lzbench_slz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t param2, char*)
+int64_t lzbench_slz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t param2, char*, bool)
 {
 	z_stream stream;
 	int err;
@@ -1647,7 +1646,7 @@ private:
 }  // namespace zling
 }  // namespace baidu
 
-int64_t lzbench_zling_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_zling_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	baidu::zling::MemInputter  inputter((uint8_t*)inbuf, insize);
 	baidu::zling::MemOutputter outputter((uint8_t*)outbuf, outsize);
@@ -1656,7 +1655,7 @@ int64_t lzbench_zling_compress(char *inbuf, size_t insize, char *outbuf, size_t 
 	return outputter.GetOutputSize();
 }
 
-int64_t lzbench_zling_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_zling_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	baidu::zling::MemInputter  inputter((uint8_t*)inbuf, insize);
 	baidu::zling::MemOutputter outputter((uint8_t*)outbuf, outsize);
@@ -1677,27 +1676,28 @@ typedef struct {
     ZSTD_CCtx* cctx;
     ZSTD_DCtx* dctx;
     ZSTD_CDict* cdict;
-    ZSTD_parameters zparams;
-    ZSTD_customMem cmem;
+    ZSTD_DDict* ddict;
 } zstd_params_s;
 
-char* lzbench_zstd_init(size_t insize, size_t level, size_t windowLog)
+// dictionary could be train follow this link: https://github.com/google/brotli/issues/697
+char* lzbench_zstd_init(size_t insize, size_t level, size_t windowLog, const std::string& dictionary)
 {
+    ZSTD_CDict* cdict = NULL;
+    ZSTD_DDict* ddict = NULL;
     zstd_params_s* zstd_params = (zstd_params_s*) malloc(sizeof(zstd_params_s));
     if (!zstd_params) return NULL;
     zstd_params->cctx = ZSTD_createCCtx();
     zstd_params->dctx = ZSTD_createDCtx();
-#if 1
-    zstd_params->cdict = NULL;
-#else
-    zstd_params->zparams = ZSTD_getParams(level, insize, 0);
-    zstd_params->cmem = { NULL, NULL, NULL };
-    if (windowLog && zstd_params->zparams.cParams.windowLog > windowLog) {
-        zstd_params->zparams.cParams.windowLog = windowLog;
-        zstd_params->zparams.cParams.chainLog = windowLog + ((zstd_params->zparams.cParams.strategy == ZSTD_btlazy2) | (zstd_params->zparams.cParams.strategy == ZSTD_btopt) | (zstd_params->zparams.cParams.strategy == ZSTD_btopt2));
+    ZSTD_CCtx_setParameter(zstd_params->cctx, ZSTD_c_compressionLevel, level);
+    ZSTD_CCtx_setParameter(zstd_params->cctx, ZSTD_c_windowLog, windowLog);
+    if (!dictionary.empty()) {
+        cdict = ZSTD_createCDict(dictionary.data(), dictionary.length(), level);;
+        ZSTD_CCtx_refCDict(zstd_params->cctx, cdict);
+        ddict = ZSTD_createDDict(dictionary.data(), dictionary.length());
+        ZSTD_DCtx_refDDict(zstd_params->dctx, ddict);
     }
-    zstd_params->cdict = ZSTD_createCDict_advanced(NULL, 0, zstd_params->zparams, zstd_params->cmem);
-#endif
+    zstd_params->cdict = cdict;
+    zstd_params->ddict = ddict;
 
     return (char*) zstd_params;
 }
@@ -1709,58 +1709,67 @@ void lzbench_zstd_deinit(char* workmem)
     if (zstd_params->cctx) ZSTD_freeCCtx(zstd_params->cctx);
     if (zstd_params->dctx) ZSTD_freeDCtx(zstd_params->dctx);
     if (zstd_params->cdict) ZSTD_freeCDict(zstd_params->cdict);
+    if (zstd_params->ddict) ZSTD_freeDDict(zstd_params->ddict);
     free(workmem);
 }
 
-int64_t lzbench_zstd_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t windowLog, char* workmem)
+int64_t lzbench_zstd_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char* workmem, bool endstream)
 {
-    size_t res;
-
     zstd_params_s* zstd_params = (zstd_params_s*) workmem;
     if (!zstd_params || !zstd_params->cctx) return 0;
 
-#if 1
-    zstd_params->zparams = ZSTD_getParams(level, insize, 0);
-    ZSTD_CCtx_setParameter(zstd_params->cctx, ZSTD_c_compressionLevel, level);
-    zstd_params->zparams.fParams.contentSizeFlag = 1;
+    // From https://github.com/facebook/zstd/blob/dev/examples/streaming_compression.c
+    size_t wsize = 0;
+    ZSTD_EndDirective const mode = endstream ? ZSTD_e_end : ZSTD_e_continue;
+    ZSTD_inBuffer input = { inbuf, insize, 0 };
+    int finished;
+    do {
+        ZSTD_outBuffer output = { outbuf+wsize, outsize-wsize, 0 };
+        const size_t remaining = ZSTD_compressStream2(zstd_params->cctx, &output , &input, mode);
+        wsize += output.pos;
 
-    if (windowLog && zstd_params->zparams.cParams.windowLog > windowLog) {
-        zstd_params->zparams.cParams.windowLog = windowLog;
-        zstd_params->zparams.cParams.chainLog = windowLog + ((zstd_params->zparams.cParams.strategy == ZSTD_btlazy2) || (zstd_params->zparams.cParams.strategy == ZSTD_btopt) || (zstd_params->zparams.cParams.strategy == ZSTD_btultra));
-    }
-    res = ZSTD_compress_advanced(zstd_params->cctx, outbuf, outsize, inbuf, insize, NULL, 0, zstd_params->zparams);
-//    res = ZSTD_compressCCtx(zstd_params->cctx, outbuf, outsize, inbuf, insize, level);
-#else
-    if (!zstd_params->cdict) return 0;
-    res = ZSTD_compress_usingCDict(zstd_params->cctx, outbuf, outsize, inbuf, insize, zstd_params->cdict);
-#endif
-    if (ZSTD_isError(res)) return res;
+        finished = endstream ? (remaining == 0) : (input.pos == input.size);
+    } while (!finished);
 
-    return res;
+    return wsize;
 }
 
-int64_t lzbench_zstd_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char* workmem)
+int64_t lzbench_zstd_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char* workmem, bool)
 {
     zstd_params_s* zstd_params = (zstd_params_s*) workmem;
     if (!zstd_params || !zstd_params->dctx) return 0;
 
-    return ZSTD_decompressDCtx(zstd_params->dctx, outbuf, outsize, inbuf, insize);
+    size_t last_ret = 0;
+    size_t wsize = 0;
+    ZSTD_inBuffer input = { inbuf, insize, 0 };
+    while (input.pos < input.size) {
+        ZSTD_outBuffer output = { outbuf+wsize, outsize-wsize, 0 };
+        const size_t ret = ZSTD_decompressStream(zstd_params->dctx, &output , &input);
+        wsize += output.pos;
+        last_ret = ret;
+    }
+
+    if (last_ret != 0) {
+        return 0;
+    }
+
+    return wsize;
 }
 
-char* lzbench_zstd_LDM_init(size_t insize, size_t level, size_t windowLog)
+char* lzbench_zstd_LDM_init(size_t insize, size_t level, size_t windowLog, const std::string& dict)
 {
-    zstd_params_s* zstd_params = (zstd_params_s*) lzbench_zstd_init(insize, level, windowLog);
+    zstd_params_s* zstd_params = (zstd_params_s*) lzbench_zstd_init(insize, level, windowLog, dict);
     if (!zstd_params) return NULL;
     ZSTD_CCtx_setParameter(zstd_params->cctx, ZSTD_c_enableLongDistanceMatching, 1);
     return (char*) zstd_params;
 }
 
-int64_t lzbench_zstd_LDM_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t windowLog, char* workmem)
+int64_t lzbench_zstd_LDM_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t windowLog, char* workmem, bool endstream)
 {
     zstd_params_s* zstd_params = (zstd_params_s*) workmem;
     if (!zstd_params || !zstd_params->cctx) return 0;
     ZSTD_CCtx_setParameter(zstd_params->cctx, ZSTD_c_enableLongDistanceMatching, 1);
-    return lzbench_zstd_compress(inbuf, insize, outbuf, outsize, level, windowLog, (char*) zstd_params);
+    return lzbench_zstd_compress(inbuf, insize, outbuf, outsize, level, windowLog, (char*) zstd_params, endstream);
 }
 #endif
 
@@ -1768,12 +1777,12 @@ int64_t lzbench_zstd_LDM_compress(char *inbuf, size_t insize, char *outbuf, size
 #ifdef BENCH_HAS_NAKAMICHI
 #include "nakamichi/nakamichi.h"
 
-int64_t lzbench_nakamichi_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+int64_t lzbench_nakamichi_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool)
 {
 	return NakaCompress(outbuf, inbuf, insize);
 }
 
-int64_t lzbench_nakamichi_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_nakamichi_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	return NakaDecompress(outbuf, inbuf, insize);
 }
@@ -1783,7 +1792,7 @@ int64_t lzbench_nakamichi_decompress(char *inbuf, size_t insize, char *outbuf, s
 #ifdef BENCH_HAS_CUDA
 #include <cuda_runtime.h>
 
-char* lzbench_cuda_init(size_t insize, size_t, size_t)
+char* lzbench_cuda_init(size_t insize, size_t, size_t, const std::string&)
 {
     char* workmem;
     cudaMalloc(& workmem, insize);
@@ -1795,14 +1804,14 @@ void lzbench_cuda_deinit(char* workmem)
     cudaFree(workmem);
 }
 
-int64_t lzbench_cuda_memcpy(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char* workmem)
+int64_t lzbench_cuda_memcpy(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char* workmem, bool)
 {
     cudaMemcpy(workmem, inbuf, insize, cudaMemcpyHostToDevice);
     cudaMemcpy(outbuf, workmem, insize, cudaMemcpyDeviceToHost);
     return insize;
 }
 
-int64_t lzbench_cuda_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char* )
+int64_t lzbench_cuda_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char*, bool)
 {
     return 0;
 }
@@ -1823,7 +1832,7 @@ typedef struct {
 
 // allocate the host and device memory buffers for the nvcom LZ4 compression and decompression
 // the chunk size is configured by the compression level, 0 to 5 inclusive, corresponding to a chunk size from 32 kB to 1 MB
-char* lzbench_nvcomp_init(size_t insize, size_t level, size_t)
+char* lzbench_nvcomp_init(size_t insize, size_t level, size_t, const std::string&)
 {
   // allocate the host memory for the algorithm options
   nvcomp_params_s* nvcomp_params = (nvcomp_params_s*) malloc(sizeof(nvcomp_params_s));

--- a/_lzbench/compressors.h
+++ b/_lzbench/compressors.h
@@ -1,17 +1,18 @@
 #ifndef LZBENCH_COMPRESSORS_H
 #define LZBENCH_COMPRESSORS_H
 
+#include <string>
 #include <stdlib.h> 
 #include <stdint.h> // int64_t
 
-int64_t lzbench_memcpy(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char* );
-int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char* );
+int64_t lzbench_memcpy(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char*, bool);
+int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char*, bool);
 
 
 
 #ifndef BENCH_REMOVE_BLOSCLZ
-	int64_t lzbench_blosclz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_blosclz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_blosclz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_blosclz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_blosclz_compress NULL
 	#define lzbench_blosclz_decompress NULL
@@ -19,10 +20,10 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_BRIEFLZ
-    char* lzbench_brieflz_init(size_t insize, size_t level, size_t);
+    char* lzbench_brieflz_init(size_t insize, size_t level, size_t, const std::string&);
     void lzbench_brieflz_deinit(char* workmem);
-	int64_t lzbench_brieflz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_brieflz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_brieflz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_brieflz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_brieflz_init NULL
 	#define lzbench_brieflz_deinit NULL
@@ -32,8 +33,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_BROTLI
-	int64_t lzbench_brotli_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_brotli_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_brotli_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_brotli_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_brotli_compress NULL
 	#define lzbench_brotli_decompress NULL
@@ -41,8 +42,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_BZIP2
-	int64_t lzbench_bzip2_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_bzip2_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_bzip2_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_bzip2_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_bzip2_compress NULL
 	#define lzbench_bzip2_decompress NULL
@@ -50,8 +51,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_CRUSH
-	int64_t lzbench_crush_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_crush_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_crush_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_crush_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_crush_compress NULL
 	#define lzbench_crush_decompress NULL
@@ -59,8 +60,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_CSC
-	int64_t lzbench_csc_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_csc_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_csc_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_csc_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_csc_compress NULL
 	#define lzbench_csc_decompress NULL
@@ -68,10 +69,10 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_DENSITY
-	char*   lzbench_density_init(size_t insize, size_t level, size_t);
+	char*   lzbench_density_init(size_t insize, size_t level, size_t, const std::string&);
 	void    lzbench_density_deinit(char* workmem);
-	int64_t lzbench_density_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_density_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_density_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_density_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_density_init NULL
 	#define lzbench_density_deinit NULL
@@ -82,8 +83,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_FASTLZ
-	int64_t lzbench_fastlz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_fastlz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_fastlz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_fastlz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_fastlz_compress NULL
 	#define lzbench_fastlz_decompress NULL
@@ -91,8 +92,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_FASTLZMA2
-	int64_t lzbench_fastlzma2_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_fastlzma2_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_fastlzma2_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_fastlzma2_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_fastlzma2_compress NULL
 	#define lzbench_fastlzma2_decompress NULL
@@ -100,8 +101,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_GIPFELI
-	int64_t lzbench_gipfeli_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_gipfeli_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_gipfeli_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_gipfeli_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_gipfeli_compress NULL
 	#define lzbench_gipfeli_decompress NULL
@@ -109,8 +110,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_GLZA
-	int64_t lzbench_glza_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
-	int64_t lzbench_glza_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_glza_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
+	int64_t lzbench_glza_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_glza_compress NULL
 	#define lzbench_glza_decompress NULL
@@ -118,8 +119,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_LIBDEFLATE
-	int64_t lzbench_libdeflate_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_libdeflate_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_libdeflate_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_libdeflate_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_libdeflate_compress NULL
 	#define lzbench_libdeflate_decompress NULL
@@ -127,8 +128,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_LIZARD
-	int64_t lzbench_lizard_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_lizard_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_lizard_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_lizard_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_lizard_compress NULL
 	#define lzbench_lizard_decompress NULL
@@ -136,10 +137,10 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_LZ4
-	int64_t lzbench_lz4_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_lz4fast_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize,  size_t level, size_t, char*);
-	int64_t lzbench_lz4hc_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize,  size_t level, size_t, char*);
-	int64_t lzbench_lz4_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_lz4_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_lz4fast_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize,  size_t level, size_t, char*, bool);
+	int64_t lzbench_lz4hc_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize,  size_t level, size_t, char*, bool);
+	int64_t lzbench_lz4_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_lz4_compress NULL
 	#define lzbench_lz4fast_compress NULL
@@ -149,8 +150,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_LZF
-	int64_t lzbench_lzf_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_lzf_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_lzf_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_lzf_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_lzf_compress NULL
 	#define lzbench_lzf_decompress NULL
@@ -158,10 +159,10 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_LZFSE
-    char* lzbench_lzfse_init(size_t insize, size_t level, size_t);
+    char* lzbench_lzfse_init(size_t insize, size_t level, size_t, const std::string&);
     void lzbench_lzfse_deinit(char* workmem);
-	int64_t lzbench_lzfse_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_lzfse_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_lzfse_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_lzfse_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_lzfse_init NULL
 	#define lzbench_lzfse_deinit NULL
@@ -171,10 +172,10 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_LZVN
-    char* lzbench_lzvn_init(size_t insize, size_t level, size_t);
+    char* lzbench_lzvn_init(size_t insize, size_t level, size_t, const std::string&);
     void lzbench_lzvn_deinit(char* workmem);
-	int64_t lzbench_lzvn_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_lzvn_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_lzvn_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_lzvn_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_lzvn_init NULL
 	#define lzbench_lzvn_deinit NULL
@@ -184,8 +185,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_LZG
-	int64_t lzbench_lzg_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_lzg_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_lzg_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_lzg_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_lzg_compress NULL
 	#define lzbench_lzg_decompress NULL
@@ -193,8 +194,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_LZHAM
-	int64_t lzbench_lzham_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_lzham_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_lzham_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_lzham_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_lzham_compress NULL
 	#define lzbench_lzham_decompress NULL
@@ -202,8 +203,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_LZJB
-	int64_t lzbench_lzjb_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_lzjb_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_lzjb_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_lzjb_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_lzjb_compress NULL
 	#define lzbench_lzjb_decompress NULL
@@ -211,8 +212,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_LZLIB
-	int64_t lzbench_lzlib_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_lzlib_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_lzlib_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_lzlib_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_lzlib_compress NULL
 	#define lzbench_lzlib_decompress NULL
@@ -220,8 +221,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_LZMA
-	int64_t lzbench_lzma_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_lzma_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_lzma_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_lzma_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_lzma_compress NULL
 	#define lzbench_lzma_decompress NULL
@@ -229,8 +230,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_LZMAT
-	int64_t lzbench_lzmat_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_lzmat_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_lzmat_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_lzmat_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_lzmat_compress NULL
 	#define lzbench_lzmat_decompress NULL
@@ -238,26 +239,26 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_LZO
-    char* lzbench_lzo_init(size_t insize, size_t level, size_t);
+    char* lzbench_lzo_init(size_t insize, size_t level, size_t, const std::string&);
     void lzbench_lzo_deinit(char* workmem);
-    int64_t lzbench_lzo1_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem);
-    int64_t lzbench_lzo1_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-    int64_t lzbench_lzo1a_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem);
-    int64_t lzbench_lzo1a_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-    int64_t lzbench_lzo1b_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem);
-    int64_t lzbench_lzo1b_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-    int64_t lzbench_lzo1c_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem);
-    int64_t lzbench_lzo1c_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-    int64_t lzbench_lzo1f_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem);
-    int64_t lzbench_lzo1f_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-    int64_t lzbench_lzo1x_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem);
-    int64_t lzbench_lzo1x_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-    int64_t lzbench_lzo1y_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem);
-    int64_t lzbench_lzo1y_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-    int64_t lzbench_lzo1z_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem);
-    int64_t lzbench_lzo1z_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-    int64_t lzbench_lzo2a_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem);
-    int64_t lzbench_lzo2a_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
+    int64_t lzbench_lzo1_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool);
+    int64_t lzbench_lzo1_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+    int64_t lzbench_lzo1a_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool);
+    int64_t lzbench_lzo1a_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+    int64_t lzbench_lzo1b_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool);
+    int64_t lzbench_lzo1b_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+    int64_t lzbench_lzo1c_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool);
+    int64_t lzbench_lzo1c_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+    int64_t lzbench_lzo1f_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool);
+    int64_t lzbench_lzo1f_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+    int64_t lzbench_lzo1x_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool);
+    int64_t lzbench_lzo1x_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+    int64_t lzbench_lzo1y_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool);
+    int64_t lzbench_lzo1y_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+    int64_t lzbench_lzo1z_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool);
+    int64_t lzbench_lzo1z_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+    int64_t lzbench_lzo2a_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool);
+    int64_t lzbench_lzo2a_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
 #else
 	#define lzbench_lzo_init NULL
 	#define lzbench_lzo_deinit NULL
@@ -283,10 +284,10 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_LZRW
-    char* lzbench_lzrw_init(size_t insize, size_t level, size_t);
+    char* lzbench_lzrw_init(size_t insize, size_t level, size_t, const std::string&);
     void lzbench_lzrw_deinit(char* workmem);
-	int64_t lzbench_lzrw_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_lzrw_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_lzrw_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_lzrw_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_lzrw_init NULL
 	#define lzbench_lzrw_deinit NULL
@@ -296,24 +297,24 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_LZSSE
-    char* lzbench_lzsse2_init(size_t insize, size_t level, size_t);
+    char* lzbench_lzsse2_init(size_t insize, size_t level, size_t, const std::string&);
     void lzbench_lzsse2_deinit(char* workmem);
-    int64_t lzbench_lzsse2_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-    int64_t lzbench_lzsse2_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
-    char* lzbench_lzsse4_init(size_t insize, size_t level, size_t);
+    int64_t lzbench_lzsse2_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+    int64_t lzbench_lzsse2_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
+    char* lzbench_lzsse4_init(size_t insize, size_t level, size_t, const std::string&);
     void lzbench_lzsse4_deinit(char* workmem);
-    int64_t lzbench_lzsse4_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-    int64_t lzbench_lzsse4_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
-    char* lzbench_lzsse4fast_init(size_t insize, size_t level, size_t);
+    int64_t lzbench_lzsse4_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+    int64_t lzbench_lzsse4_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
+    char* lzbench_lzsse4fast_init(size_t insize, size_t level, size_t, const std::string&);
     void lzbench_lzsse4fast_deinit(char* workmem);
-    int64_t lzbench_lzsse4fast_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-    char* lzbench_lzsse8_init(size_t insize, size_t level, size_t);
+    int64_t lzbench_lzsse4fast_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+    char* lzbench_lzsse8_init(size_t insize, size_t level, size_t, const std::string&);
     void lzbench_lzsse8_deinit(char* workmem);
-    int64_t lzbench_lzsse8_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-    int64_t lzbench_lzsse8_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
-    char* lzbench_lzsse8fast_init(size_t insize, size_t level, size_t);
+    int64_t lzbench_lzsse8_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+    int64_t lzbench_lzsse8_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
+    char* lzbench_lzsse8fast_init(size_t insize, size_t level, size_t, const std::string&);
     void lzbench_lzsse8fast_deinit(char* workmem);
-    int64_t lzbench_lzsse8fast_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
+    int64_t lzbench_lzsse8fast_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
 #else
     #define lzbench_lzsse2_init NULL
     #define lzbench_lzsse2_deinit NULL
@@ -337,8 +338,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_PITHY
-	int64_t lzbench_pithy_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_pithy_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_pithy_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_pithy_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_pithy_compress NULL
 	#define lzbench_pithy_decompress NULL
@@ -346,8 +347,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_QUICKLZ
-	int64_t lzbench_quicklz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_quicklz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_quicklz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_quicklz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_quicklz_compress NULL
 	#define lzbench_quicklz_decompress NULL
@@ -355,8 +356,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_SHRINKER
-	int64_t lzbench_shrinker_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_shrinker_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_shrinker_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_shrinker_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_shrinker_compress NULL
 	#define lzbench_shrinker_decompress NULL
@@ -364,8 +365,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_SLZ
-	int64_t lzbench_slz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
-	int64_t lzbench_slz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_slz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
+	int64_t lzbench_slz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_slz_compress NULL
 	#define lzbench_slz_decompress NULL
@@ -373,8 +374,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_SNAPPY
-	int64_t lzbench_snappy_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_snappy_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_snappy_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_snappy_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_snappy_compress NULL
 	#define lzbench_snappy_decompress NULL
@@ -382,8 +383,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_TORNADO
-	int64_t lzbench_tornado_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_tornado_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_tornado_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_tornado_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_tornado_compress NULL
 	#define lzbench_tornado_decompress NULL
@@ -391,12 +392,12 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_UCL
-    int64_t lzbench_ucl_nrv2b_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-    int64_t lzbench_ucl_nrv2b_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-    int64_t lzbench_ucl_nrv2d_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-    int64_t lzbench_ucl_nrv2d_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-    int64_t lzbench_ucl_nrv2e_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-    int64_t lzbench_ucl_nrv2e_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
+    int64_t lzbench_ucl_nrv2b_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+    int64_t lzbench_ucl_nrv2b_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+    int64_t lzbench_ucl_nrv2d_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+    int64_t lzbench_ucl_nrv2d_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+    int64_t lzbench_ucl_nrv2e_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+    int64_t lzbench_ucl_nrv2e_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
 #else
 	#define lzbench_ucl_nrv2b_compress NULL
 	#define lzbench_ucl_nrv2b_decompress NULL
@@ -408,10 +409,10 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_WFLZ
-    char* lzbench_wflz_init(size_t insize, size_t level, size_t);
+    char* lzbench_wflz_init(size_t insize, size_t level, size_t, const std::string&);
     void lzbench_wflz_deinit(char* workmem);
-	int64_t lzbench_wflz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_wflz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_wflz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_wflz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_wflz_init NULL
 	#define lzbench_wflz_deinit NULL
@@ -421,10 +422,10 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_XPACK
-    char* lzbench_xpack_init(size_t insize, size_t level, size_t);
+    char* lzbench_xpack_init(size_t insize, size_t level, size_t, const std::string&);
     void lzbench_xpack_deinit(char* workmem);
-	int64_t lzbench_xpack_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_xpack_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_xpack_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_xpack_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_xpack_init NULL
 	#define lzbench_xpack_deinit NULL
@@ -434,8 +435,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_XZ
-	int64_t lzbench_xz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_xz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_xz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_xz_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_xz_compress NULL
 	#define lzbench_xz_decompress NULL
@@ -443,8 +444,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_YALZ77
-	int64_t lzbench_yalz77_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_yalz77_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_yalz77_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_yalz77_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_yalz77_compress NULL
 	#define lzbench_yalz77_decompress NULL
@@ -452,9 +453,9 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_YAPPY
-    char* lzbench_yappy_init(size_t insize, size_t level, size_t);
-	int64_t lzbench_yappy_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_yappy_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+    char* lzbench_yappy_init(size_t insize, size_t level, size_t, const std::string&);
+	int64_t lzbench_yappy_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_yappy_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_yappy_init NULL
 	#define lzbench_yappy_compress NULL
@@ -463,8 +464,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_ZLIB
-	int64_t lzbench_zlib_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
-	int64_t lzbench_zlib_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_zlib_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
+	int64_t lzbench_zlib_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_zlib_compress NULL
 	#define lzbench_zlib_decompress NULL
@@ -472,8 +473,8 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_ZLING
-	int64_t lzbench_zling_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
-	int64_t lzbench_zling_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_zling_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
+	int64_t lzbench_zling_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_zling_compress NULL
 	#define lzbench_zling_decompress NULL
@@ -481,12 +482,12 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifndef BENCH_REMOVE_ZSTD
-	char* lzbench_zstd_init(size_t insize, size_t level, size_t);
+	char* lzbench_zstd_init(size_t insize, size_t level, size_t, const std::string&);
 	void lzbench_zstd_deinit(char* workmem);
-	int64_t lzbench_zstd_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
-	int64_t lzbench_zstd_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
-	char* lzbench_zstd_LDM_init(size_t insize, size_t level, size_t);
-	int64_t lzbench_zstd_LDM_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_zstd_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
+	int64_t lzbench_zstd_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
+	char* lzbench_zstd_LDM_init(size_t insize, size_t level, size_t, const std::string&);
+	int64_t lzbench_zstd_LDM_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_zstd_init NULL
 	#define lzbench_zstd_deinit NULL
@@ -498,18 +499,18 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 
 
 #ifdef BENCH_HAS_NAKAMICHI
-	int64_t lzbench_nakamichi_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
-	int64_t lzbench_nakamichi_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+	int64_t lzbench_nakamichi_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*, bool);
+	int64_t lzbench_nakamichi_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool);
 #else
 	#define lzbench_nakamichi_compress NULL
 	#define lzbench_nakamichi_decompress NULL
 #endif
 
 #ifdef BENCH_HAS_CUDA
-        char* lzbench_cuda_init(size_t insize, size_t, size_t);
+        char* lzbench_cuda_init(size_t insize, size_t, size_t, const std::string&);
         void lzbench_cuda_deinit(char* workmem);
-        int64_t lzbench_cuda_memcpy(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char* workmem);
-        int64_t lzbench_cuda_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char* );
+        int64_t lzbench_cuda_memcpy(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char* workmem, bool);
+        int64_t lzbench_cuda_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char*, bool);
 #else
         #define lzbench_cuda_init NULL
         #define lzbench_cuda_deinit NULL
@@ -518,10 +519,10 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
 #endif
 
 #ifdef BENCH_HAS_NVCOMP
-        char* lzbench_nvcomp_init(size_t insize, size_t level, size_t);
+        char* lzbench_nvcomp_init(size_t insize, size_t level, size_t, const std::string&);
         void lzbench_nvcomp_deinit(char* workmem);
-        int64_t lzbench_nvcomp_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem);
-        int64_t lzbench_nvcomp_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char* workmem);
+        int64_t lzbench_nvcomp_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char* workmem, bool);
+        int64_t lzbench_nvcomp_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char* workmem, bool);
 #else
         #define lzbench_nvcomp_init NULL
         #define lzbench_nvcomp_deinit NULL

--- a/_lzbench/csc_codec.cpp
+++ b/_lzbench/csc_codec.cpp
@@ -39,7 +39,7 @@ size_t stdio_write(void *p, const void *buf, size_t size)
     return size;
 }
 
-int64_t lzbench_csc_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t dict_size, char*)
+int64_t lzbench_csc_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t dict_size, char*, bool)
 {
 	MemSeqStream isss, osss;
 	CSCProps p;
@@ -71,7 +71,7 @@ int64_t lzbench_csc_compress(char *inbuf, size_t insize, char *outbuf, size_t ou
 }
 
 
-int64_t lzbench_csc_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*)
+int64_t lzbench_csc_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*, bool)
 {
 	MemSeqStream isss, osss;
 	CSCProps p;

--- a/_lzbench/lzbench.h
+++ b/_lzbench/lzbench.h
@@ -84,8 +84,9 @@ typedef struct string_table
 {
     std::string col1_algname;
     uint64_t col2_ctime, col3_dtime, col4_comprsize, col5_origsize;
-    std::string col6_filename;
-    string_table(std::string c1, uint64_t c2, uint64_t c3, uint64_t c4, uint64_t c5, std::string filename) : col1_algname(c1), col2_ctime(c2), col3_dtime(c3), col4_comprsize(c4), col5_origsize(c5), col6_filename(filename) {}
+    bool col6_dictionary;
+    std::string col7_filename;
+    string_table(std::string c1, uint64_t c2, uint64_t c3, uint64_t c4, uint64_t c5, bool dictionary, std::string filename) : col1_algname(c1), col2_ctime(c2), col3_dtime(c3), col4_comprsize(c4), col5_origsize(c5), col6_dictionary(dictionary), col7_filename(filename) {}
 } string_table_t;
 
 enum textformat_e { MARKDOWN=1, TEXT, TEXT_FULL, CSV, TURBOBENCH, MARKDOWN2 };
@@ -102,6 +103,7 @@ typedef struct
     int random_read;
     std::vector<string_table_t> results;
     const char* in_filename;
+    const char* dictionary;
 } lzbench_params_t;
 
 struct less_using_1st_column { inline bool operator() (const string_table_t& struct1, const string_table_t& struct2) {  return (struct1.col1_algname < struct2.col1_algname); } };
@@ -110,8 +112,8 @@ struct less_using_3rd_column { inline bool operator() (const string_table_t& str
 struct less_using_4th_column { inline bool operator() (const string_table_t& struct1, const string_table_t& struct2) {  return (struct1.col4_comprsize < struct2.col4_comprsize); } };
 struct less_using_5th_column { inline bool operator() (const string_table_t& struct1, const string_table_t& struct2) {  return (struct1.col5_origsize < struct2.col5_origsize); } };
 
-typedef int64_t (*compress_func)(char *in, size_t insize, char *out, size_t outsize, size_t, size_t, char*);
-typedef char* (*init_func)(size_t insize, size_t, size_t);
+typedef int64_t (*compress_func)(char *in, size_t insize, char *out, size_t outsize, size_t, size_t, char*, bool);
+typedef char* (*init_func)(size_t insize, size_t, size_t, const std::string&);
 typedef void (*deinit_func)(char* workmem);
 
 typedef struct


### PR DESCRIPTION
Hi @inikep, @jinfeihan57. So far compress/decompress with custom dictionary is more and more popular, such as zstd, and the newest [brotli](https://github.com/google/brotli/blob/master/c/include/brotli/shared_dictionary.h) has support it.

In new version, we can use a specific dictionary to compress/decompress:
```
./lzbench -ezlib,5/brotli,2,11/zstd,3,11 -dzstd=zstd_dict test.pdf
```

So I raise a PR to add dictionary for lzbench, could you help me review it? Thanks!