### PR TITLE
add option for internal codec threads

### DIFF
--- a/bench/codecs.h
+++ b/bench/codecs.h
@@ -18,7 +18,7 @@ typedef struct
     int level;
     int additional_param;
     char* work_mem;
-//    int threads;
+    int threads;
 } codec_options_t;
 
 

--- a/bench/lz_codecs.cpp
+++ b/bench/lz_codecs.cpp
@@ -208,7 +208,7 @@ int64_t lzbench_kanzi_compress(char *inbuf, size_t insize, char *outbuf, size_t 
 
     ostreambuf<char> buf(outbuf, outsize);
     std::iostream os(&buf);
-    int cores = 1; ///std::max(int(std::thread::hardware_concurrency()) / 2, 1);
+    int cores = codec_options->threads > 1 ? codec_options->threads : 1; ///std::max(int(std::thread::hardware_concurrency()) / 2, 1);
     kanzi::CompressedOutputStream cos(os, entropy, transform, szBlock, false, std::min(cores, 64));
     cos.write(inbuf, insize);
     cos.close();
@@ -219,11 +219,11 @@ int64_t lzbench_kanzi_decompress(char *inbuf, size_t insize, char *outbuf, size_
 {
     istreambuf<char> buf(inbuf, insize);
     std::iostream is(&buf);
-    int cores = 1; ///std::max(int(std::thread::hardware_concurrency()) / 2, 1);
+    int cores = codec_options->threads > 1 ? codec_options->threads : 1;
     kanzi::CompressedInputStream cis(is, std::min(cores, 64));
     cis.read(outbuf, outsize);
     cis.close();
-    return outsize;//cis.getRead();
+    return outsize; //cis.getRead();
 }
 #endif // BENCH_REMOVE_KANZI
 
@@ -436,7 +436,7 @@ int64_t lzbench_lzham_compress(char *inbuf, size_t insize, char *outbuf, size_t 
     memset(&comp_params, 0, sizeof(comp_params));
     comp_params.m_struct_size = sizeof(lzham_compress_params);
     comp_params.m_dict_size_log2 = dict_size_log?dict_size_log:26;
-    comp_params.m_max_helper_threads = 0;
+    comp_params.m_max_helper_threads = codec_options->threads; ////?
     comp_params.m_level = (lzham_compress_level)codec_options->level;
 
     lzham_compress_status_t comp_status;
@@ -602,7 +602,7 @@ int64_t lzbench_lzma_compress(char *inbuf, size_t insize, char *outbuf, size_t o
 
     LzmaEncProps_Init(&props);
     props.level = codec_options->level;
-    props.numThreads = 1;
+    props.numThreads = codec_options->threads > 1 ? codec_options->threads : 1;
     LzmaEncProps_Normalize(&props);
   /*
   p->level = 5;

--- a/bench/lzbench.cpp
+++ b/bench/lzbench.cpp
@@ -461,7 +461,8 @@ void lzbench_process_single_codec(ThreadPool& pool, int numThreads, lzbench_para
     std::vector<size_t> compr_sizes;
     bool comp_error = false, decomp_error = false;
     int param2 = desc->additional_param;
-    size_t compThreadsUsed = (numThreads <= 1), decompThreadsUsed = (numThreads <= 1), codecThreadsUsed = (params->codec_threads);
+    int codec_threads = params->codec_threads;
+    size_t compThreadsUsed = (numThreads <= 1), decompThreadsUsed = (numThreads <= 1), codecThreadsUsed = (codec_threads);
     std::vector<char*> workmems(numThreads, nullptr);
 
 
@@ -477,7 +478,7 @@ void lzbench_process_single_codec(ThreadPool& pool, int numThreads, lzbench_para
         }
     }
 
-    codec_options_t codec_options { param1, param2, workmems[0] };
+    codec_options_t codec_options { param1, param2, workmems[0], codec_threads };
 
     if (params->cspeed > 0)
     {

--- a/bench/lzbench.h
+++ b/bench/lzbench.h
@@ -95,9 +95,9 @@ typedef struct string_table
     std::string col1_algname;
     uint64_t col2_ctime, col3_dtime, col4_comprsize, col5_origsize;
     std::string col6_filename;
-    int usedCompThreads, usedDecompThreads;
-    string_table(std::string c1, uint64_t c2, uint64_t c3, uint64_t c4, uint64_t c5, std::string filename, int compThreads, int decompThreads) :
-        col1_algname(c1), col2_ctime(c2), col3_dtime(c3), col4_comprsize(c4), col5_origsize(c5), col6_filename(filename), usedCompThreads(compThreads), usedDecompThreads(decompThreads) {}
+    int usedCompThreads, usedDecompThreads, usedCodecThreads;
+    string_table(std::string c1, uint64_t c2, uint64_t c3, uint64_t c4, uint64_t c5, std::string filename, int compThreads, int decompThreads, int codecThreads) :
+        col1_algname(c1), col2_ctime(c2), col3_dtime(c3), col4_comprsize(c4), col5_origsize(c5), col6_filename(filename), usedCompThreads(compThreads), usedDecompThreads(decompThreads), usedCodecThreads(codecThreads) {}
 } string_table_t;
 
 enum textformat_e { MARKDOWN=1, TEXT, TEXT_FULL, CSV, TURBOBENCH, MARKDOWN2 };
@@ -105,7 +105,8 @@ enum timetype_e { FASTEST=1, AVERAGE, MEDIAN };
 
 typedef struct
 {
-    int show_speed, compress_only, threads;
+    int show_speed, compress_only;
+    int threads, codec_threads;
     timetype_e timetype;
     textformat_e textformat;
     size_t chunk_size;


### PR DESCRIPTION
Adds option to to use internal codec threads.

It just takes argument from command line as part of \`-T' switch.


```
$ ./lzbench -t0,0 -ezlib,1 lzbench

Compressor name         Compress. Decompress. Compr. size  Ratio Filename
zlib 1.3.1 -1            22.9 MB/s  97.2 MB/s     2870962  44.99 lzbench

$./lzbench -t0,0 -T2 -ezlib,1 lzbench

Compressor name     C,D Threads Compress. Decompress. Compr. size  Ratio Filename
zlib 1.3.1 -1           2, 2     27.6 MB/s   176 MB/s     2871071  44.99 lzbench

$ ./lzbench -t0,0 -T2,3 -ezlib,1 lzbench

Compressor name   C,D;K Threads Compress. Decompress. Compr. size  Ratio Filename
zlib 1.3.1 -1           2, 2, 3  27.5 MB/s   175 MB/s     2871071  44.99 lzbench
```
