### PR TITLE
Add Tamp's License & README

### DIFF
--- a/tamp/LICENSE
+++ b/tamp/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright CURRENT_YEAR_HERE YOUR_NAME_HERE
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tamp/README.md
+++ b/tamp/README.md
@@ -1,0 +1,300 @@
+<div align="center">
+  <img src="https://raw.githubusercontent.com/BrianPugh/tamp/main/assets/logo_300w.png">
+</div>
+
+<div align="center">
+
+![Python compat](https://img.shields.io/badge/%3E=python-3.8-blue.svg)
+[![PyPi](https://img.shields.io/pypi/v/tamp.svg)](https://pypi.python.org/pypi/tamp)
+[![GHA Status](https://github.com/BrianPugh/tamp/actions/workflows/tests.yaml/badge.svg?branch=main)](https://github.com/BrianPugh/tamp/actions?query=workflow%3Atests)
+[![Coverage](https://codecov.io/github/BrianPugh/tamp/coverage.svg?branch=main)](https://codecov.io/github/BrianPugh/tamp?branch=main)
+[![Documentation Status](https://readthedocs.org/projects/tamp/badge/?version=latest)](https://tamp.readthedocs.io/en/latest/?badge=latest)
+
+</div>
+
+---
+
+**Documentation:** https://tamp.readthedocs.io/en/latest/
+
+**Source Code:** https://github.com/BrianPugh/tamp
+
+---
+
+Tamp is a low-memory, DEFLATE-inspired lossless compression library intended for embedded targets.
+
+Tamp delivers the highest data compression ratios, while using the least amount of RAM and firmware storage.
+
+# Features
+
+* Various language implementations available:
+    * Pure Python reference:
+        * `tamp/__init__.py`, `tamp/compressor.py`, `tamp/decompressor.py`
+        * `pip install tamp` will use a python-bound C implementation
+            optimized for speed.
+    * Micropython:
+        * Native Module (suggested micropython implementation).
+            * `mpy_bindings/`
+        * Viper.
+            * `tamp/__init__.py`, `tamp/compressor_viper.py`, `tamp/decompressor_viper.py`
+    * C library:
+        * `tamp/_c_src/`
+* High compression ratios, low memory use, and fast.
+* Compact compression and decompression implementations.
+    * Compiled C library is <4KB (compressor + decompressor).
+* Mid-stream flushing.
+    * Allows for submission of messages while continuing to compress subsequent data.
+* Customizable dictionary for greater compression of small messages.
+* Convenient CLI interface.
+
+# Installation
+
+Tamp contains 4 implementations:
+
+1.  A reference desktop CPython implementation that is optimized for readability (and **not** speed).
+2.  A Micropython Native Module implementation (fast).
+3.  A Micropython Viper implementation (not recommended, please use Native Module).
+4.  A C implementation (with python bindings) for accelerated desktop
+    use and to be used in C projects (very fast).
+
+This section instructs how to install each implementation.
+
+## Desktop Python
+
+The Tamp library and CLI requires Python `>=3.8` and can be installed
+via:
+
+``` bash
+pip install tamp
+```
+
+## MicroPython
+
+### MicroPython Native Module
+
+Tamp provides pre-compiled [native modules]{.title-ref} that are easy to install, are small, and are incredibly fast.
+
+Download the appropriate `.mpy` file from the [release page](https://github.com/BrianPugh/tamp/releases).
+
+* Match the micropython version.
+* Match the architecture to the microcontroller (e.g. `armv6m` for a pi pico).
+
+Rename the file to `tamp.mpy` and transfer it to your board. If using [Belay](https://github.com/BrianPugh/belay), tamp can be installed by adding the following to `pyproject.toml`.
+
+``` toml
+[tool.belay.dependencies]
+tamp = "https://github.com/BrianPugh/tamp/releases/download/v1.6.0/tamp-1.6.0-mpy1.23-armv6m.mpy"
+```
+
+### MicroPython Viper
+
+**NOT RECOMMENDED, PLEASE USE NATIVE MODULE**
+
+For micropython use, there are 3 main files:
+
+1.  `tamp/__init__.py` - Always required.
+2.  `tamp/decompressor_viper.py` - Required for on-device decompression.
+3.  `tamp/compressor_viper.py` - Required for on-device compression.
+
+For example, if on-device decompression isn't used, then do not include `decompressor_viper.py`. If manually installing, just copy these files to your microcontroller's `/lib/tamp` folder.
+
+If using [mip](https://docs.micropython.org/en/latest/reference/packages.html#installing-packages-with-mip), tamp can be installed by specifying the appropriate `package-*.json` file.
+
+``` bash
+mip install github:brianpugh/tamp  # Defaults to package.json: Compressor & Decompressor
+mip install github:brianpugh/tamp/package-compressor.json  # Compressor only
+mip install github:brianpugh/tamp/package-decompressor.json  # Decompressor only
+```
+
+If using [Belay](https://github.com/BrianPugh/belay), tamp can be installed by adding the following to `pyproject.toml`.
+
+``` toml
+[tool.belay.dependencies]
+tamp = [
+   "https://github.com/BrianPugh/tamp/blob/main/tamp/__init__.py",
+   "https://github.com/BrianPugh/tamp/blob/main/tamp/compressor_viper.py",
+   "https://github.com/BrianPugh/tamp/blob/main/tamp/decompressor_viper.py",
+]
+```
+
+## C
+
+Copy the `tamp/_c_src/tamp` folder into your project. For more information, see [the documentation](https://tamp.readthedocs.io/en/latest/c_library.html).
+
+# Usage
+
+Tamp works on desktop python and micropython. On desktop, Tamp is bundled with the `tamp` command line tool for compressing and decompressing tamp files.
+
+## CLI
+
+### Compression
+
+Use `tamp compress` to compress a file or stream. If no input file is specified, data from stdin will be read. If no output is specified, the compressed output stream will be written to stdout.
+
+``` bash
+$ tamp compress --help
+Usage: tamp compress [ARGS] [OPTIONS]
+
+Compress an input file or stream.
+
+╭─ Parameters ───────────────────────────────────────────────────────────────────────────────╮
+│ INPUT,--input    -i  Input file to compress. Defaults to stdin.                            │
+│ OUTPUT,--output  -o  Output compressed file. Defaults to stdout.                           │
+│ --window         -w  Number of bits used to represent the dictionary window. [default: 10] │
+│ --literal        -l  Number of bits used to represent a literal. [default: 8]              │
+╰────────────────────────────────────────────────────────────────────────────────────────────╯
+```
+
+Example usage:
+
+``` bash
+tamp compress enwik8 -o enwik8.tamp  # Compress a file
+echo "hello world" | tamp compress | wc -c  # Compress a stream and print the compressed size.
+```
+
+The following options can impact compression ratios and memory usage:
+
+-   `window` - `2^window` plaintext bytes to look back to try and find a
+    pattern. A larger window size will increase the chance of finding a
+    longer pattern match, but will use more memory, increase compression
+    time, and cause each pattern-token to take up more space. Try
+    smaller window values if compressing highly repetitive data, or
+    short messages.
+-   `literal` - Number of bits used in each plaintext byte. For example,
+    if all input data is 7-bit ASCII, then setting this to 7 will
+    improve literal compression ratios by 11.1%. The default, 8-bits,
+    can encode any binary data.
+
+### Decompression
+
+Use `tamp decompress` to decompress a file or stream. If no input file is specified, data from stdin will be read. If no output is specified, the compressed output stream will be written to stdout.
+
+``` bash
+$ tamp decompress --help
+Usage: tamp decompress [ARGS] [OPTIONS]
+
+Decompress an input file or stream.
+
+╭─ Parameters ───────────────────────────────────────────────────────────────────────────────╮
+│ INPUT,--input    -i  Input file to decompress. Defaults to stdin.                          │
+│ OUTPUT,--output  -o  Output decompressed file. Defaults to stdout.                         │
+╰────────────────────────────────────────────────────────────────────────────────────────────╯
+```
+
+Example usage:
+
+``` bash
+tamp decompress enwik8.tamp -o enwik8
+echo "hello world" | tamp compress | tamp decompress
+```
+
+## Python
+
+The python library can perform one-shot compression, as well as operate on files/streams.
+
+``` python
+import tamp
+
+# One-shot compression
+string = b"I scream, you scream, we all scream for ice cream."
+compressed_data = tamp.compress(string)
+reconstructed = tamp.decompress(compressed_data)
+assert reconstructed == string
+
+# Streaming compression
+with tamp.open("output.tamp", "wb") as f:
+    for _ in range(10):
+        f.write(string)
+
+# Streaming decompression
+with tamp.open("output.tamp", "rb") as f:
+    reconstructed = f.read()
+```
+
+# Benchmark
+
+In the following section, we compare Tamp against:
+
+-   [zlib](https://docs.python.org/3/library/zlib.html), a python builtin gzip-compatible DEFLATE compression library.
+-   [heatshrink](https://github.com/atomicobject/heatshrink), a data compression library for embedded/real-time systems. Heatshrink has similar goals as Tamp.
+
+All of these are LZ-based compression algorithms, and tests were performed using a 1KB (10 bit) window. Since zlib already uses significantly more memory by default, the lowest memory level (`memLevel=1`) was used in these benchmarks. It should be noted that higher zlib memory levels will having greater compression ratios than Tamp. Currently, there is no micropython-compatible zlib or heatshrink compression implementation, so these numbers are provided simply as a reference.
+
+## Compression Ratio
+
+The following table shows compression algorithm performance over a variety of input data sourced from the [Silesia Corpus](https://sun.aei.polsl.pl//~sdeor/index.php?page=silesia) and [Enwik8](https://mattmahoney.net/dc/textdata.html). This should give a general idea of how these algorithms perform over a variety of input data types.
+
+  dataset               |   raw         |   tamp           |   zlib           |   heatshrink
+----------------------- | ------------- | ---------------- | ---------------- | ------------
+  enwik8                |   100,000,000 |   **51,635,633** |   56,205,166     |   56,110,394
+  build/silesia/dickens |   10,192,446  |   **5,546,761**  |   6,049,169      |   6,155,768
+  build/silesia/mozilla |   51,220,480  |   25,121,385     |   **25,104,966** |   25,435,908
+  build/silesia/mr      |   9,970,564   |   5,027,032      |   **4,864,734**  |   5,442,180
+  build/silesia/nci     |   33,553,445  |   8,643,610      |   **5,765,521**  |   8,247,487
+  build/silesia/ooffice |   6,152,192   |   **3,814,938**  |   4,077,277      |   3,994,589
+  build/silesia/osdb    |   10,085,684  |   **8,520,835**  |   8,625,159      |   8,747,527
+  build/silesia/reymont |   6,627,202   |   **2,847,981**  |   2,897,661      |   2,910,251
+  build/silesia/samba   |   21,606,400  |   9,102,594      |   **8,862,423**  |   9,223,827
+  build/silesia/sao     |   7,251,944   |   **6,137,755**  |   6,506,417      |   6,400,926
+  build/silesia/webster |   41,458,703  |   **18,694,172** |   20,212,235     |   19,942,817
+  build/silesia/x-ray   |   8,474,240   |   7,510,606      |   **7,351,750**  |   8,059,723
+  build/silesia/xml     |   5,345,280   |   1,681,687      |   **1,586,985**  |   1,665,179
+
+Tamp usually out-performs heatshrink, and is generally very competitive with zlib. While trying to be an apples-to-apples comparison, zlib still uses significantly more memory during both compression and decompression (see next section). Tamp accomplishes competitive performance while using around 10x less memory.
+
+## Memory Usage
+
+The following table shows approximately how much memory each algorithm
+uses during compression and decompression.
+
+|                       | Compression                   | Decompression           |
+| --------------------- | ----------------------------- | ----------------------- |
+| Tamp                  | (1 << windowBits)             | (1 << windowBits)       |
+| ZLib                  | (1 << (windowBits + 2)) + 7KB | (1 << windowBits) + 7KB |
+| Heatshrink            | (1 << (windowBits + 1))       | (1 << (windowBits + 1)) |
+| Deflate (micropython) | (1 << windowBits)             | (1 << windowBits)       |
+
+All libraries have a few dozen bytes of overhead in addition to the primary window buffer, but are implementation-specific and ignored for clarity here. Tamp uses significantly less memory than ZLib, and half the memory of Heatshrink.
+
+## Runtime
+
+As a rough benchmark, here is the performance (in seconds) of these different compression algorithms on the 100MB enwik8 dataset. These tests were performed on an M1 Macbook Air.
+
+|                            | Compression (s) | Decompression (s) |
+| -------------------------- | --------------- | ----------------- |
+| Tamp (Python Reference)    | 109.5           | 76.0              |
+| Tamp (C)                   | 16.45           | 0.142             |
+| ZLib                       | 0.98            | 0.98              |
+| Heatshrink (with index)    | 6.22            | 0.82              |
+| Heatshrink (without index) | 41.73           | 0.82              |
+
+Heatshrink v0.4.1 was used in these benchmarks. When heathshrink uses an index, an additional `(1 << (windowBits + 1))` bytes of memory are used, resulting in 4x more memory-usage than Tamp. Tamp could use a similar indexing to increase compression speed, but has chosen not to to focus on the primary goal of a low-memory compressor.
+
+To give an idea of Tamp's speed on an embedded device, the following table shows compression/decompression in **bytes/second of the first 100KB of enwik8 on a pi pico (rp2040)** at the default 125MHz clock rate. The C benchmark **does not** use a filesystem nor dynamic memory allocation, so it represents the maximum speed Tamp can achieve. In all tests, a 1KB window (10 bit) was used.
+
+|                                  | Compression (bytes/s) | Decompression (bytes/s) |
+| -------------------------------- | --------------------- | ----------------------- |
+| Tamp (MicroPython Viper)         | 4,300                 | 42,000                  |
+| Tamp (Micropython Native Module) | 12,770                | 644,000                 |
+| Tamp (C)                         | 28,500                | 1,042,524               |
+| Deflate (micropython builtin)    | 6,715                 | 146,477                 |
+
+
+Tamp resulted in a **51637** byte archive, while Micropython's builtin `deflate` resulted in a larger, **59442** byte archive.
+
+## Binary Size
+
+To give an idea on the resulting binary sizes, Tamp and other libraries were compiled for the Pi Pico (`armv6m`). All libraries were compiled with `-O3`. Numbers reported in bytes.
+
+|                           | Compressor | Decompressor | Compressor + Decompressor |
+| ------------------------- | ---------- | ------------ | ------------------------- |
+| Tamp (MicroPython Viper)  | 4429       | 4205         | 7554                      |
+| Tamp (MicroPython Native) | 3232       | 3047         | 5505                      |
+| Tamp (C)                  | 2008       | 1972         | 3864                      |
+| Heatshrink (C)            | 2956       | 3876         | 6832                      |
+| uzlib (C)                 | 2355       | 3963         | 6318                      |
+
+Heatshrink doesn't include a high level API; in an apples-to-apples comparison the Tamp library would be even smaller.
+
+## Acknowledgement
+
+* Thanks @BitsForPeople for the esp32-optimized compressor implementation.


### PR DESCRIPTION
Copy over Tamp's README & License as requested [here](https://github.com/inikep/lzbench/pull/135#issuecomment-2603473554). Thanks again for merging in Tamp to lzbench!