### PR TITLE
add - verbose and quiet options

### DIFF
--- a/bench/lzbench.cpp
+++ b/bench/lzbench.cpp
@@ -753,16 +753,17 @@ void usage(lzbench_params_t* params)
     fprintf(stdout, "  -iX,Y set min. number of compression and decompression iterations {%d, %d}\n", params->c_iters, params->d_iters);
     fprintf(stdout, "  -j    join files in memory but compress them independently (for many small files)\n");
     fprintf(stdout, "  -l    list of available compressors and aliases\n");
-    fprintf(stdout, "  -R    read block/chunk size from random blocks (to estimate for large files)\n");
     fprintf(stdout, "  -m#   set memory limit to # MB {no limit}\n");
     fprintf(stdout, "  -o#   output text format 1=Markdown, 2=text, 3=text+origSize, 4=CSV {%d}\n", params->textformat);
     fprintf(stdout, "  -p#   print time for all iterations: 1=fastest 2=average 3=median {%d}\n", params->timetype);
+    fprintf(stdout, "  -q    suppress progress information (-qq supresses more)\n");
+    fprintf(stdout, "  -R    read block/chunk size from random blocks (to estimate for large files)\n");
 #ifdef UTIL_HAS_CREATEFILELIST
     fprintf(stdout, "  -r    operate recursively on directories\n");
 #endif
     fprintf(stdout, "  -s#   use only compressors with compression speed over # MB {%d MB}\n", params->cspeed);
     fprintf(stdout, "  -tX,Y set min. time in seconds for compression and decompression {%.0f, %.0f}\n", params->cmintime/1000.0, params->dmintime/1000.0);
-    fprintf(stdout, "  -v    disable progress information\n");
+    fprintf(stdout, "  -v    be verbose (-vv gives more)\n");
     fprintf(stdout, "  -V    output version information and exit\n");
     fprintf(stdout, "  -x    disable real-time process priority\n");
     fprintf(stdout, "  -z    show (de)compression times instead of speed\n");
@@ -892,6 +893,10 @@ int main( int argc, char** argv)
         case 'p':
             params->timetype = (timetype_e)number;
             break;
+        case 'q':
+            params->verbose--;
+            if (params->verbose < 0) params->verbose = 0;
+            break;
 #ifdef UTIL_HAS_CREATEFILELIST
         case 'r':
             recursive = 1;
@@ -921,7 +926,8 @@ int main( int argc, char** argv)
             params->dloop_time = (params->dmintime)?DEFAULT_LOOP_TIME:0;
             break;
         case 'v':
-            params->verbose = number;
+            params->verbose++;
+            if (params->verbose > 4) params->verbose = 4;
             break;
         case 'x':
             real_time = 0;

--- a/doc/lzbench.7.txt
+++ b/doc/lzbench.7.txt
@@ -29,14 +29,16 @@ OPTIONS
           join files in memory but compress them independently (for many small files)
    -l
           list of available compressors and aliases
-   -R
-          read block/chunk size from random blocks (to estimate for large files)
    -m#
           set memory limit to # MB {no limit}
    -o#
           output text format 1=Markdown, 2=text, 3=text+origSize, 4=CSV {2}
    -p#
           print time for all iterations: 1=fastest 2=average 3=median {1}
+   -q
+          suppress progress information (-qq supresses more)
+   -R
+          read block/chunk size from random blocks (to estimate for large files)
    -r
           operate recursively on directories
    -s#
@@ -44,7 +46,7 @@ OPTIONS
    -tX,Y
           set min. time in seconds for compression and decompression {1, 2}
    -v
-          disable progress information
+          be verbose (-vv gives more)
    -V
           output version information and exit
    -x


### PR DESCRIPTION
add - verbose and quiet options
Didn't like -v as message suppressor. Somehow it didn't fit to 'compressor program' to use -v as suppressor when all the others do exactly opposite.
Also limited to 4 value as it didn't work with printer function.
