### PR TITLE
set chunk_size to current value

### DIFF
--- a/bench/lzbench.cpp
+++ b/bench/lzbench.cpp
@@ -349,6 +349,7 @@ void lzbench_process_single_codec(lzbench_params_t *params, std::vector<size_t> 
     LZBENCH_PRINT(5, "*** trying %s insize=%lu comprsize=%lu chunk_size=%lu\n", desc->name, (uint64_t)insize, (uint64_t)comprsize, (uint64_t)chunk_size);
 
     if (desc->max_block_size != 0 && chunk_size > desc->max_block_size) chunk_size = desc->max_block_size;
+    params->chunk_size = chunk_size;
     if (!desc->compress || !desc->decompress) return;
     if (desc->init) workmem = desc->init(chunk_size, param1, param2);
 


### PR DESCRIPTION
Manual/help states that chunk size is MIN(filesize,1747626 KB) but it displays 1706MB regardless of file size.


```
$ ./lzbench -ezstd,9 mozilla
Compressor name      Compress. Decompress. Compr. size  Ratio Filename
zstd 1.5.7 -9         6.48 MB/s   150 MB/s    16665339  32.54 mozilla
done... (cIters=1 dIters=1 cTime=1.0 dTime=2.0 chunkSize=1706MB cSpeed=0MB)

$ ./lzbench -b1024 -ezstd,9 mozilla
Compressor name      Compress. Decompress. Compr. size  Ratio Filename
zstd 1.5.7 -9         7.23 MB/s   161 MB/s    17519181  34.20 mozilla
done... (cIters=1 dIters=1 cTime=1.0 dTime=2.0 chunkSize=1024KB cSpeed=0MB)
```

This hopefuly corrects that.

```
$ ./lzbench-chunk_size -ezstd,9 mozilla
Compressor name      Compress. Decompress. Compr. size  Ratio Filename
zstd 1.5.7 -9         6.55 MB/s   151 MB/s    16665339  32.54 mozilla
done... (cIters=1 dIters=1 cTime=1.0 dTime=2.0 chunkSize=48MB cSpeed=0MB)

$ ./lzbench-chunk_size -b1024 -ezstd,9 mozilla
Compressor name      Compress. Decompress. Compr. size  Ratio Filename
zstd 1.5.7 -9         7.26 MB/s   162 MB/s    17519181  34.20 mozilla
done... (cIters=1 dIters=1 cTime=1.0 dTime=2.0 chunkSize=1024KB cSpeed=0MB)
```
