### PR TITLE
Don't link rt on macOS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,11 @@ else
 		DONT_BUILD_CSC ?= 1
 	endif
 
-	LDFLAGS	+= -pthread -lrt
+	ifneq ($(shell uname -s),Darwin)
+		LDFLAGS += -lrt
+	endif
+
+	LDFLAGS	+= -pthread
 
 	ifeq ($(BUILD_STATIC),1)
 		LDFLAGS	+= -lrt -static


### PR DESCRIPTION
I had trouble compiling on an M1 mac running macOS Sonoma 14.3.1. I would get the following linker error:

```
ld: library 'rt' not found
```

To resolve this, I removed linking the `rt` library on macos, and this seems to have resolved my issues.