### PR TITLE
Implementation of RLE encoder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ LIBDEFLATE_FILES += libdeflate/lib/deflate_decompress.o libdeflate/lib/gzip_comp
 LIBDEFLATE_FILES += libdeflate/lib/x86/cpu_features.o libdeflate/lib/arm/cpu_features.o libdeflate/lib/zlib_compress.o libdeflate/lib/zlib_decompress.o
 
 MISC_FILES = crush/crush.o shrinker/shrinker.o fastlz/fastlz.o pithy/pithy.o lzjb/lzjb2010.o wflz/wfLZ.o
-MISC_FILES += lzlib/lzlib.o blosclz/blosclz.o blosclz/fastcopy.o slz/slz.o
+MISC_FILES += lzlib/lzlib.o rle/rle.o  blosclz/blosclz.o blosclz/fastcopy.o slz/slz.o
 
 LZBENCH_FILES = _lzbench/lzbench.o _lzbench/compressors.o _lzbench/csc_codec.o
 
@@ -370,4 +370,4 @@ lzbench: $(BZIP2_FILES) $(DENSITY_FILES) $(FASTLZMA2_OBJ) $(ZSTD_FILES) $(GLZA_F
 	$(CXX) $(CFLAGS) $< -c -o $@
 
 clean:
-	rm -rf lzbench lzbench.exe *.o _lzbench/*.o bzip2/*.o fast-lzma2/*.o slz/*.o zstd/lib/*.o zstd/lib/*.a zstd/lib/common/*.o zstd/lib/compress/*.o zstd/lib/decompress/*.o zstd/lib/dictBuilder/*.o lzsse/lzsse2/*.o lzsse/lzsse4/*.o lzsse/lzsse8/*.o lzfse/*.o xpack/lib/*.o blosclz/*.o gipfeli/*.o xz/*.o xz/common/*.o xz/check/*.o xz/lzma/*.o xz/lz/*.o xz/rangecoder/*.o liblzg/*.o lzlib/*.o brieflz/*.o brotli/common/*.o brotli/enc/*.o brotli/dec/*.o libcsc/*.o wflz/*.o lzjb/*.o lzma/*.o density/buffers/*.o density/algorithms/*.o density/algorithms/cheetah/core/*.o density/algorithms/*.o density/algorithms/lion/forms/*.o density/algorithms/lion/core/*.o density/algorithms/chameleon/core/*.o density/*.o density/structure/*.o pithy/*.o glza/*.o libzling/*.o yappy/*.o shrinker/*.o fastlz/*.o ucl/*.o zlib/*.o lzham/*.o lzmat/*.o lz4/*.o crush/*.o lzf/*.o lzrw/*.o lzo/*.o snappy/*.o quicklz/*.o tornado/*.o libdeflate/lib/*.o libdeflate/lib/x86/*.o libdeflate/lib/arm/*.o nakamichi/*.o nvcomp/*.o
+	rm -rf lzbench lzbench.exe *.o _lzbench/*.o bzip2/*.o fast-lzma2/*.o slz/*.o zstd/lib/*.o zstd/lib/*.a zstd/lib/common/*.o zstd/lib/compress/*.o zstd/lib/decompress/*.o zstd/lib/dictBuilder/*.o lzsse/lzsse2/*.o lzsse/lzsse4/*.o lzsse/lzsse8/*.o lzfse/*.o xpack/lib/*.o rle/*.o blosclz/*.o gipfeli/*.o xz/*.o xz/common/*.o xz/check/*.o xz/lzma/*.o xz/lz/*.o xz/rangecoder/*.o liblzg/*.o lzlib/*.o brieflz/*.o brotli/common/*.o brotli/enc/*.o brotli/dec/*.o libcsc/*.o wflz/*.o lzjb/*.o lzma/*.o density/buffers/*.o density/algorithms/*.o density/algorithms/cheetah/core/*.o density/algorithms/*.o density/algorithms/lion/forms/*.o density/algorithms/lion/core/*.o density/algorithms/chameleon/core/*.o density/*.o density/structure/*.o pithy/*.o glza/*.o libzling/*.o yappy/*.o shrinker/*.o fastlz/*.o ucl/*.o zlib/*.o lzham/*.o lzmat/*.o lz4/*.o crush/*.o lzf/*.o lzrw/*.o lzo/*.o snappy/*.o quicklz/*.o tornado/*.o libdeflate/lib/*.o libdeflate/lib/x86/*.o libdeflate/lib/arm/*.o nakamichi/*.o nvcomp/*.o

--- a/_lzbench/compressors.cpp
+++ b/_lzbench/compressors.cpp
@@ -22,6 +22,20 @@ int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsiz
     return 0;
 }
 
+#ifndef BENCH_REMOVE_RLE
+#include "rle/rle.hpp"
+
+int64_t lzbench_rle_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*)
+{
+    return rle_compress((const std::uint8_t *)inbuf, insize, (std::uint8_t *)outbuf, outsize);
+}
+
+int64_t lzbench_rle_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char*)
+{
+    return rle_decompress((const std::uint8_t *)inbuf, insize, (std::uint8_t *)outbuf, outsize);
+}
+
+#endif // BENCH_REMOVE_RLE
 
 #ifndef BENCH_REMOVE_BLOSCLZ
 #include "blosclz/blosclz.h"

--- a/_lzbench/compressors.h
+++ b/_lzbench/compressors.h
@@ -8,6 +8,13 @@ int64_t lzbench_memcpy(char *inbuf, size_t insize, char *outbuf, size_t outsize,
 int64_t lzbench_return_0(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t , size_t, char* );
 
 
+#ifndef BENCH_REMOVE_RLE
+	int64_t lzbench_rle_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);
+	int64_t lzbench_rle_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t, size_t, char*);
+#else
+	#define lzbench_rle_compress NULL
+	#define lzbench_rle_decompress NULL
+#endif
 
 #ifndef BENCH_REMOVE_BLOSCLZ
 	int64_t lzbench_blosclz_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t, char*);

--- a/_lzbench/lzbench.h
+++ b/_lzbench/lzbench.h
@@ -136,11 +136,12 @@ typedef struct
 
 
 
-#define LZBENCH_COMPRESSOR_COUNT 72
+#define LZBENCH_COMPRESSOR_COUNT 73
 
 static const compressor_desc_t comp_desc[LZBENCH_COMPRESSOR_COUNT] =
 {
     { "memcpy",     "",            0,   0,    0,       0, lzbench_return_0,            lzbench_memcpy,                NULL,                    NULL },
+    { "rle",        "",            0,   0,    0,       0, lzbench_rle_compress,        lzbench_rle_decompress,        NULL,                    NULL },
     { "blosclz",    "2.0.0",       1,   9,    0, 64*1024, lzbench_blosclz_compress,    lzbench_blosclz_decompress,    NULL,                    NULL },
     { "brieflz",    "1.3.0",       1,   9,    0,       0, lzbench_brieflz_compress,    lzbench_brieflz_decompress,    lzbench_brieflz_init,    lzbench_brieflz_deinit },
     { "brotli",     "1.0.9",       0,  11,    0,       0, lzbench_brotli_compress,     lzbench_brotli_decompress,     NULL,                    NULL },
@@ -223,14 +224,14 @@ static const alias_desc_t alias_desc[LZBENCH_ALIASES_COUNT] =
     { "fast", "density/fastlz,10,11,12,13,14/lz4/lz4fast,3,17/lzf/lzfse/lzjb/lzo1b,1/lzo1c,1/lzo1f,1/lzo1x,1/lzo1y,1/" \
               "lzrw,1,3,4,5/lzsse4fast/lzsse8fast/lzvn/pithy,0,3,6,9/quicklz,1,2/shrinker/snappy/tornado,1,2,3/zstd,1,2,3,4,5" }, // default alias
 #if !defined(__arm__) && !defined(__aarch64__)
-    { "all",  "blosclz,1,3,6,9/brieflz,1,3,6,8/brotli,0,2,5,8,11/bzip2,1,5,9/" \
+    { "all",  "rle/blosclz,1,3,6,9/brieflz,1,3,6,8/brotli,0,2,5,8,11/bzip2,1,5,9/" \
               "crush,0,1,2/csc,1,3,5/density,1,2,3/fastlz,1,2/fastlzma2,1,3,5,8,10/gipfeli/libdeflate,1,3,6,9,12/lz4/lz4fast,3,17/lz4hc,1,4,9,12/" \
               "lzf,0,1/lzfse/lzg,1,4,6,8/lzham,0,1/lzjb/lzlib,0,3,6,9/lzma,0,2,4,5,9/lzo1/lzo1a/lzo1b,1,3,6,9,99,999/lzo1c,1,3,6,9,99,999/lzo1f/lzo1x/lzo1y/lzo1z/lzo2a/" \
               "lzrw,1,3,4,5/lzsse2,1,6,12,16/lzsse4,1,6,12,16/lzsse8,1,6,12,16/lzvn/pithy,0,3,6,9/quicklz,1,2,3/slz_gzip/snappy/tornado,1,2,3,4,5,6,7,10,13,16/" \
               "ucl_nrv2b,1,6,9/ucl_nrv2d,1,6,9/ucl_nrv2e,1,6,9/xpack,1,6,9/xz,0,3,6,9/yalz77,1,4,8,12/yappy,1,10,100/zlib,1,6,9/zling,0,1,2,3,4/zstd,1,2,5,8,11,15,18,22/" \
               "shrinker/wflz/lzmat" }, // these can SEGFAULT
 #else
-    { "all",  "blosclz,1,3,6,9/brieflz,1,3,6,8/brotli,0,2,5,8/bzip2,1,5,9/" \
+    { "all",  "rle/blosclz,1,3,6,9/brieflz,1,3,6,8/brotli,0,2,5,8/bzip2,1,5,9/" \
               "crush,0,1,2/csc,1,3,5/density,1,2,3/fastlz,1,2/gipfeli/libdeflate,1,3,6,9,12/lz4/lz4fast,3,17/lz4hc,1,4,9/" \
               "lzf,0,1/lzfse/lzg,1,4,6,8/lzham,0,1/lzjb/lzlib,0,3,6,9/lzma,0,2,4,5/lzo1/lzo1a/lzo1b,1,3,6,9,99,999/lzo1c,1,3,6,9,99,999/lzo1f/lzo1x/lzo1y/lzo1z/lzo2a/" \
               "lzrw,1,3,4,5/lzsse2,1,6,12,16/lzsse4,1,6,12,16/lzsse8,1,6,12,16/lzvn/pithy,0,3,6,9/quicklz,1,2,3/slz_gzip/snappy/tornado,1,2,3,4,5,6,7,10,13,16/" \

--- a/rle/rle.cpp
+++ b/rle/rle.cpp
@@ -1,0 +1,83 @@
+#include "rle.hpp"
+
+template <typename T> int write_data(std::uint8_t *&output, const T val) {
+    *reinterpret_cast<T *>(output) = val;
+    output += sizeof(T);
+    return sizeof(T);
+}
+
+template <typename T> void read_data(const std::uint8_t *&input, T &val) {
+    val = *reinterpret_cast<const T *>(input);
+    input += sizeof(T);
+}
+
+std::size_t rle_compress(const std::uint8_t *input, const std::size_t in_size_bytes, std::uint8_t *output,
+                         const std::size_t out_size_bytes) {
+    if (input == nullptr || output == nullptr) {
+        return -1;
+    }
+    if (in_size_bytes <= 0 || in_size_bytes <= 0) {
+        return -1;
+    }
+
+    std::size_t bytes_written = 0;
+    rle::RleWord rle_count = 0;
+    std::uint8_t rle_byte = *input;
+
+    for (int i = 0; i < in_size_bytes; ++i, ++rle_count) {
+        const std::uint8_t b = *input++;
+
+        // Output when we hit the end of a sequence or the max size of a RLE word:
+        if (b != rle_byte || rle_count == rle::max_run_length) {
+            if ((bytes_written + sizeof(rle::RleWord) + sizeof(std::uint8_t)) > static_cast<unsigned>(out_size_bytes)) {
+                // Can't fit anymore data! Stop with an error.
+                return -1;
+            }
+            bytes_written += write_data(output, rle_count);
+            bytes_written += write_data(output, rle_byte);
+            rle_count = 0;
+            rle_byte = b;
+        }
+    }
+
+    // Residual count at the end:
+    if (rle_count != 0) {
+        if ((bytes_written + sizeof(rle::RleWord) + sizeof(std::uint8_t)) > static_cast<unsigned>(out_size_bytes)) {
+            return -1; // No more space! Output not complete.
+        }
+        bytes_written += write_data(output, rle_count);
+        bytes_written += write_data(output, rle_byte);
+    }
+
+    return bytes_written;
+}
+
+std::size_t rle_decompress(const std::uint8_t *input, const std::size_t in_size_bytes, std::uint8_t *output,
+                           const std::size_t out_size_bytes) {
+    if (input == nullptr || output == nullptr) {
+        return -1;
+    }
+    if (in_size_bytes <= 0 || out_size_bytes <= 0) {
+        return -1;
+    }
+
+    int bytes_written = 0;
+    rle::RleWord rle_count = 0;
+    std::uint8_t rle_byte = 0;
+
+    for (int i = 0; i < in_size_bytes; i += sizeof(rle_count) + sizeof(rle_byte)) {
+        read_data(input, rle_count);
+        read_data(input, rle_byte);
+
+        // Replicate the RLE packet.
+        while (rle_count--) {
+            *output++ = rle_byte;
+            if (++bytes_written == out_size_bytes && rle_count != 0) {
+                // Reached end of output and we are not done yet, stop with an error.
+                return -1;
+            }
+        }
+    }
+
+    return bytes_written;
+}

--- a/rle/rle.hpp
+++ b/rle/rle.hpp
@@ -1,0 +1,32 @@
+#ifndef RLE_H
+#define RLE_H
+
+#include <cstddef>
+#include <cstdint>
+
+namespace rle {
+
+// #define RLE_WORD_SIZE_16
+// 16-bits run-length word allows for very long sequences,
+// but is also very inefficient if the run-lengths are generally
+// short. Byte-size words are used if this is not defined.
+//
+#ifdef RLE_WORD_SIZE_16
+using RleWord = std::uint16_t;
+constexpr RleWord max_run_length = RleWord(0xFFFF); // Max run length: 65535 => 4 bytes.
+#else                                               // !RLE_WORD_SIZE_16
+using RleWord = std::uint8_t;
+constexpr RleWord max_run_length = RleWord(0xFF); // Max run length: 255 => 2 bytes.
+#endif                                              // RLE_WORD_SIZE_16
+
+} // namespace rle
+
+std::size_t rle_compress(const std::uint8_t *input, const std::size_t in_size_bytes, std::uint8_t *output,
+                                const std::size_t out_size_bytes);
+
+
+std::size_t rle_decompress(const std::uint8_t *input, const std::size_t in_size_bytes, std::uint8_t *output,
+                                const std::size_t out_size_bytes);
+
+
+#endif // RLE_H


### PR DESCRIPTION
Implementation of known [Run-length encoding](https://en.wikipedia.org/wiki/Run-length_encoding) algorithm.

Current comparison table

```out
lzbench 1.8 (64-bit Linux)  AMD Ryzen 9 5950X 16-Core Processor

Compressor name         Compress. Decompress. Compr. size  Ratio Filename
bzip2 1.0.8 -9           18.9 MB/s  42.4 MB/s       39400  27.97 data/old_man_and_the_sea.txt
bzip2 1.0.8 -5           18.8 MB/s  42.5 MB/s       39400  27.97 data/old_man_and_the_sea.txt
bzip2 1.0.8 -1           18.2 MB/s  44.1 MB/s       41903  29.75 data/old_man_and_the_sea.txt
brotli 1.0.9 -11         0.87 MB/s   415 MB/s       42267  30.01 data/old_man_and_the_sea.txt
lzlib 1.12-rc2 -9        4.80 MB/s  58.5 MB/s       44245  31.41 data/old_man_and_the_sea.txt
xz 5.2.5 -9              3.92 MB/s  77.9 MB/s       44263  31.42 data/old_man_and_the_sea.txt
xz 5.2.5 -6              5.34 MB/s  81.8 MB/s       44263  31.42 data/old_man_and_the_sea.txt
lzma 19.00 -9            5.78 MB/s  90.0 MB/s       44272  31.43 data/old_man_and_the_sea.txt
lzma 19.00 -5            5.87 MB/s  90.2 MB/s       44282  31.44 data/old_man_and_the_sea.txt
lzlib 1.12-rc2 -6        4.92 MB/s  58.5 MB/s       44371  31.50 data/old_man_and_the_sea.txt
fastlzma2 1.0.1 -10      8.59 MB/s  88.8 MB/s       44419  31.54 data/old_man_and_the_sea.txt
csc 2016-10-13 -5        10.7 MB/s  61.2 MB/s       44502  31.59 data/old_man_and_the_sea.txt
fastlzma2 1.0.1 -8       9.51 MB/s  88.7 MB/s       44524  31.61 data/old_man_and_the_sea.txt
zstd 1.5.5 -18           3.67 MB/s  1099 MB/s       44785  31.80 data/old_man_and_the_sea.txt
zstd 1.5.5 -22           3.67 MB/s  1099 MB/s       44785  31.80 data/old_man_and_the_sea.txt
fastlzma2 1.0.1 -5       11.8 MB/s  88.6 MB/s       44800  31.81 data/old_man_and_the_sea.txt
csc 2016-10-13 -3        12.1 MB/s  60.5 MB/s       44979  31.93 data/old_man_and_the_sea.txt
fastlzma2 1.0.1 -3       12.3 MB/s  87.9 MB/s       45131  32.04 data/old_man_and_the_sea.txt
zstd 1.5.5 -15           8.77 MB/s  1117 MB/s       45223  32.11 data/old_man_and_the_sea.txt
libdeflate 1.9 -12       7.91 MB/s   855 MB/s       46602  33.09 data/old_man_and_the_sea.txt
zling 2018-10-12 -4      60.9 MB/s   191 MB/s       46799  33.22 data/old_man_and_the_sea.txt
brotli 1.0.9 -8          30.5 MB/s   518 MB/s       46847  33.26 data/old_man_and_the_sea.txt
zling 2018-10-12 -3      67.1 MB/s   189 MB/s       47012  33.38 data/old_man_and_the_sea.txt
zstd 1.5.5 -11           15.8 MB/s  1253 MB/s       47181  33.50 data/old_man_and_the_sea.txt
lzham 1.0 -d26 -1        4.77 MB/s   268 MB/s       47221  33.52 data/old_man_and_the_sea.txt
csc 2016-10-13 -1        27.5 MB/s  56.4 MB/s       47326  33.60 data/old_man_and_the_sea.txt
lzlib 1.12-rc2 -3        9.29 MB/s  55.7 MB/s       47356  33.62 data/old_man_and_the_sea.txt
zling 2018-10-12 -2      75.3 MB/s   188 MB/s       47358  33.62 data/old_man_and_the_sea.txt
zling 2018-10-12 -1      84.1 MB/s   187 MB/s       47676  33.85 data/old_man_and_the_sea.txt
xz 5.2.5 -3              13.0 MB/s  77.6 MB/s       47887  34.00 data/old_man_and_the_sea.txt
tornado 0.6a -16         8.40 MB/s   265 MB/s       47898  34.01 data/old_man_and_the_sea.txt
xpack 2016-06-02 -9      20.0 MB/s  1162 MB/s       47958  34.05 data/old_man_and_the_sea.txt
zstd 1.5.5 -8            52.6 MB/s  1200 MB/s       48265  34.27 data/old_man_and_the_sea.txt
brotli 1.0.9 -5          47.1 MB/s   498 MB/s       48272  34.27 data/old_man_and_the_sea.txt
zling 2018-10-12 -0      88.0 MB/s   182 MB/s       48319  34.30 data/old_man_and_the_sea.txt
libdeflate 1.9 -9        24.1 MB/s   761 MB/s       48624  34.52 data/old_man_and_the_sea.txt
tornado 0.6a -13         9.24 MB/s   260 MB/s       48676  34.56 data/old_man_and_the_sea.txt
xpack 2016-06-02 -6      46.0 MB/s  1130 MB/s       48742  34.60 data/old_man_and_the_sea.txt
lzma 19.00 -4            25.2 MB/s  82.7 MB/s       48808  34.65 data/old_man_and_the_sea.txt
lzma 19.00 -2            25.2 MB/s  82.9 MB/s       48808  34.65 data/old_man_and_the_sea.txt
zstd 1.5.5 -5             101 MB/s  1209 MB/s       48822  34.66 data/old_man_and_the_sea.txt
fastlzma2 1.0.1 -1       24.9 MB/s  80.3 MB/s       48952  34.75 data/old_man_and_the_sea.txt
zlib 1.2.11 -9           12.6 MB/s   390 MB/s       49277  34.98 data/old_man_and_the_sea.txt
libdeflate 1.9 -6        66.5 MB/s   785 MB/s       49278  34.98 data/old_man_and_the_sea.txt
zlib 1.2.11 -6           21.8 MB/s   389 MB/s       49627  35.23 data/old_man_and_the_sea.txt
tornado 0.6a -10         12.7 MB/s   252 MB/s       50458  35.82 data/old_man_and_the_sea.txt
brieflz 1.3.0 -8         10.4 MB/s   398 MB/s       50558  35.89 data/old_man_and_the_sea.txt
tornado 0.6a -7          33.3 MB/s   249 MB/s       50845  36.10 data/old_man_and_the_sea.txt
lzma 19.00 -0            28.7 MB/s  75.7 MB/s       51054  36.25 data/old_man_and_the_sea.txt
libdeflate 1.9 -3         129 MB/s   812 MB/s       51278  36.40 data/old_man_and_the_sea.txt
lzfse 2017-03-08         91.1 MB/s   796 MB/s       51388  36.48 data/old_man_and_the_sea.txt
crush 1.0 -2             8.28 MB/s   386 MB/s       51632  36.66 data/old_man_and_the_sea.txt
zstd 1.5.5 -2             231 MB/s  1186 MB/s       51966  36.89 data/old_man_and_the_sea.txt
brotli 1.0.9 -2           126 MB/s   434 MB/s       51987  36.91 data/old_man_and_the_sea.txt
lzsse2 2019-04-18 -12    11.1 MB/s  5016 MB/s       52035  36.94 data/old_man_and_the_sea.txt
lzsse2 2019-04-18 -6     11.1 MB/s  5016 MB/s       52035  36.94 data/old_man_and_the_sea.txt
lzsse2 2019-04-18 -16    11.1 MB/s  5017 MB/s       52035  36.94 data/old_man_and_the_sea.txt
brieflz 1.3.0 -6         46.5 MB/s   387 MB/s       52160  37.03 data/old_man_and_the_sea.txt
lzlib 1.12-rc2 -0        36.5 MB/s  49.7 MB/s       52283  37.12 data/old_man_and_the_sea.txt
lzsse4 2019-04-18 -16    12.7 MB/s  5226 MB/s       52285  37.12 data/old_man_and_the_sea.txt
lzsse4 2019-04-18 -12    12.7 MB/s  5230 MB/s       52285  37.12 data/old_man_and_the_sea.txt
lzsse4 2019-04-18 -6     12.7 MB/s  5236 MB/s       52285  37.12 data/old_man_and_the_sea.txt
lzsse8 2019-04-18 -12    12.2 MB/s  5161 MB/s       52778  37.47 data/old_man_and_the_sea.txt
lzsse8 2019-04-18 -6     12.3 MB/s  5155 MB/s       52778  37.47 data/old_man_and_the_sea.txt
lzsse8 2019-04-18 -16    12.2 MB/s  5155 MB/s       52778  37.47 data/old_man_and_the_sea.txt
crush 1.0 -1             16.3 MB/s   383 MB/s       52880  37.54 data/old_man_and_the_sea.txt
tornado 0.6a -6          55.1 MB/s   241 MB/s       53047  37.66 data/old_man_and_the_sea.txt
zstd 1.5.5 -1             280 MB/s  1282 MB/s       53622  38.07 data/old_man_and_the_sea.txt
xz 5.2.5 -0              22.1 MB/s  64.8 MB/s       53920  38.28 data/old_man_and_the_sea.txt
tornado 0.6a -5          65.6 MB/s   234 MB/s       54066  38.38 data/old_man_and_the_sea.txt
libdeflate 1.9 -1         244 MB/s   719 MB/s       54477  38.68 data/old_man_and_the_sea.txt
lzo1b 2.10 -999          13.2 MB/s   734 MB/s       55222  39.20 data/old_man_and_the_sea.txt
ucl_nrv2e 1.03 -9        3.18 MB/s   350 MB/s       55335  39.29 data/old_man_and_the_sea.txt
ucl_nrv2d 1.03 -9        3.29 MB/s   339 MB/s       55896  39.68 data/old_man_and_the_sea.txt
ucl_nrv2e 1.03 -6        14.2 MB/s   333 MB/s       55908  39.69 data/old_man_and_the_sea.txt
xpack 2016-06-02 -1       191 MB/s   808 MB/s       55909  39.69 data/old_man_and_the_sea.txt
ucl_nrv2b 1.03 -9        3.17 MB/s   350 MB/s       56145  39.86 data/old_man_and_the_sea.txt
lzham 1.0 -d26 -0        12.3 MB/s   201 MB/s       56389  40.03 data/old_man_and_the_sea.txt
ucl_nrv2b 1.03 -6        14.1 MB/s   333 MB/s       56444  40.07 data/old_man_and_the_sea.txt
ucl_nrv2d 1.03 -6        14.8 MB/s   323 MB/s       56520  40.13 data/old_man_and_the_sea.txt
lzo1x 2.10 -999          6.76 MB/s   601 MB/s       56687  40.24 data/old_man_and_the_sea.txt
brieflz 1.3.0 -3          113 MB/s   367 MB/s       56881  40.38 data/old_man_and_the_sea.txt
lzo1z 2.10 -999          6.74 MB/s   585 MB/s       56953  40.43 data/old_man_and_the_sea.txt
lzo1y 2.10 -999          6.72 MB/s   594 MB/s       57313  40.69 data/old_man_and_the_sea.txt
crush 1.0 -0             31.0 MB/s   360 MB/s       57424  40.77 data/old_man_and_the_sea.txt
lzmat 1.01               22.9 MB/s   394 MB/s       57481  40.81 data/old_man_and_the_sea.txt
tornado 0.6a -4           129 MB/s   276 MB/s       57537  40.85 data/old_man_and_the_sea.txt
tornado 0.6a -3           163 MB/s   275 MB/s       57571  40.87 data/old_man_and_the_sea.txt
lz4hc 1.9.3 -12          15.8 MB/s  3288 MB/s       57980  41.16 data/old_man_and_the_sea.txt
lzo1c 2.10 -999          24.1 MB/s   639 MB/s       58302  41.39 data/old_man_and_the_sea.txt
lz4hc 1.9.3 -9           24.0 MB/s  3325 MB/s       58743  41.70 data/old_man_and_the_sea.txt
zlib 1.2.11 -1            114 MB/s   365 MB/s       59078  41.94 data/old_man_and_the_sea.txt
lzo2a 2.10 -999          27.8 MB/s   507 MB/s       59366  42.15 data/old_man_and_the_sea.txt
brotli 1.0.9 -0           354 MB/s   371 MB/s       59990  42.59 data/old_man_and_the_sea.txt
lzsse4 2019-04-18 -1     23.9 MB/s  4508 MB/s       60629  43.04 data/old_man_and_the_sea.txt
lzsse8 2019-04-18 -1     22.3 MB/s  4556 MB/s       60890  43.23 data/old_man_and_the_sea.txt
lzo1f 2.10 -999          19.4 MB/s   609 MB/s       60908  43.24 data/old_man_and_the_sea.txt
lz4hc 1.9.3 -4           66.1 MB/s  3210 MB/s       61099  43.38 data/old_man_and_the_sea.txt
brieflz 1.3.0 -1          208 MB/s   356 MB/s       61296  43.52 data/old_man_and_the_sea.txt
ucl_nrv2b 1.03 -1        49.8 MB/s   280 MB/s       62144  44.12 data/old_man_and_the_sea.txt
ucl_nrv2e 1.03 -1        50.7 MB/s   276 MB/s       62385  44.29 data/old_man_and_the_sea.txt
ucl_nrv2d 1.03 -1        51.5 MB/s   273 MB/s       62537  44.40 data/old_man_and_the_sea.txt
lzvn 2017-03-08          60.4 MB/s   852 MB/s       63821  45.31 data/old_man_and_the_sea.txt
gipfeli 2016-07-13        296 MB/s   621 MB/s       64546  45.82 data/old_man_and_the_sea.txt
lzo1b 2.10 -99            135 MB/s   625 MB/s       64885  46.07 data/old_man_and_the_sea.txt
quicklz 1.5.0 -3         61.5 MB/s   817 MB/s       64895  46.07 data/old_man_and_the_sea.txt
quicklz 1.5.0 -2          216 MB/s   567 MB/s       64931  46.10 data/old_man_and_the_sea.txt
lzrw 15-Jul-1991 -5       145 MB/s   564 MB/s       65393  46.43 data/old_man_and_the_sea.txt
lz4hc 1.9.3 -1            108 MB/s  2981 MB/s       66186  46.99 data/old_man_and_the_sea.txt
lzo1c 2.10 -99            120 MB/s   622 MB/s       66228  47.02 data/old_man_and_the_sea.txt
lzo1a 2.10 -99            128 MB/s   648 MB/s       67419  47.86 data/old_man_and_the_sea.txt
lzo1b 2.10 -9             169 MB/s   622 MB/s       67581  47.98 data/old_man_and_the_sea.txt
lzo1 2.10 -99             128 MB/s   607 MB/s       67657  48.03 data/old_man_and_the_sea.txt
lzo1c 2.10 -9             154 MB/s   618 MB/s       68379  48.55 data/old_man_and_the_sea.txt
lzsse2 2019-04-18 -1     28.8 MB/s  3796 MB/s       68531  48.65 data/old_man_and_the_sea.txt
lzo1b 2.10 -6             200 MB/s   647 MB/s       69254  49.17 data/old_man_and_the_sea.txt
lzo1c 2.10 -6             185 MB/s   636 MB/s       70347  49.94 data/old_man_and_the_sea.txt
lzo1b 2.10 -3             245 MB/s   634 MB/s       70458  50.02 data/old_man_and_the_sea.txt
lzg 1.0.10 -8            5.69 MB/s   572 MB/s       70613  50.13 data/old_man_and_the_sea.txt
yappy 2014-03-22 -100    93.4 MB/s  2768 MB/s       70912  50.34 data/old_man_and_the_sea.txt
pithy 2011-12-24 -9       399 MB/s  2053 MB/s       71126  50.50 data/old_man_and_the_sea.txt
tornado 0.6a -2           256 MB/s   408 MB/s       71131  50.50 data/old_man_and_the_sea.txt
yappy 2014-03-22 -10      108 MB/s  2763 MB/s       71711  50.91 data/old_man_and_the_sea.txt
lzo1c 2.10 -3             241 MB/s   612 MB/s       72168  51.24 data/old_man_and_the_sea.txt
yalz77 2015-09-19 -12    62.1 MB/s   686 MB/s       72257  51.30 data/old_man_and_the_sea.txt
pithy 2011-12-24 -6       451 MB/s  1982 MB/s       72583  51.53 data/old_man_and_the_sea.txt
lzg 1.0.10 -6            7.28 MB/s   540 MB/s       72631  51.56 data/old_man_and_the_sea.txt
yalz77 2015-09-19 -8     70.5 MB/s   684 MB/s       72679  51.60 data/old_man_and_the_sea.txt
yalz77 2015-09-19 -4     85.2 MB/s   676 MB/s       73673  52.30 data/old_man_and_the_sea.txt
yappy 2014-03-22 -1       146 MB/s  2587 MB/s       74371  52.80 data/old_man_and_the_sea.txt
lzo1b 2.10 -1             241 MB/s   593 MB/s       74487  52.88 data/old_man_and_the_sea.txt
quicklz 1.5.0 -1          385 MB/s   594 MB/s       75448  53.56 data/old_man_and_the_sea.txt
lzrw 15-Jul-1991 -4       326 MB/s   523 MB/s       75561  53.64 data/old_man_and_the_sea.txt
lzf 3.6 -1                312 MB/s   610 MB/s       75569  53.65 data/old_man_and_the_sea.txt
lzo1c 2.10 -1             241 MB/s   573 MB/s       76197  54.10 data/old_man_and_the_sea.txt
fastlz 0.5.0 -2           292 MB/s   595 MB/s       76836  54.55 data/old_man_and_the_sea.txt
shrinker 0.1              365 MB/s  1247 MB/s       77129  54.76 data/old_man_and_the_sea.txt
pithy 2011-12-24 -3       422 MB/s  1703 MB/s       77413  54.96 data/old_man_and_the_sea.txt
lzg 1.0.10 -4            8.22 MB/s   476 MB/s       77604  55.09 data/old_man_and_the_sea.txt
fastlz 0.5.0 -1           311 MB/s   607 MB/s       77796  55.23 data/old_man_and_the_sea.txt
yalz77 2015-09-19 -1      122 MB/s   644 MB/s       77858  55.28 data/old_man_and_the_sea.txt
slz_gzip 1.2.0 -3         284 MB/s   326 MB/s       77989  55.37 data/old_man_and_the_sea.txt
lzrw 15-Jul-1991 -3       293 MB/s   582 MB/s       78330  55.61 data/old_man_and_the_sea.txt
lzo1x 2.10 -1             441 MB/s   533 MB/s       78428  55.68 data/old_man_and_the_sea.txt
slz_gzip 1.2.0 -2         288 MB/s   326 MB/s       78489  55.72 data/old_man_and_the_sea.txt
lzo1f 2.10 -1             208 MB/s   528 MB/s       78790  55.94 data/old_man_and_the_sea.txt
lzo1x 2.10 -15            460 MB/s   530 MB/s       79090  56.15 data/old_man_and_the_sea.txt
snappy 2020-07-11         471 MB/s  1249 MB/s       79675  56.57 data/old_man_and_the_sea.txt
lzo1a 2.10 -1             294 MB/s   570 MB/s       79898  56.72 data/old_man_and_the_sea.txt
lzf 3.6 -0                335 MB/s   566 MB/s       80479  57.14 data/old_man_and_the_sea.txt
lz4 1.9.3                 496 MB/s  3375 MB/s       80499  57.15 data/old_man_and_the_sea.txt
lzo1y 2.10 -1             467 MB/s   543 MB/s       80547  57.18 data/old_man_and_the_sea.txt
lzo1 2.10 -1              301 MB/s   536 MB/s       80548  57.19 data/old_man_and_the_sea.txt
slz_gzip 1.2.0 -1         297 MB/s   322 MB/s       80668  57.27 data/old_man_and_the_sea.txt
lzo1x 2.10 -12            447 MB/s   526 MB/s       80954  57.47 data/old_man_and_the_sea.txt
tornado 0.6a -1           307 MB/s   366 MB/s       83666  59.40 data/old_man_and_the_sea.txt
lzo1x 2.10 -11            457 MB/s   528 MB/s       84063  59.68 data/old_man_and_the_sea.txt
pithy 2011-12-24 -0       413 MB/s  1608 MB/s       84087  59.70 data/old_man_and_the_sea.txt
lzrw 15-Jul-1991 -1       280 MB/s   471 MB/s       84170  59.76 data/old_man_and_the_sea.txt
density 0.14.2 -3         240 MB/s   267 MB/s       84685  60.12 data/old_man_and_the_sea.txt
lz4fast 1.9.3 -3          566 MB/s  3767 MB/s       87629  62.21 data/old_man_and_the_sea.txt
lzg 1.0.10 -1            9.08 MB/s   441 MB/s       87761  62.31 data/old_man_and_the_sea.txt
density 0.14.2 -2         971 MB/s  1286 MB/s       91717  65.11 data/old_man_and_the_sea.txt
density 0.14.2 -1        4233 MB/s  1555 MB/s       92529  65.69 data/old_man_and_the_sea.txt
wflz 2015-09-16           265 MB/s   716 MB/s       96359  68.41 data/old_man_and_the_sea.txt
lzjb 2010                 248 MB/s   412 MB/s       99648  70.75 data/old_man_and_the_sea.txt
blosclz 2.0.0 -9          273 MB/s   524 MB/s      103757  73.66 data/old_man_and_the_sea.txt
blosclz 2.0.0 -6          273 MB/s   523 MB/s      103757  73.66 data/old_man_and_the_sea.txt
lz4fast 1.9.3 -17        1744 MB/s  9064 MB/s      120514  85.56 data/old_man_and_the_sea.txt
rle                      1712 MB/s 59157 MB/s      140855 100.00 data/old_man_and_the_sea.txt
blosclz 2.0.0 -3         1810 MB/s 58518 MB/s      140855 100.00 data/old_man_and_the_sea.txt
blosclz 2.0.0 -1        35231 MB/s 58689 MB/s      140855 100.00 data/old_man_and_the_sea.txt
```