### PR TITLE
Cuda memcpy not used

### DIFF
--- a/_lzbench/compressors.cpp
+++ b/_lzbench/compressors.cpp
@@ -17,11 +17,6 @@ int64_t lzbench_memcpy(char *inbuf, size_t insize, char *outbuf, size_t outsize,
     return insize;
 }
 
-int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char* )
-{
-    return 0;
-}
-
 
 #ifndef BENCH_REMOVE_BLOSCLZ
 #include "blosclz/blosclz.h"
@@ -1782,11 +1777,6 @@ int64_t lzbench_cuda_memcpy(char *inbuf, size_t insize, char *outbuf, size_t out
     cudaMemcpy(workmem, inbuf, insize, cudaMemcpyHostToDevice);
     cudaMemcpy(outbuf, workmem, insize, cudaMemcpyDeviceToHost);
     return insize;
-}
-
-int64_t lzbench_cuda_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char* )
-{
-    return 0;
 }
 
 #ifdef BENCH_HAS_NVCOMP

--- a/_lzbench/compressors.h
+++ b/_lzbench/compressors.h
@@ -5,7 +5,6 @@
 #include <stdint.h> // int64_t
 
 int64_t lzbench_memcpy(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char* );
-int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char* );
 
 
 
@@ -500,12 +499,10 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
         char* lzbench_cuda_init(size_t insize, size_t, size_t);
         void lzbench_cuda_deinit(char* workmem);
         int64_t lzbench_cuda_memcpy(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char* workmem);
-        int64_t lzbench_cuda_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char* );
 #else
         #define lzbench_cuda_init NULL
         #define lzbench_cuda_deinit NULL
         #define lzbench_cuda_memcpy NULL
-        #define lzbench_cuda_return_0 NULL
 #endif
 
 #ifdef BENCH_HAS_NVCOMP

--- a/_lzbench/lzbench.h
+++ b/_lzbench/lzbench.h
@@ -140,7 +140,7 @@ typedef struct
 
 static const compressor_desc_t comp_desc[LZBENCH_COMPRESSOR_COUNT] =
 {
-    { "memcpy",     "",            0,   0,    0,       0, lzbench_return_0,            lzbench_memcpy,                NULL,                    NULL },
+    { "memcpy",     "",            0,   0,    0,       0, lzbench_memcpy,              lzbench_memcpy,                NULL,                    NULL },
     { "blosclz",    "2.0.0",       1,   9,    0, 64*1024, lzbench_blosclz_compress,    lzbench_blosclz_decompress,    NULL,                    NULL },
     { "brieflz",    "1.3.0",       1,   9,    0,       0, lzbench_brieflz_compress,    lzbench_brieflz_decompress,    lzbench_brieflz_init,    lzbench_brieflz_deinit },
     { "brotli",     "1.0.9",       0,  11,    0,       0, lzbench_brotli_compress,     lzbench_brotli_decompress,     NULL,                    NULL },
@@ -210,7 +210,7 @@ static const compressor_desc_t comp_desc[LZBENCH_COMPRESSOR_COUNT] =
     { "zstd22LDM",  "1.5.5",       1,  22,   22,       0, lzbench_zstd_LDM_compress,   lzbench_zstd_decompress,       lzbench_zstd_LDM_init,   lzbench_zstd_deinit },
     { "zstd24LDM",  "1.5.5",       1,  22,   24,       0, lzbench_zstd_LDM_compress,   lzbench_zstd_decompress,       lzbench_zstd_LDM_init,   lzbench_zstd_deinit },
     { "nakamichi",  "okamigan",    0,   0,    0,       0, lzbench_nakamichi_compress,  lzbench_nakamichi_decompress,  NULL,                    NULL },
-    { "cudaMemcpy", "",            0,   0,    0,       0, lzbench_cuda_return_0,       lzbench_cuda_memcpy,           lzbench_cuda_init,       lzbench_cuda_deinit },
+    { "cudaMemcpy", "",            0,   0,    0,       0, lzbench_cuda_memcpy,         lzbench_cuda_memcpy,           lzbench_cuda_init,       lzbench_cuda_deinit },
     { "nvcomp_lz4", "1.2.2",       0,   5,    0,       0, lzbench_nvcomp_compress,     lzbench_nvcomp_decompress,     lzbench_nvcomp_init,     lzbench_nvcomp_deinit },
 };
 


### PR DESCRIPTION
The CUDA memcpy is never called when running the benchmark. 
For the compression, it calls `lzbench_cuda_return_0` which does nothing, causing the output to be set equal [by this part](https://github.com/inikep/lzbench/blob/d138844ea56b36ff1c1c43b259c866069deb64ad/_lzbench/lzbench.cpp#L284C1-L289C10).

During the decompression is the size of the compressed data the same size as the input data, which causes the decompression to use `memcpy` instead of the `lzbench_cuda_memcpy` function. [See this part](https://github.com/inikep/lzbench/blob/d138844ea56b36ff1c1c43b259c866069deb64ad/_lzbench/lzbench.cpp#L311C6-L319).

This also affects the normal memcpy, which is never executed. It is actually executing [this line](https://github.com/inikep/lzbench/blob/d138844ea56b36ff1c1c43b259c866069deb64ad/_lzbench/lzbench.cpp#L313C9-L313C9).

From:
```
lzbench 1.8 (64-bit Linux)  11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
Assembled by P.Skibinski

Compressor name         Compress. Decompress. Compr. size  Ratio Filename
memcpy                  32299 MB/s 32091 MB/s    10192446 100.00 ../datasets/silesia/dickens
cudaMemcpy              34108 MB/s 32113 MB/s    10192446 100.00 ../datasets/silesia/dickens
nvcomp_lz4 1.2.2 -0       627 MB/s  1704 MB/s     6890640  67.61 ../datasets/silesia/dickens
nvcomp_lz4 1.2.2 -1       398 MB/s  1178 MB/s     6688442  65.62 ../datasets/silesia/dickens
```
![before](https://github.com/inikep/lzbench/assets/11787137/a4b56b1c-dc4a-4aa1-84b1-b8abd72ffeae)


To:
```
lzbench 1.8 (64-bit Linux)  11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
Assembled by P.Skibinski

Compressor name         Compress. Decompress. Compr. size  Ratio Filename
memcpy                  17350 MB/s 34845 MB/s    10192446 100.00 ../datasets/silesia/dickens
cudaMemcpy               2810 MB/s  3066 MB/s    10192446 100.00 ../datasets/silesia/dickens
nvcomp_lz4 1.2.2 -0       627 MB/s  1698 MB/s     6890640  67.61 ../datasets/silesia/dickens
nvcomp_lz4 1.2.2 -1       398 MB/s  1176 MB/s     6688442  65.62 ../datasets/silesia/dickens
```
![after](https://github.com/inikep/lzbench/assets/11787137/b93fea88-e131-49b9-a4f0-afca5a3abc0c)

Note that there is something weird going on with memcpy now.