### PR TITLE
build: disable tornado on RISC-V

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,10 @@ else
         DONT_BUILD_ZLING ?= 1
     endif
 
+    ifneq (,$(filter riscv64 riscv32,$(shell uname -m)))
+        DONT_BUILD_TORNADO ?= 1
+    endif
+
     # detect MacOS
     detected_OS := $(shell uname -s)
     ifeq ($(detected_OS), Darwin)


### PR DESCRIPTION
Automatically set DONT_BUILD_TORNADO=1 when building on RISC-V architecture (riscv32/riscv64) since tornado codec is incompatible with RISC-V. 
Uses efficient filter() pattern matching for architecture detection.After adding this modification, you can use make to compile directly without reporting errors

**Error message**
Before the modification, each compilation will report an error, and you must use make DONT_BUILD_TORNADO=1 to compile successfully.
<img width="1201" height="174" alt="image" src="https://github.com/user-attachments/assets/5af0ed29-1191-4570-9155-6979345b0be0" />

