### PR TITLE
Fix CUDA compression and decompression functions

### DIFF
--- a/bench/misc_codecs.cpp
+++ b/bench/misc_codecs.cpp
@@ -161,8 +161,8 @@ void lzbench_cuda_deinit(char* workmem)
 
 int64_t lzbench_cuda_memcpy(char *inbuf, size_t insize, char *outbuf, size_t outsize, codec_options_t *codec_options)
 {
-    cudaMemcpy(workmem, inbuf, insize, cudaMemcpyHostToDevice);
-    cudaMemcpy(outbuf, workmem, insize, cudaMemcpyDeviceToHost);
+    cudaMemcpy(codec_options->work_mem, inbuf, insize, cudaMemcpyHostToDevice);
+    cudaMemcpy(outbuf, codec_options->work_mem, insize, cudaMemcpyDeviceToHost);
     return insize;
 }
 
@@ -292,7 +292,7 @@ void lzbench_nvcomp_deinit(char* nvcomp_params)
 
 int64_t lzbench_nvcomp_compress(char *inbuf, size_t in_bytes, char *outbuf, size_t outsize, codec_options_t *codec_options)
 {
-    nvcomp_params_s* params = (nvcomp_params_s*) nvcomp_params;
+    nvcomp_params_s* params = (nvcomp_params_s*) codec_options->work_mem;
     int status = 0;
 
     // copy the uncompressed data to the device
@@ -339,7 +339,7 @@ int64_t lzbench_nvcomp_compress(char *inbuf, size_t in_bytes, char *outbuf, size
 
 int64_t lzbench_nvcomp_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, codec_options_t *codec_options)
 {
-    nvcomp_params_s* params = (nvcomp_params_s*) nvcomp_params;
+    nvcomp_params_s* params = (nvcomp_params_s*) codec_options->work_mem;
     int status = 0;
     size_t uncompressed_size = outsize;
 


### PR DESCRIPTION
Fix `lzbench_cuda_memcpy`, `lzbench_nvcomp_compress` and `lzbench_nvcomp_decompress` after the changes to the interface.