### PR TITLE
automatic chunk size split for threads

### DIFF
--- a/bench/lzbench.cpp
+++ b/bench/lzbench.cpp
@@ -862,7 +862,8 @@ int lzbench_main(lzbench_params_t* params, const char** inFileNames, unsigned if
         insize = fread(inbuf, 1, insize, in);
 
         size_t sv_chunk_size = params->chunk_size;
-        if (params->threads > 1)
+        // automatic split if -b# not set
+        if ((params->threads > 1) && (params->chunk_size == DEFAULT_PARAM_CHUNK_SIZE))
         {
             size_t chunk_size = (size_t)(insize + params->threads - 1) / params->threads;
             if (chunk_size < params->chunk_size)
@@ -1018,7 +1019,7 @@ int main( int argc, char** argv)
     params->textformat = TEXT;
     params->show_speed = 1;
     params->verbose = 2;
-    params->chunk_size = (1ULL << 31) - (1ULL << 31)/6;
+    params->chunk_size = DEFAULT_PARAM_CHUNK_SIZE;
     params->cspeed = 0;
     params->c_iters = params->d_iters = 1;
     params->cmintime = 10*DEFAULT_LOOP_TIME/1000000; // 1 sec

--- a/bench/lzbench.cpp
+++ b/bench/lzbench.cpp
@@ -861,6 +861,13 @@ int lzbench_main(lzbench_params_t* params, const char** inFileNames, unsigned if
 
         insize = fread(inbuf, 1, insize, in);
 
+        size_t sv_chunk_size = params->chunk_size;
+        if (params->threads > 1)
+        {
+            size_t chunk_size = (size_t)(insize + params->threads - 1) / params->threads;
+            if (chunk_size < params->chunk_size)
+                params->chunk_size = chunk_size;
+        }
         if (params->mem_limit && real_insize > params->mem_limit)
         {
             int i;
@@ -882,6 +889,7 @@ int lzbench_main(lzbench_params_t* params, const char** inFileNames, unsigned if
             lzbench_process_mem_blocks(params, file_sizes, encoder_list?encoder_list:alias_desc[0].params, inbuf, insize, rate);
             file_sizes.clear();
         }
+        params->chunk_size = sv_chunk_size;
 
         fclose(in);
         free(inbuf);

--- a/bench/lzbench.h
+++ b/bench/lzbench.h
@@ -23,6 +23,7 @@
 #define PAD_SIZE (1024)
 #define MIN_PAGE_SIZE 4096  // smallest page size we expect, if it's wrong the first algorithm might be a bit slower
 #define DEFAULT_LOOP_TIME (100*1000000)  // 1/10 of a second
+#define DEFAULT_PARAM_CHUNK_SIZE ((1ULL << 31) - (1ULL << 31)/6) // ~1.7 Gi
 #define GET_COMPRESS_BOUND(insize) (insize + insize/8 + PAD_SIZE) // for brieflz and ucl_nrv2b with "-b64"
 #define LZBENCH_PRINT(level, fmt, ...) if (params->verbose >= level) printf(fmt, __VA_ARGS__)
 #define LZBENCH_STDERR(level, fmt, ...) if (params->verbose >= level) { fprintf(stderr, fmt, __VA_ARGS__); fflush(stderr); }


### PR DESCRIPTION
Automatic split of chunk size when using threads. If user specifies smaller block then use that instead.
I was also thinking about:
```
if (params->chunk_size < insize)
        params->chunk_size = chunk_size;
```
assuming that `if (params->chunk_size < insize)` than user must have set block size (\`-b').
