### PR TITLE
Updates zxc to version 0.1.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@ v2.x.y (work in progress)
 - updated brotli to 1.2.0 (thanks to @data-man)
 - updated lzav 5.5 (thanks to @avaneev)
 - updated quicklz to 1.5.1 beta 7
-- added zxc 0.1.0 beta
+- added zxc 0.1.1 beta
 
 v2.2 (Oct 28, 2025)
 - improvement: Automatic chunk size splitting for multi-threading (-T) when -b is not specified

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Supported compressors
  - [zling 2018-10-12](https://github.com/richox/libzling) - according to the author using libzling in a production environment is not a good idea
  - [zpaq 7.15](https://github.com/zpaq/zpaq)
  - [zstd 1.5.7](https://github.com/facebook/zstd)
- - [zxc 0.1.0](https://github.com/hellobertrand/zxc)
+ - [zxc 0.1.1](https://github.com/hellobertrand/zxc)
 
 **Warning**: The compressors listed below have security issues and/or are
 no longer maintained. For information about the security of the various compressors,

--- a/bench/lzbench.h
+++ b/bench/lzbench.h
@@ -258,7 +258,7 @@ static const compressor_desc_t comp_desc[] =
     { "zstd24LDM",  "zstd 1.5.7 --long -d24", 16,  22,   24, FULL_THREADING, lzbench_zstd_LDM_compress,   lzbench_zstd_decompress,       lzbench_zstd_LDM_init,   lzbench_zstd_deinit },
     { "zstdLDM",    "zstd 1.5.7 --long",       1,  22,    0, FULL_THREADING, lzbench_zstd_LDM_compress,   lzbench_zstd_decompress,       lzbench_zstd_LDM_init,   lzbench_zstd_deinit },
     { "zstd_fast",  "zstd 1.5.7 --fast",      -5,  -1,    0, FULL_THREADING, lzbench_zstd_compress,       lzbench_zstd_decompress,       lzbench_zstd_init,       lzbench_zstd_deinit },
-    { "zxc",        "zxc 0.1.0",               2,   5,    0, BENCH_POOL_MT,  lzbench_zxc_compress,        lzbench_zxc_decompress,        lzbench_zxc_init,        lzbench_zxc_deinit },
+    { "zxc",        "zxc 0.1.1",               2,   5,    0, BENCH_POOL_MT,  lzbench_zxc_compress,        lzbench_zxc_decompress,        lzbench_zxc_init,        lzbench_zxc_deinit },
 };
 
 const long int LZBENCH_COMPRESSOR_COUNT = sizeof(comp_desc)/sizeof(comp_desc[0]);

--- a/lz/zxc/include/zxc.h
+++ b/lz/zxc/include/zxc.h
@@ -29,7 +29,7 @@ extern "C" {
 
 #define ZXC_VERSION_MAJOR 0
 #define ZXC_VERSION_MINOR 1
-#define ZXC_VERSION_PATCH 0
+#define ZXC_VERSION_PATCH 1
 
 #define ZXC_STR_HELPER(x) #x
 #define ZXC_STR(x) ZXC_STR_HELPER(x)

--- a/lz/zxc/src/lib/zxc_compress.c
+++ b/lz/zxc/src/lib/zxc_compress.c
@@ -495,7 +495,9 @@ static int zxc_encode_block_gnr(zxc_cctx_t* ctx, const uint8_t* src, size_t src_
                 if (mlen > best_len) {
                     best_len = mlen;
                     best_ref = ref;
-                    if (best_len >= (uint32_t)sufficient_len) break;
+                    if (best_len >= (uint32_t)sufficient_len) break; // Sufficient match found
+
+                    if (ip + best_len >= iend) break; // Prevent overruns
                 }
             }
             match_idx = chain_table[match_idx];


### PR DESCRIPTION
Updates the zxc compression library to version 0.1.1.

This update includes a fix to prevent potential buffer overruns during compression by adding a check to ensure that the best match length does not exceed the input buffer's boundary.