### PR TITLE
Lzbench kanzi 1 thread

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,7 @@ int64_t lzbench_xxxx_compress(char* inbuf, size_t insize, char* outbuf, size_t o
 int64_t lzbench_xxxx_decompress(char* inbuf, size_t insize, char* outbuf, size_t outsize, size_t, size_t, char*) { }
 #endif
 ```
+- - If codec uses threads, set it to 1.
 
 - Update `Makefile`:
 

--- a/_lzbench/lz_codecs.cpp
+++ b/_lzbench/lz_codecs.cpp
@@ -165,7 +165,8 @@ int64_t lzbench_fastlzma2_decompress(char *inbuf, size_t insize, char *outbuf, s
 #include "kanzi-cpp/src/io/CompressedInputStream.hpp"
 #include "kanzi-cpp/src/io/CompressedOutputStream.hpp"
 
-int64_t lzbench_kanzi_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t windowLog, char*)                                                                                                           {
+int64_t lzbench_kanzi_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, size_t level, size_t windowLog, char*)
+{
   std::string entropy;
   std::string transform;
   kanzi::uint szBlock;
@@ -227,7 +228,7 @@ int64_t lzbench_kanzi_compress(char *inbuf, size_t insize, char *outbuf, size_t 
 
   ostreambuf<char> buf(outbuf, outsize);
   std::iostream os(&buf);
-  int cores = std::max(int(std::thread::hardware_concurrency()) / 2, 1); // Defaults to half the cores
+  int cores = 1; ///std::max(int(std::thread::hardware_concurrency()) / 2, 1);
   kanzi::CompressedOutputStream cos(os, entropy, transform, szBlock, false, std::min(cores, 64));
   cos.write(inbuf, insize);
   cos.close();
@@ -238,7 +239,7 @@ int64_t lzbench_kanzi_decompress(char *inbuf, size_t insize, char *outbuf, size_
 {
   istreambuf<char> buf(inbuf, insize);
   std::iostream is(&buf);
-  int cores = std::max(int(std::thread::hardware_concurrency()) / 2, 1); // Defaults to half the cores
+  int cores = 1; ///std::max(int(std::thread::hardware_concurrency()) / 2, 1);
   kanzi::CompressedInputStream cis(is, std::min(cores, 64));
   cis.read(outbuf, outsize);
   cis.close();


### PR DESCRIPTION
Kanzi is set to use threads. Set it to 1. Until there is no such option in the bench there is no point in favour one codec.
