### PR TITLE
docs: add RISC-V B extension compilation optimization hint

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -104,7 +104,7 @@ Compilation for various CPU architectures
 - `arm/aarch64` works fine with all default codecs except LZSSE for `arm` (32-bit) in our tests
 - `ppc64le` (PowerPC 64-bit Little-endian) works fine with all default codecs
 - `ppc/ppc64` (PowerPC 32-bit and 64-bit Big-endian) - a lot compressors fail because of Big-endian architecture
-- `riscv32/riscv64` - we have reports it works fine with `DONT_BUILD_TORNADO=1`
+- `riscv32/riscv64` - we have reports it works fine with `DONT_BUILD_TORNADO=1`. For riscv64, if the environment includes the B extension (which comprises the Zba, Zbb, and Zbs extensions), you can improve performance by adding `MOREFLAGS="-march=rv64gc_zba_zbb_zbs"` during compilation
 - `mipsel/mips64el` - waiting for reports
 - `mips/mips64` - a lot compressors will fail because of Big-endian architecture
 - `loongarch64` - we have reports it works fine


### PR DESCRIPTION
This PR adds optional build instructions for RISC-V platforms to improve lzbench performance, particularly for riscv64 systems with B-extension support.

### Environment Information
- Architecture: `riscv64`
- CPU ISA: `rv64imafdcv_zicbom_zicboz_zicntr_zicond_zicsr_zifencei_zihintntl_zihintpause_zihpm_zawrs_zfa_zfh_zfhmin_zca_zcb_zcd_zba_zbb_zbc_zbs_zve32f_zve32x_zve64d_zve64f_zve64x_zvfh_zvfhmin_sscofpmf_sstc_svinval_svnapot_svpbmt` (includes B-extension related instructions)
- Compiler: `GCC 12.3.1`
- lzbench version: `2.1`
- Test file: `../silesia.tar`
### Performance Comparison
#### Without B-extension (default build)
- Compression speed: ~128-131 MB/s
- Decompression speed: ~313-314 MB/s
- Compressed size: 100,881,340 bytes (47.60% ratio)
<img width="673" height="336" alt="image" src="https://github.com/user-attachments/assets/64501c58-00cf-4f97-83f2-41aaae308102" />

#### With B-extension (built with `MOREFLAGS="-march=rv64gc_zba_zbb_zbs"`)
- Compression speed: 164 MB/s (**~25-28% improvement**)
- Decompression speed: ~306-314 MB/s (consistent with baseline)
- Compressed size: 100,881,340 bytes (same 47.60% ratio)
<img width="728" height="426" alt="image" src="https://github.com/user-attachments/assets/f170d9fc-5d71-4160-a25d-c2c7e63445e5" />

### Notes
This is an optional optimization for riscv64 systems with B-extension support. The core functionality remains unchanged, and the default build configuration continues to work as expected. 