### PR TITLE
Update zxc to v0.10.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 v2.x.y (work in progress)
 - updated tamp to 2.1.0 (thanks to @tansy)
 - added memlz 0.2 beta (thanks to @rrrlasse)
-- added zxc 0.9.1 (thanks to @hellobertrand)
+- added zxc 0.10.0 (thanks to @hellobertrand)
 - updated brotli to 1.2.0 (thanks to @data-man)
 - updated glza to v0.12 (thanks to @tansy)
 - updated kanzi to 2.5.1 (thanks to @flanglet)

--- a/Makefile
+++ b/Makefile
@@ -537,7 +537,7 @@ ifeq "$(DONT_BUILD_ZXC)" "1"
 else
     DEFINES += -DZXC_STATIC_DEFINE
     ZXC_DIR = lz/zxc/src/lib
-    ZXC_FILES = $(ZXC_DIR)/zxc_common.o $(ZXC_DIR)/zxc_driver.o $(ZXC_DIR)/zxc_dispatch.o
+    ZXC_FILES = $(ZXC_DIR)/zxc_common.o $(ZXC_DIR)/zxc_driver.o $(ZXC_DIR)/zxc_dispatch.o $(ZXC_DIR)/zxc_seekable.o
     ZXC_FILES += $(ZXC_DIR)/zxc_compress_default.o $(ZXC_DIR)/zxc_decompress_default.o
 
     ifneq (,$(filter x86_64% amd64% i%86%,$(TARGET_ARCH)))
@@ -561,13 +561,17 @@ else
 
     $(ZXC_DIR)/%.o: $(ZXC_DIR)/%.c ; $(CMD_BUILD_ZXC)
 
-    $(ZXC_DIR)/%_default.o: ZXC_FLAGS = -DZXC_FUNCTION_SUFFIX=_default
+    ifneq (,$(filter x86_64% amd64%,$(TARGET_ARCH)))
+        $(ZXC_DIR)/%_default.o: ZXC_FLAGS = -mbmi -mbmi2 -mlzcnt -DZXC_FUNCTION_SUFFIX=_default
+    else
+        $(ZXC_DIR)/%_default.o: ZXC_FLAGS = -DZXC_FUNCTION_SUFFIX=_default
+    endif
     $(ZXC_DIR)/%_default.o: $(ZXC_DIR)/%.c ; $(CMD_BUILD_ZXC)
 
-    $(ZXC_DIR)/%_avx2.o: ZXC_FLAGS = -mavx2 -mbmi2 -DZXC_FUNCTION_SUFFIX=_avx2 -DZXC_USE_AVX2
+    $(ZXC_DIR)/%_avx2.o: ZXC_FLAGS = -mavx2 -mbmi -mbmi2 -mlzcnt -DZXC_FUNCTION_SUFFIX=_avx2 -DZXC_USE_AVX2
     $(ZXC_DIR)/%_avx2.o: $(ZXC_DIR)/%.c ; $(CMD_BUILD_ZXC)
 
-    $(ZXC_DIR)/%_avx512.o: ZXC_FLAGS = -mavx512f -mavx512bw -mbmi2 -DZXC_FUNCTION_SUFFIX=_avx512 -DZXC_USE_AVX512
+    $(ZXC_DIR)/%_avx512.o: ZXC_FLAGS = -mavx512f -mavx512bw -mbmi -mbmi2 -mlzcnt -DZXC_FUNCTION_SUFFIX=_avx512 -DZXC_USE_AVX512
     $(ZXC_DIR)/%_avx512.o: $(ZXC_DIR)/%.c ; $(CMD_BUILD_ZXC)
 
     $(ZXC_DIR)/%_neon.o: ZXC_FLAGS = $(NEON_FLAGS) -DZXC_FUNCTION_SUFFIX=_neon

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Supported compressors
  - [zling 2018-10-12](https://github.com/richox/libzling) - according to the author using libzling in a production environment is not a good idea
  - [zpaq 7.15](https://github.com/zpaq/zpaq)
  - [zstd 1.5.7](https://github.com/facebook/zstd)
- - [zxc 0.9.1](https://github.com/hellobertrand/zxc)
+ - [zxc 0.10.0](https://github.com/hellobertrand/zxc)
 
 **Warning**: The compressors listed below have security issues and/or are
 no longer maintained. For information about the security of the various compressors,

--- a/bench/lz_codecs.cpp
+++ b/bench/lz_codecs.cpp
@@ -1725,6 +1725,20 @@ char *lzbench_zxc_init(size_t insize, size_t level, size_t)
     zxc_compress_opts_t copts = {0};
     copts.level = (int)level;
 
+    /* ZXC block_size must be a power of 2 in [4KB, 2MB].
+     * Valid values:  4096  (4KB)    1 << 12
+     *                8192  (8KB)    1 << 13
+     *               16384  (16KB)   1 << 14
+     *               32768  (32KB)   1 << 15
+     *               65536  (64KB)   1 << 16
+     *              131072  (128KB)  1 << 17
+     *              262144  (256KB)  1 << 18  (default)
+     *              524288  (512KB)  1 << 19
+     *             1048576  (1MB)    1 << 20
+     *             2097152  (2MB)    1 << 21
+     * Set to 0 to use the default (256KB). */
+    copts.block_size = 0;
+
     bench->cctx = zxc_create_cctx(&copts);
     bench->dctx = zxc_create_dctx();
 

--- a/bench/lzbench.h
+++ b/bench/lzbench.h
@@ -258,7 +258,7 @@ static const compressor_desc_t comp_desc[] =
     { "zstd24LDM",  "zstd 1.5.7 --long -d24", 16,  22,   24, FULL_THREADING, lzbench_zstd_LDM_compress,   lzbench_zstd_decompress,       lzbench_zstd_LDM_init,   lzbench_zstd_deinit },
     { "zstdLDM",    "zstd 1.5.7 --long",       1,  22,    0, FULL_THREADING, lzbench_zstd_LDM_compress,   lzbench_zstd_decompress,       lzbench_zstd_LDM_init,   lzbench_zstd_deinit },
     { "zstd_fast",  "zstd 1.5.7 --fast",      -5,  -1,    0, FULL_THREADING, lzbench_zstd_compress,       lzbench_zstd_decompress,       lzbench_zstd_init,       lzbench_zstd_deinit },
-    { "zxc",        "zxc 0.9.1",               1,   5,    0, BENCH_POOL_MT,  lzbench_zxc_compress,        lzbench_zxc_decompress,        lzbench_zxc_init,        lzbench_zxc_deinit },
+    { "zxc",        "zxc 0.10.0",              1,   5,    0, BENCH_POOL_MT,  lzbench_zxc_compress,        lzbench_zxc_decompress,        lzbench_zxc_init,        lzbench_zxc_deinit },
 };
 
 const long int LZBENCH_COMPRESSOR_COUNT = sizeof(comp_desc)/sizeof(comp_desc[0]);

--- a/lz/zxc/include/zxc_buffer.h
+++ b/lz/zxc/include/zxc_buffer.h
@@ -46,6 +46,55 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup library_info Library Information
+ * @brief Runtime-queryable library metadata.
+ *
+ * These functions allow callers (including filesystem integrations)
+ * to discover the supported compression level range and library version at
+ * runtime, without relying on compile-time constants alone.
+ * @{
+ */
+
+/**
+ * @brief Returns the minimum supported compression level.
+ *
+ * Currently returns @ref ZXC_LEVEL_FASTEST (1).
+ *
+ * @return Minimum compression level value.
+ */
+ZXC_EXPORT int zxc_min_level(void);
+
+/**
+ * @brief Returns the maximum supported compression level.
+ *
+ * Currently returns @ref ZXC_LEVEL_COMPACT (5).
+ *
+ * @return Maximum compression level value.
+ */
+ZXC_EXPORT int zxc_max_level(void);
+
+/**
+ * @brief Returns the default compression level.
+ *
+ * Currently returns @ref ZXC_LEVEL_DEFAULT (3).
+ *
+ * @return Default compression level value.
+ */
+ZXC_EXPORT int zxc_default_level(void);
+
+/**
+ * @brief Returns the human-readable library version string.
+ *
+ * The returned pointer is a compile-time constant and must not be freed.
+ * Example: "0.9.1".
+ *
+ * @return Null-terminated version string.
+ */
+ZXC_EXPORT const char* zxc_version_string(void);
+
+/** @} */ /* end of library_info */
+
+/**
  * @defgroup buffer_api Buffer API
  * @brief Single-shot, buffer-based compression and decompression.
  * @{
@@ -119,6 +168,98 @@ ZXC_EXPORT int64_t zxc_decompress(const void* src, const size_t src_size, void* 
 ZXC_EXPORT uint64_t zxc_get_decompressed_size(const void* src, const size_t src_size);
 
 /* ========================================================================= */
+/*  Block-Level API (no file framing)                                        */
+/* ========================================================================= */
+
+/**
+ * @defgroup block_api Block API
+ * @brief Single-block compression/decompression without file framing.
+ *
+ * These functions compress or decompress a single independent block, producing
+ * only the block header (8 bytes) + compressed payload + optional checksum (4 bytes).
+ * No file header, EOF block, or footer is written.
+ *
+ * This API is designed for filesystem integrations where the filesystem manages its own block
+ * indexing and each block is compressed independently.
+ *
+ * @par Typical usage
+ * @code
+ * // Compress a single filesystem block
+ * zxc_cctx* cctx = zxc_create_cctx(NULL);
+ * zxc_compress_opts_t opts = { .level = 3 };
+ * size_t bound = zxc_compress_block_bound(block_size);
+ * void *dst = malloc(bound);
+ * int64_t csize = zxc_compress_block(cctx, block, block_size, dst, bound, &opts);
+ *
+ * // Decompress
+ * zxc_dctx* dctx = zxc_create_dctx();
+ * int64_t dsize = zxc_decompress_block(dctx, dst, csize, out, block_size, NULL);
+ *
+ * zxc_free_cctx(cctx);
+ * zxc_free_dctx(dctx);
+ * @endcode
+ * @{
+ */
+
+/* Forward declarations for context types (defined below). */
+typedef struct zxc_cctx_s zxc_cctx;
+typedef struct zxc_dctx_s zxc_dctx;
+
+/**
+ * @brief Returns the maximum compressed size for a single block.
+ *
+ * Unlike zxc_compress_bound(), this does NOT include file header,
+ * EOF block, or footer overhead.  Use this to size the destination
+ * buffer for zxc_compress_block().
+ *
+ * @param[in] input_size Size of the uncompressed block in bytes.
+ * @return Upper bound on compressed block size, or 0 on overflow.
+ */
+ZXC_EXPORT uint64_t zxc_compress_block_bound(size_t input_size);
+
+/**
+ * @brief Compresses a single block without file framing.
+ *
+ * Output format: @c block_header(8B) + payload + optional @c checksum(4B).
+ * The output can be decompressed with zxc_decompress_block().
+ *
+ * @param[in,out] cctx         Reusable compression context.
+ * @param[in]     src          Source data.
+ * @param[in]     src_size     Source data size in bytes.
+ * @param[out]    dst          Destination buffer.
+ * @param[in]     dst_capacity Capacity of the destination buffer
+ *                             (use zxc_compress_block_bound() to size).
+ * @param[in]     opts         Compression options, or NULL for defaults.
+ *                             Only @c level, @c block_size, and
+ *                             @c checksum_enabled are used.
+ *
+ * @return Compressed block size in bytes (> 0) on success,
+ *         or a negative @ref zxc_error_t code on failure.
+ */
+ZXC_EXPORT int64_t zxc_compress_block(zxc_cctx* cctx, const void* src, size_t src_size, void* dst,
+                                      size_t dst_capacity, const zxc_compress_opts_t* opts);
+
+/**
+ * @brief Decompresses a single block produced by zxc_compress_block().
+ *
+ * @param[in,out] dctx         Reusable decompression context.
+ * @param[in]     src          Compressed block data.
+ * @param[in]     src_size     Compressed data size in bytes.
+ * @param[out]    dst          Destination buffer for decompressed data.
+ * @param[in]     dst_capacity Capacity of the destination buffer (must be
+ *                             at least the original uncompressed size).
+ * @param[in]     opts         Decompression options (NULL for defaults).
+ *                             Only @c checksum_enabled is used.
+ *
+ * @return Decompressed size in bytes (> 0) on success,
+ *         or a negative @ref zxc_error_t code on failure.
+ */
+ZXC_EXPORT int64_t zxc_decompress_block(zxc_dctx* dctx, const void* src, size_t src_size, void* dst,
+                                        size_t dst_capacity, const zxc_decompress_opts_t* opts);
+
+/** @} */ /* end of block_api */
+
+/* ========================================================================= */
 /*  Reusable Context API (opaque, heap-allocated)                            */
 /* ========================================================================= */
 
@@ -134,9 +275,6 @@ ZXC_EXPORT uint64_t zxc_get_decompressed_size(const void* src, const size_t src_
  */
 
 /* --- Compression context ------------------------------------------------- */
-
-/** @brief Opaque compression context (forward-declared). */
-typedef struct zxc_cctx_s zxc_cctx;
 
 /**
  * @brief Creates a new reusable compression context.
@@ -188,9 +326,6 @@ ZXC_EXPORT int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* src, size_t src
                                      size_t dst_capacity, const zxc_compress_opts_t* opts);
 
 /* --- Decompression context ----------------------------------------------- */
-
-/** @brief Opaque decompression context (forward-declared). */
-typedef struct zxc_dctx_s zxc_dctx;
 
 /**
  * @brief Creates a new reusable decompression context.

--- a/lz/zxc/include/zxc_constants.h
+++ b/lz/zxc/include/zxc_constants.h
@@ -25,9 +25,9 @@
 /** @brief Major version number. */
 #define ZXC_VERSION_MAJOR 0
 /** @brief Minor version number. */
-#define ZXC_VERSION_MINOR 9
+#define ZXC_VERSION_MINOR 10
 /** @brief Patch version number. */
-#define ZXC_VERSION_PATCH 1
+#define ZXC_VERSION_PATCH 0
 
 /** @cond INTERNAL */
 #define ZXC_STR_HELPER(x) #x

--- a/lz/zxc/include/zxc_sans_io.h
+++ b/lz/zxc/include/zxc_sans_io.h
@@ -52,8 +52,8 @@ extern "C" {
  * the overhead of repeated memory allocations.
  *
  * **Key Fields:**
- * - `hash_table`: Stores indices of 4-byte sequences. Size is `2 *
- * ZXC_LZ_HASH_SIZE` to reduce collisions (load factor < 0.5).
+ * - `hash_table`: Stores epoch-tagged positions (`ZXC_LZ_HASH_SIZE` * 4 bytes).
+ * - `hash_tags`:  Stores 8-bit tags for fast rejection (`ZXC_LZ_HASH_SIZE` * 1 byte).
  * - `chain_table`: Handles collisions by storing the *previous* occurrence of a
  *   hash. This forms a linked list for each hash bucket, allowing us to
  * traverse history.
@@ -79,7 +79,8 @@ extern "C" {
 typedef struct {
     /* Hot zone: random access / high frequency.
      * Kept at the start to ensure they reside in the first cache line (64 bytes). */
-    uint32_t* hash_table;  /**< Hash table for LZ77 match finding. */
+    uint32_t* hash_table;  /**< Hash table for LZ77 match positions (epoch|pos). */
+    uint8_t* hash_tags;    /**< Split tag table for fast match rejection (8-bit tags). */
     uint16_t* chain_table; /**< Chain table for collision resolution. */
     void* memory_block;    /**< Single allocation block owner. */
     uint32_t epoch;        /**< Current epoch for lazy hash table invalidation. */
@@ -144,7 +145,8 @@ ZXC_EXPORT void zxc_cctx_free(zxc_cctx_t* ctx);
  *
  * @param[out] dst The destination buffer where the header will be written.
  * @param[in] dst_capacity The total capacity of the destination buffer in bytes.
- * @param[in] has_checksum Flag indicating whether the checksum bit should be set.
+ * @param[in] chunk_size    The block size to encode in the header.
+ * @param[in] has_checksum  Flag indicating whether the checksum bit should be set.
  * @return The number of bytes written (ZXC_FILE_HEADER_SIZE) on success,
  *         or ZXC_ERROR_DST_TOO_SMALL if the destination capacity is insufficient.
  */
@@ -160,8 +162,8 @@ ZXC_EXPORT int zxc_write_file_header(uint8_t* dst, const size_t dst_capacity,
  *
  * @param[in] src Pointer to the source buffer containing the file data.
  * @param[in] src_size Size of the source buffer in bytes.
- * @param[out] out_block_size Optional pointer to receive the recommended block size.
- * @param[out] out_has_checksum Optional pointer to receive the checksum flag.
+ * @param[out] out_block_size    Optional pointer to receive the recommended block size.
+ * @param[out] out_has_checksum  Optional pointer to receive the checksum flag.
  * @return ZXC_OK on success, or a negative error code (e.g., ZXC_ERROR_SRC_TOO_SMALL,
  * ZXC_ERROR_BAD_MAGIC, ZXC_ERROR_BAD_VERSION).
  */

--- a/lz/zxc/include/zxc_seekable.h
+++ b/lz/zxc/include/zxc_seekable.h
@@ -1,0 +1,220 @@
+/*
+ * ZXC - High-performance lossless compression
+ *
+ * Copyright (c) 2025-2026 Bertrand Lebonnois and contributors.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file zxc_seekable.h
+ * @brief Seekable compression and random-access decompression API.
+ *
+ * This header provides functions to produce seekable ZXC archives and to
+ * decompress arbitrary byte ranges without reading the entire file.
+ *
+ * A seekable archive embeds a Seek Table block (block_type = @c ZXC_BLOCK_SEK)
+ * after the EOF block, recording the compressed size of every block.
+ * The table is detected at read time by deriving @c num_blocks from the file
+ * footer's total decompressed size and the header's block size, then seeking
+ * backward to validate the SEK block header.
+ * Standard (non-seekable) decompressors ignore the seek table entirely.
+ *
+ * @par Creating a seekable archive
+ * @code
+ * zxc_compress_opts_t opts = { .level = 3, .seekable = 1 };
+ * int64_t csize = zxc_compress(src, src_size, dst, dst_cap, &opts);
+ * @endcode
+ *
+ * @par Random-access decompression
+ * @code
+ * zxc_seekable* s = zxc_seekable_open(compressed, csize);
+ * int64_t n = zxc_seekable_decompress_range(s, out, out_cap, offset, len);
+ * zxc_seekable_free(s);
+ * @endcode
+ *
+ * @see zxc_buffer.h  for the standard one-shot API.
+ * @see zxc_stream.h  for multi-threaded streaming.
+ */
+
+#ifndef ZXC_SEEKABLE_H
+#define ZXC_SEEKABLE_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "zxc_export.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup seekable_api Seekable API
+ * @brief Random-access compression and decompression.
+ * @{
+ */
+
+/* ========================================================================= */
+/*  Seekable Reader (Random-Access Decompression)                            */
+/* ========================================================================= */
+
+/**
+ * @brief Opaque handle for a seekable ZXC archive.
+ *
+ * Created by zxc_seekable_open() or zxc_seekable_open_file().
+ * Must be freed with zxc_seekable_free().
+ */
+typedef struct zxc_seekable_s zxc_seekable;
+
+/**
+ * @brief Opens a seekable archive from a memory buffer.
+ *
+ * Parses the seek table from the end of the buffer and builds the internal
+ * block index.  The buffer must remain valid for the lifetime of the handle.
+ *
+ * @param[in] src       Pointer to the compressed data.
+ * @param[in] src_size  Size of the compressed data in bytes.
+ * @return Handle on success, or @c NULL if the buffer does not contain a
+ *         valid seekable archive (e.g. missing seek block, bad block type).
+ */
+ZXC_EXPORT zxc_seekable* zxc_seekable_open(const void* src, const size_t src_size);
+
+/**
+ * @brief Opens a seekable archive from a FILE*.
+ *
+ * The file must be seekable (not stdin/pipe).  The current file position
+ * is saved and restored after parsing the seek table.  The FILE* must
+ * remain open for the lifetime of the handle.
+ *
+ * @param[in] f  File opened in "rb" mode.
+ * @return Handle on success, or @c NULL on error.
+ */
+ZXC_EXPORT zxc_seekable* zxc_seekable_open_file(FILE* f);
+
+/**
+ * @brief Returns the total number of blocks in the seekable archive.
+ *
+ * @param[in] s  Seekable handle.
+ * @return Number of data blocks (excluding EOF).
+ */
+ZXC_EXPORT uint32_t zxc_seekable_get_num_blocks(const zxc_seekable* s);
+
+/**
+ * @brief Returns the total decompressed size of the seekable archive.
+ *
+ * @param[in] s  Seekable handle.
+ * @return Total decompressed size in bytes.
+ */
+ZXC_EXPORT uint64_t zxc_seekable_get_decompressed_size(const zxc_seekable* s);
+
+/**
+ * @brief Returns the compressed size of a specific block.
+ *
+ * This is the "on-disk" size including block header, payload, and optional
+ * per-block checksum.
+ *
+ * @param[in] s          Seekable handle.
+ * @param[in] block_idx  Zero-based block index.
+ * @return Compressed block size, or 0 if @p block_idx is out of range.
+ */
+ZXC_EXPORT uint32_t zxc_seekable_get_block_comp_size(const zxc_seekable* s,
+                                                     const uint32_t block_idx);
+
+/**
+ * @brief Returns the decompressed size of a specific block.
+ *
+ * @param[in] s          Seekable handle.
+ * @param[in] block_idx  Zero-based block index.
+ * @return Decompressed block size, or 0 if @p block_idx is out of range.
+ */
+ZXC_EXPORT uint32_t zxc_seekable_get_block_decomp_size(const zxc_seekable* s,
+                                                       const uint32_t block_idx);
+
+/**
+ * @brief Decompresses an arbitrary byte range from the original data.
+ *
+ * Only the blocks overlapping [@p offset, @p offset + @p len) are read and
+ * decompressed.  This is the core random-access primitive.
+ *
+ * @param[in,out] s            Seekable handle.
+ * @param[out]    dst          Destination buffer.
+ * @param[in]     dst_capacity Capacity of @p dst (must be >= @p len).
+ * @param[in]     offset       Byte offset into the original uncompressed data.
+ * @param[in]     len          Number of bytes to decompress.
+ * @return Number of bytes written to @p dst (== @p len on success),
+ *         or a negative @ref zxc_error_t code on failure.
+ */
+ZXC_EXPORT int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst,
+                                                 const size_t dst_capacity, const uint64_t offset,
+                                                 const size_t len);
+
+/**
+ * @brief Multi-threaded variant of zxc_seekable_decompress_range().
+ *
+ * Decompresses blocks in parallel using a fork-join thread pool.  Each worker
+ * thread owns its own decompression context and reads compressed data via
+ * @c pread() (POSIX) or @c ReadFile() (Windows) for lock-free concurrent I/O.
+ *
+ * Falls back to single-threaded mode when @p n_threads <= 1 or when the
+ * requested range spans a single block.
+ *
+ * @param[in,out] s            Seekable handle.
+ * @param[out]    dst          Destination buffer.
+ * @param[in]     dst_capacity Capacity of @p dst (must be >= @p len).
+ * @param[in]     offset       Byte offset into the original uncompressed data.
+ * @param[in]     len          Number of bytes to decompress.
+ * @param[in]     n_threads    Number of worker threads (0 = auto-detect CPU cores).
+ * @return Number of bytes written to @p dst (== @p len on success),
+ *         or a negative @ref zxc_error_t code on failure.
+ */
+ZXC_EXPORT int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst,
+                                                    const size_t dst_capacity,
+                                                    const uint64_t offset, const size_t len,
+                                                    int n_threads);
+
+/**
+ * @brief Frees a seekable handle and all associated resources.
+ *
+ * Safe to call with @c NULL.
+ *
+ * @param[in] s  Handle to free.
+ */
+ZXC_EXPORT void zxc_seekable_free(zxc_seekable* s);
+
+/* ========================================================================= */
+/*  Seek Table Writer (low-level)                                            */
+/* ========================================================================= */
+
+/**
+ * @brief Writes a seek table to the destination buffer.
+ *
+ * This is a low-level helper used internally by the seekable compression
+ * paths.  It writes: block_header(8) + N entries(4 each).
+ * Each entry stores only @c comp_size; decompressed sizes are derived at
+ * read time from the file header's block_size.
+ *
+ * @param[out] dst             Destination buffer.
+ * @param[in]  dst_capacity    Capacity of @p dst in bytes.
+ * @param[in]  comp_sizes      Array of compressed block sizes.
+ * @param[in]  num_blocks      Number of blocks.
+ * @return Number of bytes written, or a negative @ref zxc_error_t on failure.
+ */
+ZXC_EXPORT int64_t zxc_write_seek_table(uint8_t* dst, const size_t dst_capacity,
+                                        const uint32_t* comp_sizes, const uint32_t num_blocks);
+
+/**
+ * @brief Returns the encoded size of a seek table for the given block count.
+ *
+ * @param[in] num_blocks     Number of blocks.
+ * @return Total byte size of the seek table.
+ */
+ZXC_EXPORT size_t zxc_seek_table_size(const uint32_t num_blocks);
+
+/** @} */ /* end of seekable_api */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZXC_SEEKABLE_H */

--- a/lz/zxc/include/zxc_stream.h
+++ b/lz/zxc/include/zxc_stream.h
@@ -60,7 +60,7 @@ typedef void (*zxc_progress_callback_t)(uint64_t bytes_processed, uint64_t bytes
  * @brief Options for streaming compression.
  *
  * Zero-initialise for safe defaults: level 0 maps to ZXC_LEVEL_DEFAULT (3),
- * block_size 0 maps to ZXC_BLOCK_SIZE_DEFAULT (256 KB), n_threads 0 means
+ * block_size 0 maps to ZXC_BLOCK_SIZE_DEFAULT, n_threads 0 means
  * auto-detect, and all other fields are disabled.
  *
  * @code
@@ -69,11 +69,12 @@ typedef void (*zxc_progress_callback_t)(uint64_t bytes_processed, uint64_t bytes
  * @endcode
  */
 typedef struct {
-    int n_threads;        /**< Worker thread count (0 = auto-detect CPU cores). */
-    int level;            /**< Compression level 1-5 (0 = default, ZXC_LEVEL_DEFAULT). */
-    size_t block_size;    /**< Block size in bytes (0 = default 256 KB). Must be power of 2, [4KB -
-                             2MB]. */
+    int n_threads;     /**< Worker thread count (0 = auto-detect CPU cores). */
+    int level;         /**< Compression level 1-5 (0 = default, ZXC_LEVEL_DEFAULT). */
+    size_t block_size; /**< Block size in bytes (0 = default ZXC_BLOCK_SIZE_DEFAULT). Must be power
+                          of 2, [4KB - 2MB]. */
     int checksum_enabled; /**< 1 to enable per-block and global checksums, 0 to disable. */
+    int seekable;         /**< 1 to append a seek table for random-access decompression. */
     zxc_progress_callback_t progress_cb; /**< Optional progress callback (NULL to disable). */
     void* user_data;                     /**< User context pointer passed to progress_cb. */
 } zxc_compress_opts_t;

--- a/lz/zxc/src/lib/zxc_common.c
+++ b/lz/zxc/src/lib/zxc_common.c
@@ -81,26 +81,29 @@ int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int m
     ctx->chunk_size = chunk_size;
     const uint32_t offset_bits = zxc_log2_u32((uint32_t)chunk_size);
     ctx->offset_bits = offset_bits;
-    ctx->offset_mask = (1U << offset_bits) - 1;
-    ctx->max_epoch = 1U << (32 - offset_bits);
+    ctx->offset_mask = (uint32_t)((1ULL << offset_bits) - 1);
+    ctx->max_epoch = (uint32_t)(1ULL << (32 - offset_bits));
 
     if (mode == 0) return ZXC_OK;
 
     const size_t max_seq = chunk_size / sizeof(uint32_t) + 256;
-    const size_t sz_hash = 2 * ZXC_LZ_HASH_SIZE * sizeof(uint32_t);
+    const size_t sz_hash_pos = ZXC_LZ_HASH_SIZE * sizeof(uint32_t);
+    const size_t sz_hash_tags = ZXC_LZ_HASH_SIZE * sizeof(uint8_t);
     const size_t sz_chain = chunk_size * sizeof(uint16_t);
     const size_t sz_sequences = max_seq * sizeof(uint32_t);
     const size_t sz_tokens = max_seq * sizeof(uint8_t);
     const size_t sz_offsets = max_seq * sizeof(uint16_t);
     const size_t sz_extras =
         max_seq * 2 *
-        ZXC_VBYTE_ALLOC_LEN;  // Max 3 bytes per LL/ML VByte (sufficient for 256KB block)
+        ZXC_VBYTE_ALLOC_LEN;  // Max 3 bytes per LL/ML VByte (21 bits, sufficient for <= 2MB block)
     const size_t sz_lit = chunk_size + ZXC_PAD_SIZE;
 
     // Calculate sizes with alignment padding (64 bytes for cache line alignment)
     size_t total_size = 0;
-    const size_t off_hash = total_size;
-    total_size += (sz_hash + ZXC_ALIGNMENT_MASK) & ~ZXC_ALIGNMENT_MASK;
+    const size_t off_hash_pos = total_size;
+    total_size += (sz_hash_pos + ZXC_ALIGNMENT_MASK) & ~ZXC_ALIGNMENT_MASK;
+    const size_t off_hash_tags = total_size;
+    total_size += (sz_hash_tags + ZXC_ALIGNMENT_MASK) & ~ZXC_ALIGNMENT_MASK;
     const size_t off_chain = total_size;
     total_size += (sz_chain + ZXC_ALIGNMENT_MASK) & ~ZXC_ALIGNMENT_MASK;
     const size_t off_sequences = total_size;
@@ -118,7 +121,8 @@ int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int m
     if (UNLIKELY(!mem)) return ZXC_ERROR_MEMORY;
 
     ctx->memory_block = mem;
-    ctx->hash_table = (uint32_t*)(mem + off_hash);
+    ctx->hash_table = (uint32_t*)(mem + off_hash_pos);
+    ctx->hash_tags = (uint8_t*)(mem + off_hash_tags);
     ctx->chain_table = (uint16_t*)(mem + off_chain);
     ctx->buf_sequences = (uint32_t*)(mem + off_sequences);
     ctx->buf_tokens = (uint8_t*)(mem + off_tokens);
@@ -129,7 +133,8 @@ int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int m
     ctx->compression_level = level;
     ctx->epoch = 1;
 
-    ZXC_MEMSET(ctx->hash_table, 0, sz_hash);
+    ZXC_MEMSET(ctx->hash_table, 0, sz_hash_pos);
+    ZXC_MEMSET(ctx->hash_tags, 0, sz_hash_tags);
     return ZXC_OK;
 }
 
@@ -158,6 +163,7 @@ void zxc_cctx_free(zxc_cctx_t* ctx) {
     }
 
     ctx->hash_table = NULL;
+    ctx->hash_tags = NULL;
     ctx->chain_table = NULL;
     ctx->buf_sequences = NULL;
     ctx->buf_tokens = NULL;
@@ -245,7 +251,7 @@ int zxc_read_file_header(const uint8_t* RESTRICT src, const size_t src_size,
             block_size = (size_t)1U << code;
         } else if (code == 64) {
             // Legacy: hardcoded 256 KB default
-            block_size = ZXC_BLOCK_SIZE_DEFAULT;
+            block_size = 256 * 1024;
         } else {
             return ZXC_ERROR_BAD_BLOCK_SIZE;
         }
@@ -530,7 +536,7 @@ int zxc_read_ghi_header_and_desc(const uint8_t* RESTRICT src, const size_t len,
  */
 int zxc_bitpack_stream_32(const uint32_t* RESTRICT src, const size_t count, uint8_t* RESTRICT dst,
                           const size_t dst_cap, const uint8_t bits) {
-    const size_t out_bytes = ((count * bits) + ZXC_BITS_PER_BYTE - 1) / ZXC_BITS_PER_BYTE;
+    const size_t out_bytes = ((count * bits) + CHAR_BIT - 1) / CHAR_BIT;
 
     // +4 bytes: packing may write past out_bytes when the last value straddles a byte boundary.
     const size_t safe_bytes = out_bytes + sizeof(uint32_t);
@@ -545,22 +551,22 @@ int zxc_bitpack_stream_32(const uint32_t* RESTRICT src, const size_t count, uint
     // However, if bits=64 (unlikely for a 32-bit packer), it would be an issue.
     // For 0 < bits <= 32:
     const uint64_t val_mask =
-        (bits == sizeof(uint32_t) * ZXC_BITS_PER_BYTE) ? UINT32_MAX : ((1ULL << bits) - 1);
+        (bits == sizeof(uint32_t) * CHAR_BIT) ? UINT32_MAX : ((1ULL << bits) - 1);
 
     for (size_t i = 0; i < count; i++) {
         // Mask the input value to ensure we don't write garbage
-        const uint64_t v = ((uint64_t)src[i] & val_mask) << (bit_pos % ZXC_BITS_PER_BYTE);
+        const uint64_t v = ((uint64_t)src[i] & val_mask) << (bit_pos % CHAR_BIT);
 
-        const size_t byte_idx = bit_pos / ZXC_BITS_PER_BYTE;
+        const size_t byte_idx = bit_pos / CHAR_BIT;
         dst[byte_idx] |= (uint8_t)v;
-        if (bits + (bit_pos % ZXC_BITS_PER_BYTE) > 1 * ZXC_BITS_PER_BYTE)
-            dst[byte_idx + 1] |= (uint8_t)(v >> (1 * ZXC_BITS_PER_BYTE));
-        if (bits + (bit_pos % ZXC_BITS_PER_BYTE) > 2 * ZXC_BITS_PER_BYTE)
-            dst[byte_idx + 2] |= (uint8_t)(v >> (2 * ZXC_BITS_PER_BYTE));
-        if (bits + (bit_pos % ZXC_BITS_PER_BYTE) > 3 * ZXC_BITS_PER_BYTE)
-            dst[byte_idx + 3] |= (uint8_t)(v >> (3 * ZXC_BITS_PER_BYTE));
-        if (bits + (bit_pos % ZXC_BITS_PER_BYTE) > 4 * ZXC_BITS_PER_BYTE)
-            dst[byte_idx + 4] |= (uint8_t)(v >> (4 * ZXC_BITS_PER_BYTE));
+        if (bits + (bit_pos % CHAR_BIT) > 1 * CHAR_BIT)
+            dst[byte_idx + 1] |= (uint8_t)(v >> (1 * CHAR_BIT));
+        if (bits + (bit_pos % CHAR_BIT) > 2 * CHAR_BIT)
+            dst[byte_idx + 2] |= (uint8_t)(v >> (2 * CHAR_BIT));
+        if (bits + (bit_pos % CHAR_BIT) > 3 * CHAR_BIT)
+            dst[byte_idx + 3] |= (uint8_t)(v >> (3 * CHAR_BIT));
+        if (bits + (bit_pos % CHAR_BIT) > 4 * CHAR_BIT)
+            dst[byte_idx + 4] |= (uint8_t)(v >> (4 * CHAR_BIT));
         bit_pos += bits;
     }
     return (int)out_bytes;
@@ -575,7 +581,11 @@ int zxc_bitpack_stream_32(const uint32_t* RESTRICT src, const size_t count, uint
  * @brief Returns the maximum compressed size for a given input size.
  *
  * The result accounts for the file header, per-block headers, block
- * checksums, worst-case expansion, EOF block, and the file footer.
+ * checksums, worst-case expansion, EOF block, seekable overhead (SEK
+ * block), and the file footer.
+ *
+ * The block count is derived from @ref ZXC_BLOCK_SIZE_MIN (4 KB) to
+ * guarantee the bound holds for all valid block sizes and seekable mode.
  *
  * @param[in] input_size Uncompressed input size in bytes.
  * @return Upper bound on compressed size, or 0 if @p input_size would overflow.
@@ -583,10 +593,25 @@ int zxc_bitpack_stream_32(const uint32_t* RESTRICT src, const size_t count, uint
 uint64_t zxc_compress_bound(const size_t input_size) {
     // Guard UINT64_MAX / SIZE_MAX would overflow.
     if (UNLIKELY(input_size > (SIZE_MAX - (SIZE_MAX >> 8)))) return 0;
-    uint64_t n = ((uint64_t)input_size + ZXC_BLOCK_SIZE_DEFAULT - 1) / ZXC_BLOCK_SIZE_DEFAULT;
+    uint64_t n = ((uint64_t)input_size + ZXC_BLOCK_SIZE_MIN - 1) / ZXC_BLOCK_SIZE_MIN;
     if (n == 0) n = 1;
     return ZXC_FILE_HEADER_SIZE + (n * (ZXC_BLOCK_HEADER_SIZE + ZXC_BLOCK_CHECKSUM_SIZE + 64)) +
-           (uint64_t)input_size + ZXC_BLOCK_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE;
+           (uint64_t)input_size + ZXC_BLOCK_HEADER_SIZE + /* EOF block */
+           ZXC_BLOCK_HEADER_SIZE +                        /* SEK block header (seekable) */
+           (n * ZXC_SEEK_ENTRY_SIZE) +                    /* SEK entries: 4 bytes per block */
+           ZXC_FILE_FOOTER_SIZE;
+}
+
+/*
+ * @brief Returns the maximum compressed size for a single block (no file framing).
+ *
+ * @param[in] input_size Uncompressed block size in bytes.
+ * @return Upper bound on compressed block size, or 0 on overflow.
+ */
+uint64_t zxc_compress_block_bound(const size_t input_size) {
+    if (UNLIKELY(input_size > (SIZE_MAX - (SIZE_MAX >> 8)))) return 0;
+    // Block header + worst-case expansion (64B overhead) + checksum
+    return (uint64_t)ZXC_BLOCK_HEADER_SIZE + (uint64_t)input_size + 64 + ZXC_BLOCK_CHECKSUM_SIZE;
 }
 
 /*
@@ -638,3 +663,40 @@ const char* zxc_error_name(const int code) {
             return "ZXC_UNKNOWN_ERROR";
     }
 }
+
+/*
+ * ============================================================================
+ * LIBRARY INFORMATION
+ * ============================================================================
+ */
+
+/*
+ * @brief Returns the minimum supported compression level.
+ *
+ * Returns the value of ZXC_LEVEL_FASTEST (currently 1).
+ * This allows integrators to discover the level range at runtime without relying on
+ * compile-time macros alone.
+ */
+int zxc_min_level(void) { return ZXC_LEVEL_FASTEST; }
+
+/*
+ * @brief Returns the maximum supported compression level.
+ *
+ * Returns the value of ZXC_LEVEL_COMPACT (currently 5).
+ */
+int zxc_max_level(void) { return ZXC_LEVEL_COMPACT; }
+
+/*
+ * @brief Returns the default compression level.
+ *
+ * Returns the value of ZXC_LEVEL_DEFAULT (currently 3).
+ */
+int zxc_default_level(void) { return ZXC_LEVEL_DEFAULT; }
+
+/*
+ * @brief Returns the human-readable library version string.
+ *
+ * The returned pointer is a compile-time constant and must not be freed.
+ * Example: "0.9.1".
+ */
+const char* zxc_version_string(void) { return ZXC_LIB_VERSION_STR; }

--- a/lz/zxc/src/lib/zxc_compress.c
+++ b/lz/zxc/src/lib/zxc_compress.c
@@ -37,13 +37,13 @@
  * 4-byte Marsaglia hash.
  * @return uint32_t A hash value suitable for indexing the match table.
  */
-static ZXC_ALWAYS_INLINE uint32_t zxc_hash_func(uint64_t val, const int use_hash5) {
+static ZXC_ALWAYS_INLINE uint32_t zxc_hash_func(const uint64_t val, const int use_hash5) {
     if (use_hash5) {
         const uint64_t v5 = val & 0xFFFFFFFFFFULL;
         return (uint32_t)((v5 * ZXC_LZ_HASH_PRIME2) >> (64 - ZXC_LZ_HASH_BITS));
     } else {
-        val ^= val >> 15;
-        return ((uint32_t)val * ZXC_LZ_HASH_PRIME1) >> (32 - ZXC_LZ_HASH_BITS);
+        const uint64_t v4 = val ^ (val >> 15);
+        return ((uint32_t)v4 * ZXC_LZ_HASH_PRIME1) >> (32 - ZXC_LZ_HASH_BITS);
     }
 }
 
@@ -90,45 +90,27 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_mm256_reduce_max_epu32(__m256i v) {
  * @param[in] val The 32-bit unsigned integer value to encode.
  * @return The number of bytes written to the destination buffer.
  */
-static ZXC_ALWAYS_INLINE size_t zxc_write_varint(uint8_t* RESTRICT dst, uint32_t val) {
-    // Prefix Varint Encoding
-    // 1 byte: 0xxxxxxx (7 bits) -> val < 128
-    if (LIKELY(val < 128)) {
+static ZXC_ALWAYS_INLINE size_t zxc_write_varint(uint8_t* RESTRICT dst, const uint32_t val) {
+    // 1 byte: 0xxxxxxx (7 bits) = 2^7 = 128
+    if (LIKELY(val < (1 << 7))) {
         dst[0] = (uint8_t)val;
         return 1;
     }
 
-    // 2 bytes: 10xxxxxx xxxxxxxx (14 bits) -> val < 16384 (2^14)
-    if (LIKELY(val < 16384)) {
+    // 2 bytes: 10xxxxxx xxxxxxxx (14 bits) = 2^14 = 16384
+    if (LIKELY(val < (1 << 14))) {
         dst[0] = (uint8_t)(0x80 | (val & 0x3F));
         dst[1] = (uint8_t)(val >> 6);
         return 2;
     }
 
-    // 3 bytes: 110xxxxx xxxxxxxx xxxxxxxx (21 bits) -> val < 2097152 (2^21)
-    if (LIKELY(val < 2097152)) {
-        dst[0] = (uint8_t)(0xC0 | (val & 0x1F));
-        dst[1] = (uint8_t)(val >> 5);
-        dst[2] = (uint8_t)(val >> 13);
-        return 3;
-    }
-
-    // 4 bytes: 1110xxxx xxxxxxxx xxxxxxxx xxxxxxxx (28 bits) -> val < 268435456 (2^28)
-    if (LIKELY(val < 268435456)) {
-        dst[0] = (uint8_t)(0xE0 | (val & 0x0F));
-        dst[1] = (uint8_t)(val >> 4);
-        dst[2] = (uint8_t)(val >> 12);
-        dst[3] = (uint8_t)(val >> 20);
-        return 4;
-    }
-
-    // 5 bytes: 11110xxx ... (35 bits) -> Full 32-bit range
-    dst[0] = (uint8_t)(0xF0 | (val & 0x07));
-    dst[1] = (uint8_t)(val >> 3);
-    dst[2] = (uint8_t)(val >> 11);
-    dst[3] = (uint8_t)(val >> 19);
-    dst[4] = (uint8_t)(val >> 27);
-    return 5;
+    // 3 bytes: 110xxxxx xxxxxxxx xxxxxxxx (21 bits) = 2^21 = 2097152
+    // Max varint value is bounded by ZXC_BLOCK_SIZE_MAX (2MB = 2^21).
+    // ZXC_VBYTE_ALLOC_LEN == 3 guarantees this is the last reachable path.
+    dst[0] = (uint8_t)(0xC0 | (val & 0x1F));
+    dst[1] = (uint8_t)(val >> 5);
+    dst[2] = (uint8_t)(val >> 13);
+    return ZXC_VBYTE_ALLOC_LEN;
 }
 
 /**
@@ -150,16 +132,17 @@ typedef struct {
 /**
  * @brief Finds the best matching sequence for LZ77 compression
  *
- * This function searches for the longest matching sequence in the
- * sliding window dictionary for LZ77 compression algorithm.
- * It is marked as always inline for performance optimization.
+ * Uses a split hash table layout:
+ * - hash_table[h]  : uint32_t position + epoch (128 KB for 15-bit hash)
+ * - hash_tags[h]   : uint8_t tag for fast rejection (32 KB, L1-resident)
  *
  * @param[in] src Pointer to the start of the source buffer.
  * @param[in] ip Current input position pointer.
  * @param[in] iend Pointer to the end of the input buffer.
  * @param[in] mflimit Pointer to the match finding limit.
  * @param[in] anchor Pointer to the current anchor position.
- * @param[in,out] hash_table Pointer to the hash table for match finding.
+ * @param[in,out] hash_table Pointer to the position table for match finding.
+ * @param[in,out] hash_tags Pointer to the tag table for fast rejection.
  * @param[in,out] chain_table Pointer to the chain table for collision handling.
  * @param[in] epoch_mark Current epoch marker for hash table invalidation.
  * @param[in] p LZ77 parameters controlling search depth, lazy matching, and stepping.
@@ -168,8 +151,9 @@ typedef struct {
  */
 static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
     const uint8_t* src, const uint8_t* ip, const uint8_t* iend, const uint8_t* mflimit,
-    const uint8_t* anchor, uint32_t* RESTRICT hash_table, uint16_t* RESTRICT chain_table,
-    uint32_t epoch_mark, uint32_t offset_mask, const int level, const zxc_lz77_params_t p) {
+    const uint8_t* anchor, uint32_t* RESTRICT hash_table, uint8_t* RESTRICT hash_tags,
+    uint16_t* RESTRICT chain_table, const uint32_t epoch_mark, const uint32_t offset_mask,
+    const int level, const zxc_lz77_params_t p) {
     const int use_hash5 = (level >= 3);
     // Track the best match found so far.
     //  ref is the pointer to the start of the match in the history buffer,
@@ -179,43 +163,33 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
 
     // Load the 8-byte sequence at the current position.
     uint64_t cur_val8 = zxc_le64(ip);
-    // First 4 bytes for tag and old lookups
     uint32_t cur_val = (uint32_t)cur_val8;
     uint32_t h = zxc_hash_func(cur_val8, use_hash5);
 
-    // For levels 1-2, enhance tag with byte5 info via XOR (preserves byte4 info)
-    // High byte becomes (byte4 ^ byte5), keeping discrimination from both bytes
-    uint32_t cur_tag = (level <= 2) ? (cur_val ^ ((uint32_t)(cur_val8 >> 32) << 24)) : cur_val;
+    // 8-bit tag: XOR fold of first 4 bytes for fast rejection
+    const uint8_t cur_tag = (uint8_t)(cur_val ^ (cur_val >> 16));
 
     // Current position in the input buffer expressed as a 32-bit index.
-    // This index is what we store in / retrieve from the hash/chain tables.
     const uint32_t cur_pos = (uint32_t)(ip - src);
 
-    // Each hash bucket stores:
-    // - raw_head: compressed pointer (epoch in high bits, position in low bits)
-    // - stored_tag: 4-byte tag (or XOR-enhanced for levels 1-2) to quickly reject mismatches.
-    // Epoch bits allow the tables to be lazily invalidated without clearing all entries.
-    const uint32_t raw_head = hash_table[2 * h];
-    const uint32_t stored_tag = hash_table[2 * h + 1];
+    // Split table reads: tag table + position table
+    const uint8_t stored_tag = hash_tags[h];
+    const uint32_t raw_head = hash_table[h];
 
     // If the epoch in raw_head matches the current epoch_mark, extract the
     // stored position; otherwise treat this bucket as empty (index 0).
-    // Branchless optimization:
-    // Create a mask that is 0xFFFFFFFF if epochs match, 0 otherwise.
-    const uint32_t epoch_mask = -((int32_t)((raw_head & ~offset_mask) == epoch_mark));
-    uint32_t match_idx = (raw_head & offset_mask) & epoch_mask;
+    uint32_t match_idx = ((raw_head & ~offset_mask) == epoch_mark) ? (raw_head & offset_mask) : 0;
 
     // Decide whether to skip the head entry of the hash chain.
     const int skip_head = (match_idx != 0) & (stored_tag != cur_tag);
 
-    // If we should skip the head and level is low (<= 2), we drop the match entirely (match_idx =
-    // 0). drop_mask is 0 if we drop (skip_head && level <= 2 is true becomes 1, 1-1=0), -1
-    // otherwise.
+    // If we should skip the head and level is low (<= 2), we drop the match entirely.
     const uint32_t drop_mask = (uint32_t)((skip_head & (level <= 2)) - 1);
     match_idx &= drop_mask;
 
-    hash_table[2 * h] = epoch_mark | cur_pos;
-    hash_table[2 * h + 1] = cur_tag;
+    // Split table writes
+    hash_table[h] = epoch_mark | cur_pos;
+    hash_tags[h] = cur_tag;
 
     // Branchless chain table update
     const uint32_t dist = cur_pos - match_idx;
@@ -314,7 +288,8 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
                 uint8x8_t p1 = vpmin_u8(vget_low_u8(v_cmp), vget_high_u8(v_cmp));
                 uint8x8_t p2 = vpmin_u8(p1, p1);
                 uint8x8_t p3 = vpmin_u8(p2, p2);
-                uint8_t min_val = vget_lane_u8(p3, 0);
+                uint8x8_t p4 = vpmin_u8(p3, p3);
+                uint8_t min_val = vget_lane_u8(p4, 0);
                 if (min_val == 0xFF)
                     mlen += 16;
                 else {
@@ -374,83 +349,94 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
         best.ref = b_ref;
     }
 
-    if (p.use_lazy && best.ref && best.len < 128 && ip + 1 < mflimit) {
+    if (p.use_lazy && best.ref && best.len < (uint32_t)p.lazy_len_threshold && ip + 1 < mflimit) {
+        // --- Lazy evaluation at ip+1 ---
         const uint64_t next_val8 = zxc_le64(ip + 1);
         const uint32_t next_val = (uint32_t)next_val8;
         const uint32_t h2 = zxc_hash_func(next_val8, use_hash5);
-        const uint32_t next_head = hash_table[2 * h2];
-        const uint32_t next_stored_tag = hash_table[2 * h2 + 1];
+        const uint8_t next_stored_tag = hash_tags[h2];
+        const uint32_t next_head = hash_table[h2];
         uint32_t next_idx =
             (next_head & ~offset_mask) == epoch_mark ? (next_head & offset_mask) : 0;
-        const int skip_lazy_head = (next_idx > 0 && next_stored_tag != next_val);
-        uint32_t max_lazy = 0;
+        const uint8_t next_tag = (uint8_t)(next_val ^ (next_val >> 16));
+        const int skip_lazy_head = (next_idx > 0 && next_stored_tag != next_tag);
+        uint32_t max_lazy2 = 0;
         int lazy_att = p.lazy_attempts;
         int is_lazy_first = 1;
 
         while (next_idx > 0 && lazy_att-- > 0) {
             if (UNLIKELY((uint32_t)(ip + 1 - src) - next_idx > ZXC_LZ_MAX_DIST)) break;
             const uint8_t* ref2 = src + next_idx;
+
             if ((!is_lazy_first || !skip_lazy_head) && zxc_le32(ref2) == next_val) {
                 uint32_t l2 = sizeof(uint32_t);
-                const uint8_t* limit8 = iend - sizeof(uint64_t);
-                while (ip + 1 + l2 < limit8) {
+                const uint8_t* limit = iend - sizeof(uint64_t);
+
+                while (ip + 1 + l2 < limit) {
                     const uint64_t v1 = zxc_le64(ip + 1 + l2);
                     const uint64_t v2 = zxc_le64(ref2 + l2);
                     if (v1 != v2) {
                         l2 += (uint32_t)(zxc_ctz64(v1 ^ v2) >> 3);
-                        goto lazy1_done;
+                        goto lazy2_done;
                     }
                     l2 += sizeof(uint64_t);
                 }
                 while (ip + 1 + l2 < iend && ref2[l2] == ip[1 + l2]) l2++;
-            lazy1_done:
-                if (l2 > max_lazy) max_lazy = l2;
+            lazy2_done:
+                max_lazy2 = l2 > max_lazy2 ? l2 : max_lazy2;
             }
+
             const uint16_t delta = chain_table[next_idx];
             if (UNLIKELY(delta == 0)) break;
             next_idx -= delta;
             is_lazy_first = 0;
         }
 
-        if (max_lazy > best.len + 1) {
-            best.ref = NULL;
-        } else if (level >= 4 && ip + 2 < mflimit) {
+        // --- Lazy evaluation at ip+2 (computed in parallel, no dependency on lazy 1) ---
+        uint32_t max_lazy3 = 0;
+        if (level >= 4 && ip + 2 < mflimit) {
             const uint64_t val3_8 = zxc_le64(ip + 2);
             const uint32_t val3 = (uint32_t)val3_8;
             const uint32_t h3 = zxc_hash_func(val3_8, use_hash5);
-            const uint32_t head3 = hash_table[2 * h3];
-            const uint32_t tag3 = hash_table[2 * h3 + 1];
+            const uint8_t tag3 = hash_tags[h3];
+            const uint32_t head3 = hash_table[h3];
             uint32_t idx3 = (head3 & ~offset_mask) == epoch_mark ? (head3 & offset_mask) : 0;
-            const int skip_head3 = (idx3 > 0 && tag3 != val3);
+            const uint8_t cur_tag3 = (uint8_t)(val3 ^ (val3 >> 16));
+            const int skip_head3 = (idx3 > 0 && tag3 != cur_tag3);
+
             int is_first3 = 1;
-            uint32_t max_lazy3 = 0;
             lazy_att = p.lazy_attempts;
             while (idx3 > 0 && lazy_att-- > 0) {
                 if (UNLIKELY((uint32_t)(ip + 2 - src) - idx3 > ZXC_LZ_MAX_DIST)) break;
+
                 const uint8_t* ref3 = src + idx3;
                 if ((!is_first3 || !skip_head3) && zxc_le32(ref3) == val3) {
                     uint32_t l3 = sizeof(uint32_t);
-                    const uint8_t* limit8_3 = iend - sizeof(uint64_t);
-                    while (ip + 2 + l3 < limit8_3) {
+                    const uint8_t* limit = iend - sizeof(uint64_t);
+
+                    while (ip + 2 + l3 < limit) {
                         const uint64_t v1 = zxc_le64(ip + 2 + l3);
                         const uint64_t v2 = zxc_le64(ref3 + l3);
                         if (v1 != v2) {
                             l3 += (uint32_t)(zxc_ctz64(v1 ^ v2) >> 3);
-                            goto lazy2_done;
+                            goto lazy3_done;
                         }
                         l3 += sizeof(uint64_t);
                     }
                     while (ip + 2 + l3 < iend && ref3[l3] == ip[2 + l3]) l3++;
-                lazy2_done:
-                    if (l3 > max_lazy3) max_lazy3 = l3;
+                lazy3_done:
+                    max_lazy3 = l3 > max_lazy3 ? l3 : max_lazy3;
                 }
+
                 const uint16_t delta = chain_table[idx3];
                 if (UNLIKELY(delta == 0)) break;
                 idx3 -= delta;
                 is_first3 = 0;
             }
-            if (max_lazy3 > best.len + 2) best.ref = NULL;
         }
+
+        // Single decision: invalidate if either lazy position found a better match
+        if (max_lazy2 > best.len + 1 || max_lazy3 > best.len + 2) best.ref = NULL;
     }
 
     return best;
@@ -627,7 +613,7 @@ static int zxc_encode_block_num(const zxc_cctx_t* RESTRICT ctx, const uint8_t* R
         in_ptr += frames * sizeof(uint32_t);
 
         const uint8_t bits = zxc_highbit32(max_d);
-        const size_t packed = ((frames * bits) + ZXC_BITS_PER_BYTE - 1) / ZXC_BITS_PER_BYTE;
+        const size_t packed = ((frames * bits) + CHAR_BIT - 1) / CHAR_BIT;
         if (UNLIKELY(rem < ZXC_NUM_CHUNK_HEADER_SIZE + packed + sizeof(uint32_t)))
             return ZXC_ERROR_DST_TOO_SMALL;
 
@@ -710,13 +696,17 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
 
     ctx->epoch++;
     if (UNLIKELY(ctx->epoch >= ctx->max_epoch)) {
-        ZXC_MEMSET(ctx->hash_table, 0, 2 * ZXC_LZ_HASH_SIZE * sizeof(uint32_t));
+        ZXC_MEMSET(ctx->hash_table, 0, ZXC_LZ_HASH_SIZE * sizeof(uint32_t));
+        ZXC_MEMSET(ctx->hash_tags, 0, ZXC_LZ_HASH_SIZE * sizeof(uint8_t));
         ctx->epoch = 1;
     }
-    const uint32_t epoch_mark = ctx->epoch << ctx->offset_bits;
+    const uint32_t offset_bits = ctx->offset_bits;
+    const uint32_t offset_mask = ctx->offset_mask;
+    const uint32_t epoch_mark = ctx->epoch << offset_bits;
     const uint8_t *ip = src, *iend = src + src_sz, *anchor = ip, *mflimit = iend - 12;
 
     uint32_t* const hash_table = ctx->hash_table;
+    uint8_t* const hash_tags = ctx->hash_tags;
     uint16_t* const chain_table = ctx->chain_table;
     uint8_t* const literals = ctx->literals;
     uint8_t* const buf_tokens = ctx->buf_tokens;
@@ -733,11 +723,9 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         size_t step = lzp.step_base + (dist >> lzp.step_shift);
         if (UNLIKELY(ip + step >= mflimit)) step = 1;
 
-        ZXC_PREFETCH_READ(ip + step * 4 + ZXC_CACHE_LINE_SIZE);
-
         const zxc_match_t m =
-            zxc_lz77_find_best_match(src, ip, iend, mflimit, anchor, hash_table, chain_table,
-                                     epoch_mark, ctx->offset_mask, level, lzp);
+            zxc_lz77_find_best_match(src, ip, iend, mflimit, anchor, hash_table, hash_tags,
+                                     chain_table, epoch_mark, offset_mask, level, lzp);
 
         if (m.ref) {
             ip -= m.backtrack;
@@ -746,12 +734,15 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
             const uint32_t off = (uint32_t)(ip - m.ref);
 
             if (ll > 0) {
-                if (ll <= 16 && anchor + 16 <= iend)
-                    zxc_copy16(literals + lit_c, anchor);
-                else if (ll <= 32 && anchor + 32 <= iend)
+                if (LIKELY(anchor + ZXC_PAD_SIZE <= iend)) {
                     zxc_copy32(literals + lit_c, anchor);
-                else
+                    if (UNLIKELY(ll > ZXC_PAD_SIZE)) {
+                        ZXC_MEMCPY(literals + lit_c + ZXC_PAD_SIZE, anchor + ZXC_PAD_SIZE,
+                                   ll - ZXC_PAD_SIZE);
+                    }
+                } else {
                     ZXC_MEMCPY(literals + lit_c, anchor, ll);
+                }
                 lit_c += ll;
             }
 
@@ -762,12 +753,12 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
             if ((off - ZXC_LZ_OFFSET_BIAS) > max_offset)
                 max_offset = (uint16_t)(off - ZXC_LZ_OFFSET_BIAS);
 
-            if (ll >= ZXC_TOKEN_LL_MASK) {
+            if (ll >= ZXC_TOKEN_LL_MASK)
                 extras_sz += zxc_write_varint(buf_extras + extras_sz, ll - ZXC_TOKEN_LL_MASK);
-            }
-            if (ml >= ZXC_TOKEN_ML_MASK) {
+
+            if (ml >= ZXC_TOKEN_ML_MASK)
                 extras_sz += zxc_write_varint(buf_extras + extras_sz, ml - ZXC_TOKEN_ML_MASK);
-            }
+
             seq_c++;
 
             if (m.len > 2 && level > 4) {
@@ -778,12 +769,11 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
                     const uint32_t val_u = (uint32_t)val_u8;
                     const uint32_t h_u =
                         zxc_hash_func(val_u8, 1);  // Only for level > 4, uses hash5
-                    const uint32_t prev_head = hash_table[2 * h_u];
-                    const uint32_t prev_idx = (prev_head & ~ctx->offset_mask) == epoch_mark
-                                                  ? (prev_head & ctx->offset_mask)
-                                                  : 0;
-                    hash_table[2 * h_u] = epoch_mark | pos_u;
-                    hash_table[2 * h_u + 1] = val_u;
+                    const uint32_t prev_head = hash_table[h_u];
+                    const uint32_t prev_idx =
+                        (prev_head & ~offset_mask) == epoch_mark ? (prev_head & offset_mask) : 0;
+                    hash_table[h_u] = epoch_mark | pos_u;
+                    hash_tags[h_u] = (uint8_t)(val_u ^ (val_u >> 16));
                     chain_table[pos_u] = (prev_idx > 0 && (pos_u - prev_idx) < ZXC_LZ_WINDOW_SIZE)
                                              ? (uint16_t)(pos_u - prev_idx)
                                              : 0;
@@ -805,7 +795,7 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
 
     // --- RLE ANALYSIS ---
     size_t rle_size = 0;
-    int use_rle = 0;
+    int enc_lit = ZXC_SECTION_ENCODING_RAW;
 
     if (lit_c > 0) {
         const uint8_t* p = literals;
@@ -844,18 +834,19 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
             while (p <= p_end - 16) {
                 const uint8x16_t v = vld1q_u8(p);
                 const uint8x16_t eq = vceqq_u8(v, vb);
-                const uint8x16_t not_eq = vmvnq_u8(eq);
-                const uint64_t lo = vgetq_lane_u64(vreinterpretq_u64_u8(not_eq), 0);
-                if (lo != 0) {
-                    p += (zxc_ctz64(lo) >> 3);
+                if (vminvq_u8(eq) == 0xFF) {
+                    p += 16;
+                } else {
+                    const uint8x16_t not_eq = vmvnq_u8(eq);
+                    const uint64_t lo = vgetq_lane_u64(vreinterpretq_u64_u8(not_eq), 0);
+                    if (lo != 0) {
+                        p += (zxc_ctz64(lo) >> 3);
+                    } else {
+                        const uint64_t hi = vgetq_lane_u64(vreinterpretq_u64_u8(not_eq), 1);
+                        p += 8 + (zxc_ctz64(hi) >> 3);
+                    }
                     goto _run_done;
                 }
-                uint64_t hi = vgetq_lane_u64(vreinterpretq_u64_u8(not_eq), 1);
-                if (hi != 0) {
-                    p += 8 + (zxc_ctz64(hi) >> 3);
-                    goto _run_done;
-                }
-                p += 16;
             }
 #elif defined(ZXC_USE_NEON32)
             uint8x16_t vb = vdupq_n_u8(b);
@@ -949,17 +940,18 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
                     uint8x16_t v3 = vld1q_u8(p + 3);
                     uint8x16_t eq =
                         vandq_u8(vceqq_u8(v0, v1), vandq_u8(vceqq_u8(v1, v2), vceqq_u8(v2, v3)));
-                    uint64_t lo = vgetq_lane_u64(vreinterpretq_u64_u8(eq), 0);
-                    if (lo != 0) {
-                        p += (zxc_ctz64(lo) >> 3);
+                    if (vmaxvq_u8(eq) == 0) {
+                        p += 16;
+                    } else {
+                        uint64_t lo = vgetq_lane_u64(vreinterpretq_u64_u8(eq), 0);
+                        if (lo != 0) {
+                            p += (zxc_ctz64(lo) >> 3);
+                        } else {
+                            uint64_t hi = vgetq_lane_u64(vreinterpretq_u64_u8(eq), 1);
+                            p += 8 + (zxc_ctz64(hi) >> 3);
+                        }
                         goto _lit_done;
                     }
-                    uint64_t hi = vgetq_lane_u64(vreinterpretq_u64_u8(eq), 1);
-                    if (hi != 0) {
-                        p += 8 + (zxc_ctz64(hi) >> 3);
-                        goto _lit_done;
-                    }
-                    p += 16;
                 }
 #elif defined(ZXC_USE_NEON32)
                 while (p <= p_end_4 - 16) {
@@ -1015,7 +1007,7 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         }
 
         // Threshold: ~3% savings using integer math (97% ~= 1 - 1/32)
-        if (rle_size < lit_c - (lit_c >> 5)) use_rle = 1;
+        if (rle_size < lit_c - (lit_c >> 5)) enc_lit = ZXC_SECTION_ENCODING_RLE;
     }
 
     zxc_block_header_t bh = {.block_type = ZXC_BLOCK_GLO};
@@ -1028,13 +1020,14 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
 
     const zxc_gnr_header_t gh = {.n_sequences = seq_c,
                                  .n_literals = (uint32_t)lit_c,
-                                 .enc_lit = (uint8_t)use_rle,
+                                 .enc_lit = enc_lit,
                                  .enc_litlen = 0,
                                  .enc_mlen = 0,
                                  .enc_off = (uint8_t)use_8bit_off};
 
     zxc_section_desc_t desc[ZXC_GLO_SECTIONS] = {0};
-    desc[0].sizes = (uint64_t)(use_rle ? rle_size : lit_c) | ((uint64_t)lit_c << 32);
+    desc[0].sizes = (uint64_t)(enc_lit == ZXC_SECTION_ENCODING_RLE ? rle_size : lit_c) |
+                    ((uint64_t)lit_c << 32);
     desc[1].sizes = (uint64_t)seq_c | ((uint64_t)seq_c << 32);
     desc[2].sizes = (uint64_t)off_stream_size | ((uint64_t)off_stream_size << 32);
     desc[3].sizes = (uint64_t)extras_sz | ((uint64_t)extras_sz << 32);
@@ -1053,7 +1046,7 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
 
     if (UNLIKELY(rem < sz_lit)) return ZXC_ERROR_DST_TOO_SMALL;
 
-    if (use_rle) {
+    if (enc_lit == ZXC_SECTION_ENCODING_RLE) {
         // Write RLE - optimized single-pass encoding
         const uint8_t* lit_ptr = literals;
         const uint8_t* const lit_end = literals + lit_c;
@@ -1204,13 +1197,17 @@ static int zxc_encode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
 
     ctx->epoch++;
     if (UNLIKELY(ctx->epoch >= ctx->max_epoch)) {
-        ZXC_MEMSET(ctx->hash_table, 0, 2 * ZXC_LZ_HASH_SIZE * sizeof(uint32_t));
+        ZXC_MEMSET(ctx->hash_table, 0, ZXC_LZ_HASH_SIZE * sizeof(uint32_t));
+        ZXC_MEMSET(ctx->hash_tags, 0, ZXC_LZ_HASH_SIZE * sizeof(uint8_t));
         ctx->epoch = 1;
     }
-    const uint32_t epoch_mark = ctx->epoch << ctx->offset_bits;
+    const uint32_t offset_bits = ctx->offset_bits;
+    const uint32_t offset_mask = ctx->offset_mask;
+    const uint32_t epoch_mark = ctx->epoch << offset_bits;
     const uint8_t *ip = src, *iend = src + src_sz, *anchor = ip, *mflimit = iend - 12;
 
     uint32_t* const hash_table = ctx->hash_table;
+    uint8_t* const hash_tags = ctx->hash_tags;
     uint8_t* const buf_extras = ctx->buf_extras;
     uint16_t* const chain_table = ctx->chain_table;
     uint8_t* const literals = ctx->literals;
@@ -1226,11 +1223,11 @@ static int zxc_encode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         size_t step = lzp.step_base + (dist >> lzp.step_shift);
         if (UNLIKELY(ip + step >= mflimit)) step = 1;
 
-        ZXC_PREFETCH_READ(ip + step * 4 + 64);
+        ZXC_PREFETCH_READ(ip + step * 4 + ZXC_CACHE_LINE_SIZE);
 
         const zxc_match_t m =
-            zxc_lz77_find_best_match(src, ip, iend, mflimit, anchor, hash_table, chain_table,
-                                     epoch_mark, ctx->offset_mask, level, lzp);
+            zxc_lz77_find_best_match(src, ip, iend, mflimit, anchor, hash_table, hash_tags,
+                                     chain_table, epoch_mark, offset_mask, level, lzp);
 
         if (m.ref) {
             ip -= m.backtrack;
@@ -1239,12 +1236,15 @@ static int zxc_encode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
             const uint32_t off = (uint32_t)(ip - m.ref);
 
             if (ll > 0) {
-                if (ll <= 16 && anchor + 16 <= iend)
-                    zxc_copy16(literals + lit_c, anchor);
-                else if (ll <= 32 && anchor + 32 <= iend)
+                if (LIKELY(anchor + ZXC_PAD_SIZE <= iend)) {
                     zxc_copy32(literals + lit_c, anchor);
-                else
+                    if (UNLIKELY(ll > ZXC_PAD_SIZE)) {
+                        ZXC_MEMCPY(literals + lit_c + ZXC_PAD_SIZE, anchor + ZXC_PAD_SIZE,
+                                   ll - ZXC_PAD_SIZE);
+                    }
+                } else {
                     ZXC_MEMCPY(literals + lit_c, anchor, ll);
+                }
                 lit_c += ll;
             }
 
@@ -1258,12 +1258,10 @@ static int zxc_encode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
             buf_sequences[seq_c] = seq_val;
             seq_c++;
 
-            if (ll >= ZXC_SEQ_LL_MASK) {
+            if (ll >= ZXC_SEQ_LL_MASK)
                 extras_c += zxc_write_varint(buf_extras + extras_c, ll - ZXC_SEQ_LL_MASK);
-            }
-            if (ml >= ZXC_SEQ_ML_MASK) {
+            if (ml >= ZXC_SEQ_ML_MASK)
                 extras_c += zxc_write_varint(buf_extras + extras_c, ml - ZXC_SEQ_ML_MASK);
-            }
 
             ip += m.len;
             anchor = ip;
@@ -1285,7 +1283,7 @@ static int zxc_encode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
     // Decide offset encoding mode
     const zxc_gnr_header_t gh = {.n_sequences = seq_c,
                                  .n_literals = (uint32_t)lit_c,
-                                 .enc_lit = 0,
+                                 .enc_lit = ZXC_SECTION_ENCODING_RAW,
                                  .enc_litlen = 0,
                                  .enc_mlen = 0,
                                  .enc_off = (uint8_t)(max_offset <= 255) ? 1 : 0};
@@ -1398,45 +1396,51 @@ static int zxc_encode_block_raw(const uint8_t* RESTRICT src, const size_t src_sz
 static int zxc_probe_is_numeric(const uint8_t* src, const size_t size) {
     if (UNLIKELY(size % sizeof(uint32_t) != 0 || size < (4 * sizeof(uint32_t)))) return 0;
 
-    size_t count = size / sizeof(uint32_t);
-    count = count < 128 ? count : 128;  // Sample more values for accuracy
+    const size_t total_vals = size / sizeof(uint32_t);
+    const size_t sample_len = 16;
 
-    uint32_t prev = zxc_le32(src);
-    const uint8_t* p = src + sizeof(uint32_t);
+    // Sample 2 contiguous regions: start and middle of the block.
+    // Each region computes its own deltas independently.
+    const size_t offsets[2] = {0, (total_vals / 2) & ~(size_t)3};  // Align to uint32_t boundary
+    const size_t n_regions = (total_vals > sample_len * 2) ? 2 : 1;
 
     uint32_t max_zigzag = 0;
     uint32_t small_count = 0;   // Deltas < 256 (8 bits)
     uint32_t medium_count = 0;  // Deltas < 65536 (16 bits)
+    size_t total_sampled = 0;
 
-    for (size_t i = 1; i < count; i++) {
-        const uint32_t curr = zxc_le32(p);
-        const int32_t diff = (int32_t)(curr - prev);
-        const uint32_t zigzag = zxc_zigzag_encode(diff);
-
-        max_zigzag = zigzag > max_zigzag ? zigzag : max_zigzag;
-        small_count += (uint32_t)(zigzag < 256);
-        medium_count += (uint32_t)(zigzag >= 256) & (uint32_t)(zigzag < 65536);
-
-        prev = curr;
+    for (size_t r = 0; r < n_regions; r++) {
+        const uint8_t* p = src + offsets[r] * sizeof(uint32_t);
+        const size_t region_count =
+            ((total_vals - offsets[r]) < sample_len) ? (total_vals - offsets[r]) : sample_len;
+        uint32_t prev = zxc_le32(p);
         p += sizeof(uint32_t);
+
+        for (size_t i = 1; i < region_count; i++) {
+            const uint32_t curr = zxc_le32(p);
+            const int32_t diff = (int32_t)(curr - prev);
+            const uint32_t zigzag = zxc_zigzag_encode(diff);
+
+            max_zigzag = zigzag > max_zigzag ? zigzag : max_zigzag;
+            small_count += (uint32_t)(zigzag < 256);
+            medium_count += (uint32_t)(zigzag >= 256) & (uint32_t)(zigzag < 65536);
+
+            prev = curr;
+            p += sizeof(uint32_t);
+        }
+        total_sampled += region_count - 1;
     }
 
-    // Calculate bit width needed for max delta
-    uint32_t bits_needed = 0;
-    uint32_t tmp = max_zigzag;
-    while (tmp > 0) {
-        bits_needed++;
-        tmp >>= 1;
-    }
+    const uint32_t bits_needed = zxc_highbit32(max_zigzag);
 
     // Estimate compression ratio:
     // NUM uses ~bits_needed per value, Raw uses 32 bits per value
     // Worth it if bits_needed <= 20 (saves >37.5%)
     if (bits_needed <= 16) return 1;
-    if (bits_needed <= 20 && (small_count + medium_count) >= (count * 85) / 100) return 1;
+    if (bits_needed <= 20 && (small_count + medium_count) >= (total_sampled * 85) / 100) return 1;
 
     // Fallback: if 90% of deltas are small, still use NUM
-    if ((small_count + medium_count) >= (count * 90) / 100) return 1;
+    if ((small_count + medium_count) >= (total_sampled * 90) / 100) return 1;
 
     return 0;
 }
@@ -1446,7 +1450,7 @@ int zxc_compress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT
                                const size_t src_sz, uint8_t* RESTRICT dst, const size_t dst_cap) {
     size_t w = 0;
     int res = ZXC_OK;
-    int try_num = UNLIKELY(zxc_probe_is_numeric(chunk, src_sz));
+    int try_num = zxc_probe_is_numeric(chunk, src_sz);
 
     if (UNLIKELY(try_num)) {
         res = zxc_encode_block_num(ctx, chunk, src_sz, dst, dst_cap, &w);

--- a/lz/zxc/src/lib/zxc_decompress.c
+++ b/lz/zxc/src/lib/zxc_decompress.c
@@ -45,8 +45,9 @@
  * depending on implementation).
  * @return The value of the consumed bits as a 32-bit unsigned integer.
  */
-static ZXC_ALWAYS_INLINE uint32_t zxc_br_consume_fast(zxc_bit_reader_t* br, uint8_t n) {
-#if defined(__BMI2__) && (defined(__x86_64__) || defined(_M_X64))
+static ZXC_ALWAYS_INLINE uint32_t zxc_br_consume_fast(zxc_bit_reader_t* RESTRICT br,
+                                                      const uint8_t n) {
+#if !defined(ZXC_DISABLE_SIMD) && defined(__BMI2__) && (defined(__x86_64__) || defined(_M_X64))
     // BMI2 Optimization: _bzhi_u64(x, n) copies the lower n bits of x to dst and
     // clears the rest. It is equivalent to x & ((1ULL << n) - 1) but executes in
     // a single cycle without dependency chains.
@@ -67,11 +68,11 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_br_consume_fast(zxc_bit_reader_t* br, uint
  * the total length (1-5 bytes).
  *
  * Format:
- * - 1 byte (0xxxxxxx): 7 bits (val < 128)
- * - 2 bytes (10xxxxxx ...): 14 bits (val < 16384)
- * - 3 bytes (110xxxxx ...): 21 bits (val < 2M)
- * - 4 bytes (1110xxxx ...): 28 bits (val < 256M)
- * - 5 bytes (11110xxx ...): 32 bits (Full Range)
+ * - 1 byte  (0xxxxxxx):  7-bit payload (val < 2^7  = 128)
+ * - 2 bytes (10xxxxxx): 14-bit payload (val < 2^14 = 16384)
+ * - 3 bytes (110xxxxx): 21-bit payload (val < 2^21 = 2097152)
+ * - 4 bytes (1110xxxx): 28-bit payload (val < 2^28 = 268435456)
+ * - 5 bytes (11110xxx): 32-bit payload (full uint32_t range)
  *
  * @param[in,out] ptr Pointer to a pointer to the current position in the stream.
  * @param[in] end Pointer to the end of the readable stream (for bounds checking).
@@ -84,13 +85,13 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_read_varint(const uint8_t** ptr, const uin
 
     const uint32_t b0 = p[0];
 
-    // 1 Byte: 0xxxxxxx (7 bits) -> val < 128
-    if (LIKELY(b0 < 128)) {
+    // 1 Byte: 0xxxxxxx (7 bits) -> val < 128 (2^7)
+    if (LIKELY(b0 < 0x80)) {
         *ptr = p + 1;
         return b0;
     }
 
-    // 2 Bytes: 10xxxxxx xxxxxxxx (14 bits)
+    // 2 Bytes: 10xxxxxx xxxxxxxx (14 bits) -> val < 16384 (2^14)
     if (LIKELY(b0 < 0xC0)) {
         if (UNLIKELY(p + 1 >= end)) {
             *ptr = end;
@@ -100,7 +101,7 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_read_varint(const uint8_t** ptr, const uin
         return (b0 & 0x3F) | ((uint32_t)p[1] << 6);
     }
 
-    // 3 Bytes: 110xxxxx xxxxxxxx xxxxxxxx (21 bits)
+    // 3 Bytes: 110xxxxx xxxxxxxx xxxxxxxx (21 bits) -> val < 2097152 (2^21)
     if (LIKELY(b0 < 0xE0)) {
         if (UNLIKELY(p + 2 >= end)) {
             *ptr = end;
@@ -110,7 +111,7 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_read_varint(const uint8_t** ptr, const uin
         return (b0 & 0x1F) | ((uint32_t)p[1] << 5) | ((uint32_t)p[2] << 13);
     }
 
-    // 4 Bytes: 1110xxxx ... (28 bits)
+    // 4 Bytes: 1110xxxx ... (28 bits) -> val < 268435456 (2^28)
     if (UNLIKELY(b0 < 0xF0)) {
         if (UNLIKELY(p + 3 >= end)) {
             *ptr = end;
@@ -121,7 +122,7 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_read_varint(const uint8_t** ptr, const uin
                ((uint32_t)p[3] << 20);
     }
 
-    // 5 Bytes: 11110xxx ... (32 bits)
+    // 5 Bytes: 11110xxx ... (32 bits) -> val < 4294967296 (2^32)
     if (UNLIKELY(p + 4 >= end)) {
         *ptr = end;
         return 0;
@@ -368,7 +369,7 @@ static int zxc_decode_block_num(const uint8_t* RESTRICT src, const size_t src_si
 
         if (UNLIKELY(nvals > vals_remaining || src_size < offset + psize ||
                      (size_t)(d_end - d_ptr) < (size_t)nvals * sizeof(uint32_t) ||
-                     bits > (sizeof(uint32_t) * ZXC_BITS_PER_BYTE)))
+                     bits > (sizeof(uint32_t) * CHAR_BIT)))
             return ZXC_ERROR_CORRUPT_DATA;
 
         zxc_bit_reader_t br;
@@ -390,9 +391,9 @@ static int zxc_decode_block_num(const uint8_t* RESTRICT src, const size_t src_si
             uint32_t* batch_dst = (uint32_t*)d_ptr;
 
 #if defined(ZXC_USE_AVX512)
+            __m512i v_run = _mm512_set1_epi32(running_val);  // Broadcast initial running total
             for (int k = 0; k < ZXC_NUM_DEC_BATCH; k += 16) {
                 __m512i v_deltas = _mm512_load_si512((void*)&deltas[k]);  // Load 16 deltas
-                __m512i v_run = _mm512_set1_epi32(running_val);  // Broadcast current running total
 
                 __m512i v_sum = zxc_mm512_prefix_sum_epi32(v_deltas);  // Compute local prefix sums
                 v_sum = _mm512_add_epi32(v_sum, v_run);                // Add base running total
@@ -400,24 +401,34 @@ static int zxc_decode_block_num(const uint8_t* RESTRICT src, const size_t src_si
                 _mm512_storeu_si512((void*)&batch_dst[k],
                                     v_sum);  // Store decoded values
 
-                // Extract the last value (15th element) to update running_val for next
-                // batch
-                __m128i v_last128 = _mm512_extracti32x4_epi32(v_sum, 3);
-                running_val = (uint32_t)_mm_cvtsi128_si32(_mm_shuffle_epi32(v_last128, 0xFF));
+                // Broadcast 15th element of v_sum to v_run directly within ZMM registers
+                // 1. Align upper 128-bit lane down to all lanes
+                __m512i v_last128 = _mm512_shuffle_i32x4(v_sum, v_sum, 0xFF);
+                // 2. Broadcast the 3rd element of those lanes
+                v_run = _mm512_shuffle_epi32(v_last128, 0xFF);
             }
+            // Extract final running_val back to GPR for scalar fallback
+            running_val = (uint32_t)_mm_cvtsi128_si32(_mm512_castsi512_si128(v_run));
 
 #elif defined(ZXC_USE_AVX2)
+            __m256i v_run = _mm256_set1_epi32(running_val);  // Broadcast initial running total
             for (int k = 0; k < ZXC_NUM_DEC_BATCH; k += 8) {
                 __m256i v_deltas = _mm256_load_si256((const __m256i*)&deltas[k]);  // Load 8 deltas
-                __m256i v_run = _mm256_set1_epi32(running_val);  // Broadcast running total
 
                 __m256i v_sum = zxc_mm256_prefix_sum_epi32(v_deltas);  // Compute local prefix sums
                 v_sum = _mm256_add_epi32(v_sum, v_run);                // Add base
 
                 _mm256_storeu_si256((__m256i*)&batch_dst[k],
-                                    v_sum);                   // Store decoded values
-                running_val = ((uint32_t*)&batch_dst[k])[7];  // Update running_val
+                                    v_sum);  // Store decoded values
+
+                // Compute v_run directly from vector register without memory readback
+                // Duplicate upper 128-bits into both lanes
+                __m256i last_val = _mm256_permute2x128_si256(v_sum, v_sum, 0x11);
+                // Broadcast 4th element to all elements
+                v_run = _mm256_shuffle_epi32(last_val, 0xFF);
             }
+            // Extract final running_val back to GPR for scalar fallback
+            running_val = (uint32_t)_mm_cvtsi128_si32(_mm256_castsi256_si128(v_run));
 
 #elif defined(ZXC_USE_NEON64) || defined(ZXC_USE_NEON32)
             uint32x4_t v_run = vdupq_n_u32(running_val);  // Broadcast running total
@@ -429,9 +440,16 @@ static int zxc_decode_block_num(const uint8_t* RESTRICT src, const size_t src_si
 
                 vst1q_u32(&batch_dst[k], v_sum);  // Store decoded values
 
+#if defined(ZXC_USE_NEON64)
+                v_run = vdupq_laneq_u32(v_sum, 3);  // Update vector directly (no GPR transit)
+#else
                 running_val = vgetq_lane_u32(v_sum, 3);  // Extract last element
                 v_run = vdupq_n_u32(running_val);        // Update vector for next iter
+#endif
             }
+#if defined(ZXC_USE_NEON64)
+            running_val = vgetq_lane_u32(v_run, 0);  // Extract once at the end of the batch
+#endif
 
 #else
             for (int k = 0; k < ZXC_NUM_DEC_BATCH; k++) {
@@ -497,7 +515,7 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
 
     size_t lit_stream_size = (size_t)(desc[0].sizes & ZXC_SECTION_SIZE_MASK);
 
-    if (gh.enc_lit == 1) {
+    if (gh.enc_lit == ZXC_SECTION_ENCODING_RLE) {
         const size_t required_size = (size_t)(desc[0].sizes >> 32);
 
         if (required_size > 0) {
@@ -631,147 +649,93 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
     // After threshold, all offsets are guaranteed valid (can't exceed written bytes)
     size_t written = 0;
 
-// Macro for copy literal + match (uses 32-byte wild copies)
+// --- Factored sub-macros for literal copy + match copy ---
+// Used by DECODE_SEQ_SAFE and DECODE_SEQ_FAST to avoid duplication.
+
+// Copy literals from l_ptr to d_ptr using 32-byte wild copies
+#define DECODE_COPY_LITERALS(ll)              \
+    do {                                      \
+        const uint8_t* src_lit = l_ptr;       \
+        uint8_t* dst_lit = d_ptr;             \
+        zxc_copy32(dst_lit, src_lit);         \
+        if (UNLIKELY(ll > ZXC_PAD_SIZE)) {    \
+            dst_lit += ZXC_PAD_SIZE;          \
+            src_lit += ZXC_PAD_SIZE;          \
+            size_t rem = ll - ZXC_PAD_SIZE;   \
+            while (rem > ZXC_PAD_SIZE) {      \
+                zxc_copy32(dst_lit, src_lit); \
+                dst_lit += ZXC_PAD_SIZE;      \
+                src_lit += ZXC_PAD_SIZE;      \
+                rem -= ZXC_PAD_SIZE;          \
+            }                                 \
+            zxc_copy32(dst_lit, src_lit);     \
+        }                                     \
+        l_ptr += ll;                          \
+        d_ptr += ll;                          \
+    } while (0)
+
+// Copy match from d_ptr - off to d_ptr, handling overlap cases
+#define DECODE_COPY_MATCH(ml, off)                                   \
+    do {                                                             \
+        const uint8_t* match_src = d_ptr - off;                      \
+        if (LIKELY(off >= ZXC_PAD_SIZE)) {                           \
+            zxc_copy32(d_ptr, match_src);                            \
+            if (UNLIKELY(ml > ZXC_PAD_SIZE)) {                       \
+                uint8_t* out = d_ptr + ZXC_PAD_SIZE;                 \
+                const uint8_t* ref = match_src + ZXC_PAD_SIZE;       \
+                size_t rem = ml - ZXC_PAD_SIZE;                      \
+                while (rem > ZXC_PAD_SIZE) {                         \
+                    zxc_copy32(out, ref);                            \
+                    out += ZXC_PAD_SIZE;                             \
+                    ref += ZXC_PAD_SIZE;                             \
+                    rem -= ZXC_PAD_SIZE;                             \
+                }                                                    \
+                zxc_copy32(out, ref);                                \
+            }                                                        \
+            d_ptr += ml;                                             \
+        } else if (off >= (ZXC_PAD_SIZE / 2)) {                      \
+            zxc_copy16(d_ptr, match_src);                            \
+            if (UNLIKELY(ml > (ZXC_PAD_SIZE / 2))) {                 \
+                uint8_t* out = d_ptr + (ZXC_PAD_SIZE / 2);           \
+                const uint8_t* ref = match_src + (ZXC_PAD_SIZE / 2); \
+                size_t rem = ml - (ZXC_PAD_SIZE / 2);                \
+                while (rem > (ZXC_PAD_SIZE / 2)) {                   \
+                    zxc_copy16(out, ref);                            \
+                    out += (ZXC_PAD_SIZE / 2);                       \
+                    ref += (ZXC_PAD_SIZE / 2);                       \
+                    rem -= (ZXC_PAD_SIZE / 2);                       \
+                }                                                    \
+                zxc_copy16(out, ref);                                \
+            }                                                        \
+            d_ptr += ml;                                             \
+        } else if (off == 1) {                                       \
+            ZXC_MEMSET(d_ptr, match_src[0], ml);                     \
+            d_ptr += ml;                                             \
+        } else {                                                     \
+            size_t copied = 0;                                       \
+            while (copied < ml) {                                    \
+                zxc_copy_overlap16(d_ptr + copied, off);             \
+                copied += (ZXC_PAD_SIZE / 2);                        \
+            }                                                        \
+            d_ptr += ml;                                             \
+        }                                                            \
+    } while (0)
+
 // SAFE version: validates offset against written bytes
-#define DECODE_SEQ_SAFE(ll, ml, off)                                     \
-    do {                                                                 \
-        {                                                                \
-            const uint8_t* src_lit = l_ptr;                              \
-            uint8_t* dst_lit = d_ptr;                                    \
-            zxc_copy32(dst_lit, src_lit);                                \
-            if (UNLIKELY(ll > ZXC_PAD_SIZE)) {                           \
-                dst_lit += ZXC_PAD_SIZE;                                 \
-                src_lit += ZXC_PAD_SIZE;                                 \
-                size_t rem = ll - ZXC_PAD_SIZE;                          \
-                while (rem > ZXC_PAD_SIZE) {                             \
-                    zxc_copy32(dst_lit, src_lit);                        \
-                    dst_lit += ZXC_PAD_SIZE;                             \
-                    src_lit += ZXC_PAD_SIZE;                             \
-                    rem -= ZXC_PAD_SIZE;                                 \
-                }                                                        \
-                zxc_copy32(dst_lit, src_lit);                            \
-            }                                                            \
-            l_ptr += ll;                                                 \
-            d_ptr += ll;                                                 \
-            written += ll;                                               \
-        }                                                                \
-        {                                                                \
-            if (UNLIKELY(off > written)) return ZXC_ERROR_BAD_OFFSET;    \
-            const uint8_t* match_src = d_ptr - off;                      \
-            if (LIKELY(off >= ZXC_PAD_SIZE)) {                           \
-                zxc_copy32(d_ptr, match_src);                            \
-                if (UNLIKELY(ml > ZXC_PAD_SIZE)) {                       \
-                    uint8_t* out = d_ptr + ZXC_PAD_SIZE;                 \
-                    const uint8_t* ref = match_src + ZXC_PAD_SIZE;       \
-                    size_t rem = ml - ZXC_PAD_SIZE;                      \
-                    while (rem > ZXC_PAD_SIZE) {                         \
-                        zxc_copy32(out, ref);                            \
-                        out += ZXC_PAD_SIZE;                             \
-                        ref += ZXC_PAD_SIZE;                             \
-                        rem -= ZXC_PAD_SIZE;                             \
-                    }                                                    \
-                    zxc_copy32(out, ref);                                \
-                }                                                        \
-                d_ptr += ml;                                             \
-                written += ml;                                           \
-            } else if (off >= (ZXC_PAD_SIZE / 2)) {                      \
-                zxc_copy16(d_ptr, match_src);                            \
-                if (UNLIKELY(ml > (ZXC_PAD_SIZE / 2))) {                 \
-                    uint8_t* out = d_ptr + (ZXC_PAD_SIZE / 2);           \
-                    const uint8_t* ref = match_src + (ZXC_PAD_SIZE / 2); \
-                    size_t rem = ml - (ZXC_PAD_SIZE / 2);                \
-                    while (rem > (ZXC_PAD_SIZE / 2)) {                   \
-                        zxc_copy16(out, ref);                            \
-                        out += (ZXC_PAD_SIZE / 2);                       \
-                        ref += (ZXC_PAD_SIZE / 2);                       \
-                        rem -= (ZXC_PAD_SIZE / 2);                       \
-                    }                                                    \
-                    zxc_copy16(out, ref);                                \
-                }                                                        \
-                d_ptr += ml;                                             \
-                written += ml;                                           \
-            } else if (off == 1) {                                       \
-                ZXC_MEMSET(d_ptr, match_src[0], ml);                     \
-                d_ptr += ml;                                             \
-                written += ml;                                           \
-            } else {                                                     \
-                size_t copied = 0;                                       \
-                while (copied < ml) {                                    \
-                    zxc_copy_overlap16(d_ptr + copied, off);             \
-                    copied += (ZXC_PAD_SIZE / 2);                        \
-                }                                                        \
-                d_ptr += ml;                                             \
-                written += ml;                                           \
-            }                                                            \
-        }                                                                \
+#define DECODE_SEQ_SAFE(ll, ml, off)                              \
+    do {                                                          \
+        DECODE_COPY_LITERALS(ll);                                 \
+        written += ll;                                            \
+        if (UNLIKELY(off > written)) return ZXC_ERROR_BAD_OFFSET; \
+        DECODE_COPY_MATCH(ml, off);                               \
+        written += ml;                                            \
     } while (0)
 
 // FAST version: no offset validation (for use after written >= 256 or 65536)
-#define DECODE_SEQ_FAST(ll, ml, off)                                     \
-    do {                                                                 \
-        {                                                                \
-            const uint8_t* src_lit = l_ptr;                              \
-            uint8_t* dst_lit = d_ptr;                                    \
-            zxc_copy32(dst_lit, src_lit);                                \
-            if (UNLIKELY(ll > ZXC_PAD_SIZE)) {                           \
-                dst_lit += ZXC_PAD_SIZE;                                 \
-                src_lit += ZXC_PAD_SIZE;                                 \
-                size_t rem = ll - ZXC_PAD_SIZE;                          \
-                while (rem > ZXC_PAD_SIZE) {                             \
-                    zxc_copy32(dst_lit, src_lit);                        \
-                    dst_lit += ZXC_PAD_SIZE;                             \
-                    src_lit += ZXC_PAD_SIZE;                             \
-                    rem -= ZXC_PAD_SIZE;                                 \
-                }                                                        \
-                zxc_copy32(dst_lit, src_lit);                            \
-            }                                                            \
-            l_ptr += ll;                                                 \
-            d_ptr += ll;                                                 \
-        }                                                                \
-        {                                                                \
-            const uint8_t* match_src = d_ptr - off;                      \
-            if (LIKELY(off >= ZXC_PAD_SIZE)) {                           \
-                zxc_copy32(d_ptr, match_src);                            \
-                if (UNLIKELY(ml > ZXC_PAD_SIZE)) {                       \
-                    uint8_t* out = d_ptr + ZXC_PAD_SIZE;                 \
-                    const uint8_t* ref = match_src + ZXC_PAD_SIZE;       \
-                    size_t rem = ml - ZXC_PAD_SIZE;                      \
-                    while (rem > ZXC_PAD_SIZE) {                         \
-                        zxc_copy32(out, ref);                            \
-                        out += ZXC_PAD_SIZE;                             \
-                        ref += ZXC_PAD_SIZE;                             \
-                        rem -= ZXC_PAD_SIZE;                             \
-                    }                                                    \
-                    zxc_copy32(out, ref);                                \
-                }                                                        \
-                d_ptr += ml;                                             \
-            } else if (off >= (ZXC_PAD_SIZE / 2)) {                      \
-                zxc_copy16(d_ptr, match_src);                            \
-                if (UNLIKELY(ml > (ZXC_PAD_SIZE / 2))) {                 \
-                    uint8_t* out = d_ptr + (ZXC_PAD_SIZE / 2);           \
-                    const uint8_t* ref = match_src + (ZXC_PAD_SIZE / 2); \
-                    size_t rem = ml - (ZXC_PAD_SIZE / 2);                \
-                    while (rem > (ZXC_PAD_SIZE / 2)) {                   \
-                        zxc_copy16(out, ref);                            \
-                        out += (ZXC_PAD_SIZE / 2);                       \
-                        ref += (ZXC_PAD_SIZE / 2);                       \
-                        rem -= (ZXC_PAD_SIZE / 2);                       \
-                    }                                                    \
-                    zxc_copy16(out, ref);                                \
-                }                                                        \
-                d_ptr += ml;                                             \
-            } else if (off == 1) {                                       \
-                ZXC_MEMSET(d_ptr, match_src[0], ml);                     \
-                d_ptr += ml;                                             \
-            } else {                                                     \
-                size_t copied = 0;                                       \
-                while (copied < ml) {                                    \
-                    zxc_copy_overlap16(d_ptr + copied, off);             \
-                    copied += (ZXC_PAD_SIZE / 2);                        \
-                }                                                        \
-                d_ptr += ml;                                             \
-            }                                                            \
-        }                                                                \
+#define DECODE_SEQ_FAST(ll, ml, off) \
+    do {                             \
+        DECODE_COPY_LITERALS(ll);    \
+        DECODE_COPY_MATCH(ml, off);  \
     } while (0)
 
     // --- SAFE Loop: offset validation until threshold (4x unroll) ---
@@ -808,60 +772,60 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         uint32_t ml1 = (tokens & 0x00F);
         if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
             ll1 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 > d_end)) return ZXC_ERROR_OVERFLOW;
+            if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
         if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
             ml1 += zxc_read_varint(&e_ptr, e_end);
-            ml1 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll1 + ml1 > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml1 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml1 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_SAFE(ll1, ml1, off1);
 
         uint32_t ll2 = (tokens & 0x0F000) >> 12;
         uint32_t ml2 = (tokens & 0x00F00) >> 8;
         if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
             ll2 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 > d_end)) return ZXC_ERROR_OVERFLOW;
+            if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
         if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
             ml2 += zxc_read_varint(&e_ptr, e_end);
-            ml2 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll2 + ml2 > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml2 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml2 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_SAFE(ll2, ml2, off2);
 
         uint32_t ll3 = (tokens & 0x0F00000) >> 20;
         uint32_t ml3 = (tokens & 0x00F0000) >> 16;
         if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
             ll3 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 > d_end)) return ZXC_ERROR_OVERFLOW;
+            if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
         if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
             ml3 += zxc_read_varint(&e_ptr, e_end);
-            ml3 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll3 + ml3 > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml3 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml3 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_SAFE(ll3, ml3, off3);
 
         uint32_t ll4 = (tokens >> 28);
         uint32_t ml4 = (tokens >> 24) & 0x0F;
         if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
             ll4 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 > d_end)) return ZXC_ERROR_OVERFLOW;
+            if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
         if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
             ml4 += zxc_read_varint(&e_ptr, e_end);
-            ml4 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll4 + ml4 > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml4 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml4 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_SAFE(ll4, ml4, off4);
 
         n_seq -= 4;
@@ -896,60 +860,60 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         uint32_t ml1 = (tokens & 0x00F);
         if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
             ll1 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 > d_end)) return ZXC_ERROR_OVERFLOW;
+            if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
         if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
             ml1 += zxc_read_varint(&e_ptr, e_end);
-            ml1 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll1 + ml1 > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml1 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml1 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_FAST(ll1, ml1, off1);
 
         uint32_t ll2 = (tokens & 0x0F000) >> 12;
         uint32_t ml2 = (tokens & 0x00F00) >> 8;
         if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
             ll2 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 > d_end)) return ZXC_ERROR_OVERFLOW;
+            if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
         if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
             ml2 += zxc_read_varint(&e_ptr, e_end);
-            ml2 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll2 + ml2 > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml2 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml2 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_FAST(ll2, ml2, off2);
 
         uint32_t ll3 = (tokens & 0x0F00000) >> 20;
         uint32_t ml3 = (tokens & 0x00F0000) >> 16;
         if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
             ll3 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 > d_end)) return ZXC_ERROR_OVERFLOW;
+            if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
         if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
             ml3 += zxc_read_varint(&e_ptr, e_end);
-            ml3 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll3 + ml3 > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml3 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml3 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_FAST(ll3, ml3, off3);
 
         uint32_t ll4 = (tokens >> 28);
         uint32_t ml4 = (tokens >> 24) & 0x0F;
         if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
             ll4 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 > d_end)) return ZXC_ERROR_OVERFLOW;
+            if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
         if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
             ml4 += zxc_read_varint(&e_ptr, e_end);
-            ml4 += ZXC_LZ_MIN_MATCH_LEN;
-            if (UNLIKELY(d_ptr + ll4 + ml4 > d_end)) return ZXC_ERROR_OVERFLOW;
-        } else {
-            ml4 += ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
+        ml4 += ZXC_LZ_MIN_MATCH_LEN;
         DECODE_SEQ_FAST(ll4, ml4, off4);
 
         n_seq -= 4;
@@ -957,6 +921,8 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
 
 #undef DECODE_SEQ_SAFE
 #undef DECODE_SEQ_FAST
+#undef DECODE_COPY_LITERALS
+#undef DECODE_COPY_MATCH
 
     // Validate vbyte reads didn't overflow
     if (UNLIKELY(e_ptr > e_end)) return ZXC_ERROR_CORRUPT_DATA;
@@ -1172,155 +1138,169 @@ static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
     // After threshold, all offsets are guaranteed valid (can't exceed written bytes)
     size_t written = 0;
 
-// Macro for copy literal + match (uses 32-byte wild copies)
-// SAFE version: validates offset against written bytes
-#define DECODE_SEQ_SAFE(ll, ml, off)                                     \
-    do {                                                                 \
-        {                                                                \
-            const uint8_t* src_lit = l_ptr;                              \
-            uint8_t* dst_lit = d_ptr;                                    \
-            zxc_copy32(dst_lit, src_lit);                                \
-            if (UNLIKELY(ll > ZXC_PAD_SIZE)) {                           \
-                dst_lit += ZXC_PAD_SIZE;                                 \
-                src_lit += ZXC_PAD_SIZE;                                 \
-                size_t rem = ll - ZXC_PAD_SIZE;                          \
-                while (rem > ZXC_PAD_SIZE) {                             \
-                    zxc_copy32(dst_lit, src_lit);                        \
-                    dst_lit += ZXC_PAD_SIZE;                             \
-                    src_lit += ZXC_PAD_SIZE;                             \
-                    rem -= ZXC_PAD_SIZE;                                 \
-                }                                                        \
-                zxc_copy32(dst_lit, src_lit);                            \
-            }                                                            \
-            l_ptr += ll;                                                 \
-            d_ptr += ll;                                                 \
-            written += ll;                                               \
-        }                                                                \
-        {                                                                \
-            if (UNLIKELY(off > written)) return ZXC_ERROR_BAD_OFFSET;    \
-            const uint8_t* match_src = d_ptr - off;                      \
-            if (LIKELY(off >= ZXC_PAD_SIZE)) {                           \
-                zxc_copy32(d_ptr, match_src);                            \
-                if (UNLIKELY(ml > ZXC_PAD_SIZE)) {                       \
-                    uint8_t* out = d_ptr + ZXC_PAD_SIZE;                 \
-                    const uint8_t* ref = match_src + ZXC_PAD_SIZE;       \
-                    size_t rem = ml - ZXC_PAD_SIZE;                      \
-                    while (rem > ZXC_PAD_SIZE) {                         \
-                        zxc_copy32(out, ref);                            \
-                        out += ZXC_PAD_SIZE;                             \
-                        ref += ZXC_PAD_SIZE;                             \
-                        rem -= ZXC_PAD_SIZE;                             \
-                    }                                                    \
-                    zxc_copy32(out, ref);                                \
-                }                                                        \
-                d_ptr += ml;                                             \
-                written += ml;                                           \
-            } else if (off >= (ZXC_PAD_SIZE / 2)) {                      \
-                zxc_copy16(d_ptr, match_src);                            \
-                if (UNLIKELY(ml > (ZXC_PAD_SIZE / 2))) {                 \
-                    uint8_t* out = d_ptr + (ZXC_PAD_SIZE / 2);           \
-                    const uint8_t* ref = match_src + (ZXC_PAD_SIZE / 2); \
-                    size_t rem = ml - (ZXC_PAD_SIZE / 2);                \
-                    while (rem > (ZXC_PAD_SIZE / 2)) {                   \
-                        zxc_copy16(out, ref);                            \
-                        out += (ZXC_PAD_SIZE / 2);                       \
-                        ref += (ZXC_PAD_SIZE / 2);                       \
-                        rem -= (ZXC_PAD_SIZE / 2);                       \
-                    }                                                    \
-                    zxc_copy16(out, ref);                                \
-                }                                                        \
-                d_ptr += ml;                                             \
-                written += ml;                                           \
-            } else if (off == 1) {                                       \
-                ZXC_MEMSET(d_ptr, match_src[0], ml);                     \
-                d_ptr += ml;                                             \
-                written += ml;                                           \
-            } else {                                                     \
-                size_t copied = 0;                                       \
-                while (copied < ml) {                                    \
-                    zxc_copy_overlap16(d_ptr + copied, off);             \
-                    copied += (ZXC_PAD_SIZE / 2);                        \
-                }                                                        \
-                d_ptr += ml;                                             \
-                written += ml;                                           \
-            }                                                            \
-        }                                                                \
+    // --- Factored sub-macros for literal copy + match copy ---
+    // Used by DECODE_SEQ_SAFE and DECODE_SEQ_FAST to avoid duplication.
+
+#define DECODE_COPY_LITERALS(ll)              \
+    do {                                      \
+        const uint8_t* src_lit = l_ptr;       \
+        uint8_t* dst_lit = d_ptr;             \
+        zxc_copy32(dst_lit, src_lit);         \
+        if (UNLIKELY(ll > ZXC_PAD_SIZE)) {    \
+            dst_lit += ZXC_PAD_SIZE;          \
+            src_lit += ZXC_PAD_SIZE;          \
+            size_t rem = ll - ZXC_PAD_SIZE;   \
+            while (rem > ZXC_PAD_SIZE) {      \
+                zxc_copy32(dst_lit, src_lit); \
+                dst_lit += ZXC_PAD_SIZE;      \
+                src_lit += ZXC_PAD_SIZE;      \
+                rem -= ZXC_PAD_SIZE;          \
+            }                                 \
+            zxc_copy32(dst_lit, src_lit);     \
+        }                                     \
+        l_ptr += ll;                          \
+        d_ptr += ll;                          \
     } while (0)
 
-// FAST version: no offset validation (for use after written >= 256 or 65536)
-#define DECODE_SEQ_FAST(ll, ml, off)                                     \
-    do {                                                                 \
-        {                                                                \
-            const uint8_t* src_lit = l_ptr;                              \
-            uint8_t* dst_lit = d_ptr;                                    \
-            zxc_copy32(dst_lit, src_lit);                                \
-            if (UNLIKELY(ll > ZXC_PAD_SIZE)) {                           \
-                dst_lit += ZXC_PAD_SIZE;                                 \
-                src_lit += ZXC_PAD_SIZE;                                 \
-                size_t rem = ll - ZXC_PAD_SIZE;                          \
-                while (rem > ZXC_PAD_SIZE) {                             \
-                    zxc_copy32(dst_lit, src_lit);                        \
-                    dst_lit += ZXC_PAD_SIZE;                             \
-                    src_lit += ZXC_PAD_SIZE;                             \
-                    rem -= ZXC_PAD_SIZE;                                 \
-                }                                                        \
-                zxc_copy32(dst_lit, src_lit);                            \
-            }                                                            \
-            l_ptr += ll;                                                 \
-            d_ptr += ll;                                                 \
-        }                                                                \
-        {                                                                \
-            const uint8_t* match_src = d_ptr - off;                      \
-            if (LIKELY(off >= ZXC_PAD_SIZE)) {                           \
-                zxc_copy32(d_ptr, match_src);                            \
-                if (UNLIKELY(ml > ZXC_PAD_SIZE)) {                       \
-                    uint8_t* out = d_ptr + ZXC_PAD_SIZE;                 \
-                    const uint8_t* ref = match_src + ZXC_PAD_SIZE;       \
-                    size_t rem = ml - ZXC_PAD_SIZE;                      \
-                    while (rem > ZXC_PAD_SIZE) {                         \
-                        zxc_copy32(out, ref);                            \
-                        out += ZXC_PAD_SIZE;                             \
-                        ref += ZXC_PAD_SIZE;                             \
-                        rem -= ZXC_PAD_SIZE;                             \
-                    }                                                    \
-                    zxc_copy32(out, ref);                                \
-                }                                                        \
-                d_ptr += ml;                                             \
-            } else if (off >= (ZXC_PAD_SIZE / 2)) {                      \
-                zxc_copy16(d_ptr, match_src);                            \
-                if (UNLIKELY(ml > (ZXC_PAD_SIZE / 2))) {                 \
-                    uint8_t* out = d_ptr + (ZXC_PAD_SIZE / 2);           \
-                    const uint8_t* ref = match_src + (ZXC_PAD_SIZE / 2); \
-                    size_t rem = ml - (ZXC_PAD_SIZE / 2);                \
-                    while (rem > (ZXC_PAD_SIZE / 2)) {                   \
-                        zxc_copy16(out, ref);                            \
-                        out += (ZXC_PAD_SIZE / 2);                       \
-                        ref += (ZXC_PAD_SIZE / 2);                       \
-                        rem -= (ZXC_PAD_SIZE / 2);                       \
-                    }                                                    \
-                    zxc_copy16(out, ref);                                \
-                }                                                        \
-                d_ptr += ml;                                             \
-            } else if (off == 1) {                                       \
-                ZXC_MEMSET(d_ptr, match_src[0], ml);                     \
-                d_ptr += ml;                                             \
-            } else {                                                     \
-                size_t copied = 0;                                       \
-                while (copied < ml) {                                    \
-                    zxc_copy_overlap16(d_ptr + copied, off);             \
-                    copied += (ZXC_PAD_SIZE / 2);                        \
-                }                                                        \
-                d_ptr += ml;                                             \
-            }                                                            \
-        }                                                                \
+#define DECODE_COPY_MATCH(ml, off)                                   \
+    do {                                                             \
+        const uint8_t* match_src = d_ptr - off;                      \
+        if (LIKELY(off >= ZXC_PAD_SIZE)) {                           \
+            zxc_copy32(d_ptr, match_src);                            \
+            if (UNLIKELY(ml > ZXC_PAD_SIZE)) {                       \
+                uint8_t* out = d_ptr + ZXC_PAD_SIZE;                 \
+                const uint8_t* ref = match_src + ZXC_PAD_SIZE;       \
+                size_t rem = ml - ZXC_PAD_SIZE;                      \
+                while (rem > ZXC_PAD_SIZE) {                         \
+                    zxc_copy32(out, ref);                            \
+                    out += ZXC_PAD_SIZE;                             \
+                    ref += ZXC_PAD_SIZE;                             \
+                    rem -= ZXC_PAD_SIZE;                             \
+                }                                                    \
+                zxc_copy32(out, ref);                                \
+            }                                                        \
+            d_ptr += ml;                                             \
+        } else if (off >= (ZXC_PAD_SIZE / 2)) {                      \
+            zxc_copy16(d_ptr, match_src);                            \
+            if (UNLIKELY(ml > (ZXC_PAD_SIZE / 2))) {                 \
+                uint8_t* out = d_ptr + (ZXC_PAD_SIZE / 2);           \
+                const uint8_t* ref = match_src + (ZXC_PAD_SIZE / 2); \
+                size_t rem = ml - (ZXC_PAD_SIZE / 2);                \
+                while (rem > (ZXC_PAD_SIZE / 2)) {                   \
+                    zxc_copy16(out, ref);                            \
+                    out += (ZXC_PAD_SIZE / 2);                       \
+                    ref += (ZXC_PAD_SIZE / 2);                       \
+                    rem -= (ZXC_PAD_SIZE / 2);                       \
+                }                                                    \
+                zxc_copy16(out, ref);                                \
+            }                                                        \
+            d_ptr += ml;                                             \
+        } else if (off == 1) {                                       \
+            ZXC_MEMSET(d_ptr, match_src[0], ml);                     \
+            d_ptr += ml;                                             \
+        } else {                                                     \
+            size_t copied = 0;                                       \
+            while (copied < ml) {                                    \
+                zxc_copy_overlap16(d_ptr + copied, off);             \
+                copied += (ZXC_PAD_SIZE / 2);                        \
+            }                                                        \
+            d_ptr += ml;                                             \
+        }                                                            \
     } while (0)
 
-    // --- SAFE Loop: offset validation until threshold ---
+#define DECODE_SEQ_SAFE(ll, ml, off)                              \
+    do {                                                          \
+        DECODE_COPY_LITERALS(ll);                                 \
+        written += ll;                                            \
+        if (UNLIKELY(off > written)) return ZXC_ERROR_BAD_OFFSET; \
+        DECODE_COPY_MATCH(ml, off);                               \
+        written += ml;                                            \
+    } while (0)
+
+#define DECODE_SEQ_FAST(ll, ml, off) \
+    do {                             \
+        DECODE_COPY_LITERALS(ll);    \
+        DECODE_COPY_MATCH(ml, off);  \
+    } while (0)
+
+    // --- SAFE Loop: offset validation until threshold (4x unroll) ---
     // Since offset is 16-bit, threshold is 65536.
     // For 1-byte offsets (enc_off==1): validate until 256 bytes written
     // For 2-byte offsets (enc_off==0): validate until 65536 bytes written
     const size_t bounds_threshold = (gh.enc_off == 1) ? (1U << 8) : (1U << 16);
 
+    while (n_seq >= 4 && d_ptr < d_end_safe && l_ptr < l_end_safe_4x &&
+           written < bounds_threshold) {
+        uint32_t s1 = zxc_le32(seq_ptr);
+        uint32_t s2 = zxc_le32(seq_ptr + 4);
+        uint32_t s3 = zxc_le32(seq_ptr + 8);
+        uint32_t s4 = zxc_le32(seq_ptr + 12);
+        seq_ptr += 16;
+
+        uint32_t ll1 = (uint32_t)(s1 >> 24);
+        if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
+            ll1 += zxc_read_varint(&extras_ptr, extras_end);
+            if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
+        }
+        uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
+        uint32_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
+        if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
+            ml1 += zxc_read_varint(&extras_ptr, extras_end);
+            if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
+        }
+        uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+        DECODE_SEQ_SAFE(ll1, ml1, off1);
+
+        uint32_t ll2 = (uint32_t)(s2 >> 24);
+        if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
+            ll2 += zxc_read_varint(&extras_ptr, extras_end);
+            if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
+        }
+        uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
+        uint32_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
+        if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
+            ml2 += zxc_read_varint(&extras_ptr, extras_end);
+            if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
+        }
+        uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+        DECODE_SEQ_SAFE(ll2, ml2, off2);
+
+        uint32_t ll3 = (uint32_t)(s3 >> 24);
+        if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
+            ll3 += zxc_read_varint(&extras_ptr, extras_end);
+            if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
+        }
+        uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
+        uint32_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
+        if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
+            ml3 += zxc_read_varint(&extras_ptr, extras_end);
+            if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
+        }
+        uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+        DECODE_SEQ_SAFE(ll3, ml3, off3);
+
+        uint32_t ll4 = (uint32_t)(s4 >> 24);
+        if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
+            ll4 += zxc_read_varint(&extras_ptr, extras_end);
+            if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
+        }
+        uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
+        uint32_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
+        if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
+            ml4 += zxc_read_varint(&extras_ptr, extras_end);
+            if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
+        }
+        uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+        DECODE_SEQ_SAFE(ll4, ml4, off4);
+
+        n_seq -= 4;
+    }
+
+    // --- SAFE Loop tail: remaining sequences with offset validation (1x) ---
     while (n_seq > 0 && d_ptr < d_end_safe && written < bounds_threshold) {
         uint32_t seq = zxc_le32(seq_ptr);
         seq_ptr += 4;
@@ -1369,16 +1349,20 @@ static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         uint32_t s4 = zxc_le32(seq_ptr + 12);
         seq_ptr += 16;
 
+        // Prefetch ahead in literal and extras streams to hide memory latency
+        ZXC_PREFETCH_READ(l_ptr + ZXC_CACHE_LINE_SIZE);
+
         uint32_t ll1 = (uint32_t)(s1 >> 24);
         if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
             ll1 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 > d_end)) return ZXC_ERROR_OVERFLOW;
+            if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
         uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
         uint32_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
         if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
             ml1 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(d_ptr + ll1 + ml1 > d_end)) return ZXC_ERROR_OVERFLOW;
+            if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
         }
         uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
         DECODE_SEQ_FAST(ll1, ml1, off1);
@@ -1386,13 +1370,14 @@ static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         uint32_t ll2 = (uint32_t)(s2 >> 24);
         if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
             ll2 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 > d_end)) return ZXC_ERROR_OVERFLOW;
+            if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
         uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
         uint32_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
         if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
             ml2 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(d_ptr + ll2 + ml2 > d_end)) return ZXC_ERROR_OVERFLOW;
+            if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
         }
         uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
         DECODE_SEQ_FAST(ll2, ml2, off2);
@@ -1400,13 +1385,14 @@ static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         uint32_t ll3 = (uint32_t)(s3 >> 24);
         if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
             ll3 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 > d_end)) return ZXC_ERROR_OVERFLOW;
+            if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
         uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
         uint32_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
         if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
             ml3 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(d_ptr + ll3 + ml3 > d_end)) return ZXC_ERROR_OVERFLOW;
+            if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
         }
         uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
         DECODE_SEQ_FAST(ll3, ml3, off3);
@@ -1414,13 +1400,14 @@ static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         uint32_t ll4 = (uint32_t)(s4 >> 24);
         if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
             ll4 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 > d_end)) return ZXC_ERROR_OVERFLOW;
+            if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                return ZXC_ERROR_OVERFLOW;
         }
         uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
         uint32_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
         if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
             ml4 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(d_ptr + ll4 + ml4 > d_end)) return ZXC_ERROR_OVERFLOW;
+            if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
         }
         uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
         DECODE_SEQ_FAST(ll4, ml4, off4);
@@ -1430,6 +1417,8 @@ static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
 
 #undef DECODE_SEQ_SAFE
 #undef DECODE_SEQ_FAST
+#undef DECODE_COPY_LITERALS
+#undef DECODE_COPY_MATCH
 
     // --- Remaining 1 sequence (Fast Path) ---
     while (n_seq > 0 && d_ptr < d_end_safe && l_ptr < l_end_safe_1x) {

--- a/lz/zxc/src/lib/zxc_dispatch.c
+++ b/lz/zxc/src/lib/zxc_dispatch.c
@@ -16,7 +16,17 @@
  */
 
 #include "../../include/zxc_error.h"
+#include "../../include/zxc_seekable.h"
 #include "zxc_internal.h"
+
+/*
+ * ZXC_DISABLE_SIMD => force ZXC_ONLY_DEFAULT so the dispatcher never selects
+ * an AVX2/AVX512/NEON variant.
+ */
+#if defined(ZXC_DISABLE_SIMD) && !defined(ZXC_ONLY_DEFAULT)
+#define ZXC_ONLY_DEFAULT
+#endif
+
 #if defined(_MSC_VER)
 #include <intrin.h>
 #endif
@@ -338,6 +348,7 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
     if (UNLIKELY(!src || !dst || src_size == 0 || dst_capacity == 0)) return ZXC_ERROR_NULL_INPUT;
 
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
+    const int seekable = opts ? opts->seekable : 0;
     const int level = (opts && opts->level > 0) ? opts->level : ZXC_LEVEL_DEFAULT;
     const size_t block_size =
         (opts && opts->block_size > 0) ? opts->block_size : ZXC_BLOCK_SIZE_DEFAULT;
@@ -351,16 +362,40 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
     uint32_t global_hash = 0;
     zxc_cctx_t ctx;
 
+    // LCOV_EXCL_START
     if (UNLIKELY(zxc_cctx_init(&ctx, block_size, 1, level, checksum_enabled) != ZXC_OK))
         return ZXC_ERROR_MEMORY;
+    // LCOV_EXCL_STOP
 
     const int h_val =
         zxc_write_file_header(op, (size_t)(op_end - op), block_size, checksum_enabled);
+    // LCOV_EXCL_START
     if (UNLIKELY(h_val < 0)) {
         zxc_cctx_free(&ctx);
         return h_val;
     }
+    // LCOV_EXCL_STOP
     op += h_val;
+
+    /* Seekable: dynamic array for per-block compressed sizes */
+    uint32_t* seek_comp = NULL;
+    uint32_t seek_count = 0;
+    uint32_t seek_cap = 0;
+    if (seekable) {
+        const size_t block_count = src_size / block_size;
+        if (UNLIKELY(block_count > (size_t)UINT32_MAX - 2)) {
+            zxc_cctx_free(&ctx);
+            return ZXC_ERROR_BAD_BLOCK_SIZE;
+        }
+        seek_cap = (uint32_t)(block_count + 2);
+        seek_comp = (uint32_t*)malloc(seek_cap * sizeof(uint32_t));
+        // LCOV_EXCL_START
+        if (UNLIKELY(!seek_comp)) {
+            zxc_cctx_free(&ctx);
+            return ZXC_ERROR_MEMORY;
+        }
+        // LCOV_EXCL_STOP
+    }
 
     size_t pos = 0;
     while (pos < src_size) {
@@ -369,6 +404,7 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
 
         const int res = zxc_compress_chunk_wrapper(&ctx, ip + pos, chunk_len, op, rem_cap);
         if (UNLIKELY(res < 0)) {
+            free(seek_comp);
             zxc_cctx_free(&ctx);
             return res;
         }
@@ -382,26 +418,61 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
             }
         }
 
+        /* Seekable: record compressed block size */
+        if (seekable) {
+            // LCOV_EXCL_START
+            if (UNLIKELY(seek_count >= seek_cap)) {
+                seek_cap = seek_cap * 2;
+                uint32_t* nc = (uint32_t*)realloc(seek_comp, seek_cap * sizeof(uint32_t));
+                if (UNLIKELY(!nc)) {
+                    free(seek_comp);
+                    zxc_cctx_free(&ctx);
+                    return ZXC_ERROR_MEMORY;
+                }
+                seek_comp = nc;
+            }
+            // LCOV_EXCL_STOP
+            seek_comp[seek_count] = (uint32_t)res;
+            seek_count++;
+        }
+
         op += res;
         pos += chunk_len;
     }
 
     zxc_cctx_free(&ctx);
 
-    // Write EOF Block (Checksum flag handled by Block Header, but we zero it out now)
+    // Write EOF Block
     const size_t rem_cap = (size_t)(op_end - op);
     const zxc_block_header_t eof_bh = {
         .block_type = ZXC_BLOCK_EOF, .block_flags = 0, .reserved = 0, .comp_size = 0};
     const int eof_val = zxc_write_block_header(op, rem_cap, &eof_bh);
-    if (UNLIKELY(eof_val < 0)) return eof_val;
+    // LCOV_EXCL_START
+    if (UNLIKELY(eof_val < 0)) {
+        free(seek_comp);
+        return eof_val;
+    }
+    // LCOV_EXCL_STOP
     op += eof_val;
 
-    if (UNLIKELY(rem_cap < (size_t)eof_val + ZXC_FILE_FOOTER_SIZE)) return ZXC_ERROR_DST_TOO_SMALL;
+    /* Seekable: write seek table between EOF block and footer */
+    if (seekable && seek_count > 0) {
+        const size_t st_cap = (size_t)(op_end - op);
+        const int64_t st_val = zxc_write_seek_table(op, st_cap, seek_comp, seek_count);
+        free(seek_comp);
+        if (UNLIKELY(st_val < 0)) return (int64_t)st_val;  // LCOV_EXCL_LINE
+        op += st_val;
+    } else {
+        free(seek_comp);
+    }
+
+    if (UNLIKELY((size_t)(op_end - op) < ZXC_FILE_FOOTER_SIZE))
+        return ZXC_ERROR_DST_TOO_SMALL;  // LCOV_EXCL_LINE
 
     // Write 12-byte Footer: [Source Size (8)] + [Global Hash (4)]
     const int footer_val =
         zxc_write_file_footer(op, (size_t)(op_end - op), src_size, global_hash, checksum_enabled);
-    if (UNLIKELY(footer_val < 0)) return footer_val;
+    if (UNLIKELY(footer_val < 0)) return footer_val;  // LCOV_EXCL_LINE
     op += footer_val;
 
     return (int64_t)(op - op_start);
@@ -452,10 +523,12 @@ int64_t zxc_decompress(const void* RESTRICT src, const size_t src_size, void* RE
     if (ctx.work_buf_cap < work_sz) {
         free(ctx.work_buf);
         ctx.work_buf = (uint8_t*)malloc(work_sz);
+        // LCOV_EXCL_START
         if (UNLIKELY(!ctx.work_buf)) {
             zxc_cctx_free(&ctx);
             return ZXC_ERROR_MEMORY;
         }
+        // LCOV_EXCL_STOP
         ctx.work_buf_cap = work_sz;
     }
 
@@ -473,12 +546,15 @@ int64_t zxc_decompress(const void* RESTRICT src, const size_t src_size, void* RE
 
         // Handle EOF block separately (not a real chunk to decompress)
         if (UNLIKELY(bh.block_type == ZXC_BLOCK_EOF)) {
-            // Validate we have the footer after the header
-            if (UNLIKELY(rem_src < ZXC_BLOCK_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE)) {
+            // Footer is always the last ZXC_FILE_FOOTER_SIZE bytes of the source,
+            // even when a seek table is inserted between EOF block and footer.
+            // LCOV_EXCL_START
+            if (UNLIKELY(src_size < ZXC_FILE_FOOTER_SIZE)) {
                 zxc_cctx_free(&ctx);
                 return ZXC_ERROR_SRC_TOO_SMALL;
             }
-            const uint8_t* const footer = ip + ZXC_BLOCK_HEADER_SIZE;
+            // LCOV_EXCL_STOP
+            const uint8_t* const footer = (const uint8_t*)src + src_size - ZXC_FILE_FOOTER_SIZE;
 
             // Validate source size matches what we decompressed
             const uint64_t stored_size = zxc_le64(footer);
@@ -498,19 +574,22 @@ int64_t zxc_decompress(const void* RESTRICT src, const size_t src_size, void* RE
             break;  // EOF reached, exit loop
         }
 
-        const size_t rem_cap = (size_t)(op_end - op);
         int res;
-        if (LIKELY(rem_cap >= runtime_chunk_size + ZXC_PAD_SIZE)) {
-            // Fast path: decode directly into dst (enough padding for wild copies).
-            res = zxc_decompress_chunk_wrapper(&ctx, ip, rem_src, op, rem_cap);
+        const size_t rem_cap = (size_t)(op_end - op);
+        if (LIKELY(rem_cap >= runtime_chunk_size + 2 * ZXC_PAD_SIZE)) {
+            // Fast path: decode directly into dst. Cap dst_cap to chunk_size + PAD
+            res = zxc_decompress_chunk_wrapper(&ctx, ip, rem_src, op,
+                                               runtime_chunk_size + ZXC_PAD_SIZE);
         } else {
             // Safe path: decode into bounce buffer, then copy exact result.
             res = zxc_decompress_chunk_wrapper(&ctx, ip, rem_src, ctx.work_buf, runtime_chunk_size);
             if (LIKELY(res > 0)) {
+                // LCOV_EXCL_START
                 if (UNLIKELY((size_t)res > rem_cap)) {
                     zxc_cctx_free(&ctx);
                     return ZXC_ERROR_DST_TOO_SMALL;
                 }
+                // LCOV_EXCL_STOP
                 ZXC_MEMCPY(op, ctx.work_buf, (size_t)res);
             }
         }
@@ -577,7 +656,7 @@ struct zxc_cctx_s {
 
 zxc_cctx* zxc_create_cctx(const zxc_compress_opts_t* opts) {
     zxc_cctx* const cctx = (zxc_cctx*)calloc(1, sizeof(zxc_cctx));
-    if (UNLIKELY(!cctx)) return NULL;
+    if (UNLIKELY(!cctx)) return NULL;  // LCOV_EXCL_LINE
 
     /* Resolve and store sticky defaults. */
     cctx->stored_level = (opts && opts->level > 0) ? opts->level : ZXC_LEVEL_DEFAULT;
@@ -586,12 +665,14 @@ zxc_cctx* zxc_create_cctx(const zxc_compress_opts_t* opts) {
     cctx->stored_checksum = opts ? opts->checksum_enabled : 0;
 
     if (opts) {
+        // LCOV_EXCL_START
         if (UNLIKELY(!zxc_validate_block_size(cctx->stored_block_size) ||
                      zxc_cctx_init(&cctx->inner, cctx->stored_block_size, 1, cctx->stored_level,
                                    cctx->stored_checksum) != ZXC_OK)) {
             free(cctx);
             return NULL;
         }
+        // LCOV_EXCL_STOP
         cctx->last_block_size = cctx->stored_block_size;
         cctx->initialized = 1;
     }
@@ -624,9 +705,14 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
 
     /* Re-init only when block_size changed (it drives buffer sizes). */
     if (!cctx->initialized || cctx->last_block_size != block_size) {
-        if (cctx->initialized) zxc_cctx_free(&cctx->inner);
+        if (cctx->initialized) {
+            zxc_cctx_free(&cctx->inner);
+            cctx->initialized = 0;
+        }
+        // LCOV_EXCL_START
         if (UNLIKELY(zxc_cctx_init(&cctx->inner, block_size, 1, level, checksum_enabled) != ZXC_OK))
             return ZXC_ERROR_MEMORY;
+        // LCOV_EXCL_STOP
         cctx->last_block_size = block_size;
         cctx->initialized = 1;
     } else {
@@ -645,7 +731,7 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
 
     const int h_val =
         zxc_write_file_header(op, (size_t)(op_end - op), block_size, checksum_enabled);
-    if (UNLIKELY(h_val < 0)) return h_val;
+    if (UNLIKELY(h_val < 0)) return h_val;  // LCOV_EXCL_LINE
     op += h_val;
 
     size_t pos = 0;
@@ -672,14 +758,15 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
     const zxc_block_header_t eof_bh = {
         .block_type = ZXC_BLOCK_EOF, .block_flags = 0, .reserved = 0, .comp_size = 0};
     const int eof_val = zxc_write_block_header(op, rem_cap, &eof_bh);
-    if (UNLIKELY(eof_val < 0)) return eof_val;
+    if (UNLIKELY(eof_val < 0)) return eof_val;  // LCOV_EXCL_LINE
     op += eof_val;
 
-    if (UNLIKELY(rem_cap < (size_t)eof_val + ZXC_FILE_FOOTER_SIZE)) return ZXC_ERROR_DST_TOO_SMALL;
+    if (UNLIKELY(rem_cap < (size_t)eof_val + ZXC_FILE_FOOTER_SIZE))
+        return ZXC_ERROR_DST_TOO_SMALL;  // LCOV_EXCL_LINE
 
     const int footer_val =
         zxc_write_file_footer(op, (size_t)(op_end - op), src_size, global_hash, checksum_enabled);
-    if (UNLIKELY(footer_val < 0)) return footer_val;
+    if (UNLIKELY(footer_val < 0)) return footer_val;  // LCOV_EXCL_LINE
     op += footer_val;
 
     return (int64_t)(op - op_start);
@@ -726,10 +813,15 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
 
     /* Re-init only when block size changed. */
     if (!dctx->initialized || dctx->last_block_size != runtime_chunk_size) {
-        if (dctx->initialized) zxc_cctx_free(&dctx->inner);
+        if (dctx->initialized) {
+            zxc_cctx_free(&dctx->inner);
+            dctx->initialized = 0;
+        }
+        // LCOV_EXCL_START
         if (UNLIKELY(zxc_cctx_init(&dctx->inner, runtime_chunk_size, 0, 0,
                                    file_has_checksums && checksum_enabled) != ZXC_OK))
             return ZXC_ERROR_MEMORY;
+        // LCOV_EXCL_STOP
         dctx->last_block_size = runtime_chunk_size;
         dctx->initialized = 1;
     } else {
@@ -744,7 +836,7 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
     if (ctx->work_buf_cap < work_sz) {
         free(ctx->work_buf);
         ctx->work_buf = (uint8_t*)malloc(work_sz);
-        if (UNLIKELY(!ctx->work_buf)) return ZXC_ERROR_MEMORY;
+        if (UNLIKELY(!ctx->work_buf)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
         ctx->work_buf_cap = work_sz;
     }
 
@@ -780,7 +872,8 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
             // Safe path: decode into bounce buffer, then copy exact result.
             res = zxc_decompress_chunk_wrapper(ctx, ip, rem_src, ctx->work_buf, runtime_chunk_size);
             if (LIKELY(res > 0)) {
-                if (UNLIKELY((size_t)res > rem_cap)) return ZXC_ERROR_DST_TOO_SMALL;
+                if (UNLIKELY((size_t)res > rem_cap))
+                    return ZXC_ERROR_DST_TOO_SMALL;  // LCOV_EXCL_LINE
                 ZXC_MEMCPY(op, ctx->work_buf, (size_t)res);
             }
         }
@@ -797,4 +890,105 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
     }
 
     return (int64_t)(op - op_start);
+}
+
+/* ========================================================================= */
+/*  Block-Level API (no file framing)                                        */
+/* ========================================================================= */
+
+int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_t src_size,
+                           void* RESTRICT dst, const size_t dst_capacity,
+                           const zxc_compress_opts_t* opts) {
+    if (UNLIKELY(!cctx || !src || !dst || src_size == 0 || dst_capacity == 0))
+        return ZXC_ERROR_NULL_INPUT;
+
+    const int checksum_enabled = opts ? opts->checksum_enabled : cctx->stored_checksum;
+    const int level = (opts && opts->level > 0) ? opts->level : cctx->stored_level;
+    /* For block API, block_size == src_size (the caller compresses one block at a time). */
+    const size_t block_size =
+        (opts && opts->block_size > 0) ? opts->block_size : cctx->stored_block_size;
+    const size_t effective_block_size = (block_size > 0) ? block_size : src_size;
+
+    cctx->stored_level = level;
+    cctx->stored_block_size = effective_block_size;
+    cctx->stored_checksum = checksum_enabled;
+
+    /* Re-init only when block_size changed. */
+    if (!cctx->initialized || cctx->last_block_size != effective_block_size) {
+        if (cctx->initialized) {
+            zxc_cctx_free(&cctx->inner);
+            cctx->initialized = 0;
+        }
+        // LCOV_EXCL_START
+        if (UNLIKELY(zxc_cctx_init(&cctx->inner, effective_block_size, 1, level,
+                                   checksum_enabled) != ZXC_OK))
+            return ZXC_ERROR_MEMORY;
+        // LCOV_EXCL_STOP
+        cctx->last_block_size = effective_block_size;
+        cctx->initialized = 1;
+    } else {
+        cctx->inner.compression_level = level;
+        cctx->inner.checksum_enabled = checksum_enabled;
+    }
+
+    const int res = zxc_compress_chunk_wrapper(&cctx->inner, (const uint8_t*)src, src_size,
+                                               (uint8_t*)dst, dst_capacity);
+    if (UNLIKELY(res < 0)) return res;
+    return (int64_t)res;
+}
+
+int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const size_t src_size,
+                             void* RESTRICT dst, const size_t dst_capacity,
+                             const zxc_decompress_opts_t* opts) {
+    if (UNLIKELY(!dctx || !src || !dst || src_size < ZXC_BLOCK_HEADER_SIZE))
+        return ZXC_ERROR_NULL_INPUT;
+
+    const int checksum_enabled = opts ? opts->checksum_enabled : 0;
+
+    /*
+     * Derive the block_size from dst_capacity (callers know the original size).
+     * Re-init only when needed.
+     */
+    const size_t block_size = dst_capacity;
+    if (!dctx->initialized || dctx->last_block_size != block_size) {
+        if (dctx->initialized) {
+            zxc_cctx_free(&dctx->inner);
+            dctx->initialized = 0;
+        }
+        // LCOV_EXCL_START
+        if (UNLIKELY(zxc_cctx_init(&dctx->inner, block_size, 0, 0, checksum_enabled) != ZXC_OK))
+            return ZXC_ERROR_MEMORY;
+        // LCOV_EXCL_STOP
+        dctx->last_block_size = block_size;
+        dctx->initialized = 1;
+    } else {
+        dctx->inner.checksum_enabled = checksum_enabled;
+    }
+
+    zxc_cctx_t* const ctx = &dctx->inner;
+
+    /* Ensure scratch buffer for safe-path wild copies. */
+    const size_t work_sz = block_size + ZXC_PAD_SIZE;
+    if (ctx->work_buf_cap < work_sz) {
+        free(ctx->work_buf);
+        ctx->work_buf = (uint8_t*)malloc(work_sz);
+        if (UNLIKELY(!ctx->work_buf)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
+        ctx->work_buf_cap = work_sz;
+    }
+
+    int res;
+    if (LIKELY(dst_capacity >= block_size + ZXC_PAD_SIZE)) {
+        res = zxc_decompress_chunk_wrapper(ctx, (const uint8_t*)src, src_size, (uint8_t*)dst,
+                                           dst_capacity);
+    } else {
+        /* Bounce through work_buf when output can't absorb wild copies. */
+        res = zxc_decompress_chunk_wrapper(ctx, (const uint8_t*)src, src_size, ctx->work_buf,
+                                           block_size);
+        if (LIKELY(res > 0)) {
+            if (UNLIKELY((size_t)res > dst_capacity)) return ZXC_ERROR_DST_TOO_SMALL;
+            ZXC_MEMCPY(dst, ctx->work_buf, (size_t)res);
+        }
+    }
+    if (UNLIKELY(res < 0)) return res;
+    return (int64_t)res;
 }

--- a/lz/zxc/src/lib/zxc_driver.c
+++ b/lz/zxc/src/lib/zxc_driver.c
@@ -22,6 +22,7 @@
 #include "../../include/zxc_buffer.h"
 #include "../../include/zxc_error.h"
 #include "../../include/zxc_sans_io.h"
+#include "../../include/zxc_seekable.h"
 #include "../../include/zxc_stream.h"
 #include "zxc_internal.h"
 
@@ -300,6 +301,15 @@ typedef struct {
  *
  * @var writer_args_t::bytes_processed
  * The number of bytes processed so far, used for progress reporting.
+ *
+ * @var writer_args_t::seek_comp
+ * Array of compressed block sizes for seek table construction.
+ *
+ * @var writer_args_t::seek_count
+ * Number of entries in the seek table.
+ *
+ * @var writer_args_t::seek_cap
+ * Capacity of the seek table array.
  */
 typedef struct {
     zxc_stream_ctx_t* ctx;
@@ -307,6 +317,9 @@ typedef struct {
     int64_t total_bytes;
     uint32_t global_hash;
     uint64_t bytes_processed;  // For progress callback
+    uint32_t* seek_comp;
+    uint32_t seek_count;
+    uint32_t seek_cap;
 } writer_args_t;
 
 /**
@@ -347,8 +360,15 @@ static void* zxc_stream_worker(void* arg) {
 
     if (zxc_cctx_init(&cctx, ctx->chunk_size, ctx->compression_mode, ctx->compression_level,
                       unified_chk) != ZXC_OK) {
+        // LCOV_EXCL_START
         zxc_cctx_free(&cctx);
+        pthread_mutex_lock(&ctx->lock);
+        ctx->io_error = 1;
+        pthread_cond_broadcast(&ctx->cond_writer);
+        pthread_cond_broadcast(&ctx->cond_reader);
+        pthread_mutex_unlock(&ctx->lock);
         return NULL;
+        // LCOV_EXCL_STOP
     }
 
     cctx.compression_level = ctx->compression_level;
@@ -370,10 +390,10 @@ static void* zxc_stream_worker(void* arg) {
         pthread_mutex_unlock(&ctx->lock);
 
         const int res = ctx->processor(&cctx, job->in_buf, job->in_sz, job->out_buf, job->out_cap);
-        job->result_sz = UNLIKELY(res < 0) ? 0 : (size_t)res;
-        job->status = JOB_STATUS_PROCESSED;
 
         pthread_mutex_lock(&ctx->lock);
+        job->result_sz = UNLIKELY(res < 0) ? 0 : (size_t)res;
+        job->status = JOB_STATUS_PROCESSED;
         if (UNLIKELY(res < 0)) {
             ctx->io_error = 1;
             pthread_cond_broadcast(&ctx->cond_writer);
@@ -418,7 +438,7 @@ static void* zxc_async_writer(void* arg) {
     while (1) {
         zxc_stream_job_t* const job = &ctx->jobs[ctx->write_idx];
         pthread_mutex_lock(&ctx->lock);
-        while (job->status != JOB_STATUS_PROCESSED)
+        while (job->status != JOB_STATUS_PROCESSED && !ctx->io_error)
             pthread_cond_wait(&ctx->cond_writer, &ctx->lock);
 
         if (job->result_sz == (size_t)-1) {
@@ -429,7 +449,10 @@ static void* zxc_async_writer(void* arg) {
 
         if (args->f && job->result_sz > 0) {
             if (fwrite(job->out_buf, 1, job->result_sz, args->f) != job->result_sz) {
+                pthread_mutex_lock(&ctx->lock);
                 ctx->io_error = 1;
+                pthread_cond_signal(&ctx->cond_reader);
+                pthread_mutex_unlock(&ctx->lock);
             } else if (ctx->checksum_enabled && ctx->compression_mode == 1) {
                 // Update Global Hash (Rotation + XOR)
                 if (LIKELY(job->result_sz >= ZXC_GLOBAL_CHECKSUM_SIZE)) {
@@ -448,11 +471,34 @@ static void* zxc_async_writer(void* arg) {
         }
         args->total_bytes += (int64_t)job->result_sz;
 
+        /* Seekable: record compressed block size */
+        if (args->seek_comp && ctx->compression_mode == 1) {
+            if (UNLIKELY(args->seek_count >= args->seek_cap)) {
+                args->seek_cap = args->seek_cap * 2;
+                uint32_t* nc =
+                    (uint32_t*)realloc(args->seek_comp, args->seek_cap * sizeof(uint32_t));
+                // LCOV_EXCL_START
+                if (UNLIKELY(!nc)) {
+                    ctx->io_error = 1;
+                    pthread_mutex_lock(&ctx->lock);
+                    job->status = JOB_STATUS_FREE;
+                    pthread_cond_signal(&ctx->cond_reader);
+                    pthread_mutex_unlock(&ctx->lock);
+                    break;
+                }
+                // LCOV_EXCL_STOP
+                args->seek_comp = nc;
+            }
+            args->seek_comp[args->seek_count++] = (uint32_t)job->result_sz;
+        }
+
         // Update progress callback
         if (ctx->progress_cb) {
+            // LCOV_EXCL_START
             args->bytes_processed += ctx->compression_mode == 1 ? job->in_sz : job->result_sz;
             ctx->progress_cb(args->bytes_processed, ctx->total_input_bytes,
                              ctx->progress_user_data);
+            // LCOV_EXCL_STOP
         }
 
         pthread_mutex_lock(&ctx->lock);
@@ -503,7 +549,8 @@ static void* zxc_async_writer(void* arg) {
  */
 static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_threads, const int mode,
                                      const int level, const size_t block_size,
-                                     const int checksum_enabled, zxc_chunk_processor_t func,
+                                     const int checksum_enabled, const int seekable,
+                                     zxc_chunk_processor_t func,
                                      zxc_progress_callback_t progress_cb, void* user_data) {
     zxc_stream_ctx_t ctx;
     ZXC_MEMSET(&ctx, 0, sizeof(ctx));
@@ -515,6 +562,7 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     // For decompression, the CLI precomputes the size and passes it via user_data
     uint64_t total_file_size = 0;
     if (mode == 1 && progress_cb) {
+        // LCOV_EXCL_START
         const long long saved_pos = ftello(f_in);
         if (saved_pos >= 0) {
             if (fseeko(f_in, 0, SEEK_END) == 0) {
@@ -523,6 +571,7 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
                 fseeko(f_in, saved_pos, SEEK_SET);
             }
         }
+        // LCOV_EXCL_STOP
     }
 
     if (mode == 0) {
@@ -554,16 +603,21 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     uint32_t d_global_hash = 0;
 
     const uint64_t max_out = zxc_compress_bound(runtime_chunk_sz);
-    const size_t raw_alloc_in = ((mode) ? runtime_chunk_sz : max_out) + ZXC_PAD_SIZE;
+    const size_t raw_alloc_in = (size_t)(((mode) ? runtime_chunk_sz : max_out) + ZXC_PAD_SIZE);
     const size_t alloc_in = (raw_alloc_in + ZXC_ALIGNMENT_MASK) & ~ZXC_ALIGNMENT_MASK;
 
-    const size_t raw_alloc_out = ((mode) ? max_out : runtime_chunk_sz) + ZXC_PAD_SIZE;
+    const size_t raw_alloc_out = (size_t)(((mode) ? max_out : runtime_chunk_sz) + ZXC_PAD_SIZE);
     const size_t alloc_out = (raw_alloc_out + ZXC_ALIGNMENT_MASK) & ~ZXC_ALIGNMENT_MASK;
 
-    size_t alloc_size =
-        ctx.ring_size * (sizeof(zxc_stream_job_t) + sizeof(int) + alloc_in + alloc_out);
+    const size_t per_job_sz = sizeof(zxc_stream_job_t) + sizeof(int) + alloc_in + alloc_out;
+    const size_t alloc_size = ctx.ring_size * per_job_sz;
     uint8_t* const mem_block = zxc_aligned_malloc(alloc_size, ZXC_CACHE_LINE_SIZE);
-    if (UNLIKELY(!mem_block)) return ZXC_ERROR_MEMORY;
+    if (UNLIKELY(!mem_block || per_job_sz > SIZE_MAX / ctx.ring_size)) {
+        // LCOV_EXCL_START
+        zxc_aligned_free(mem_block);
+        return ZXC_ERROR_MEMORY;
+        // LCOV_EXCL_STOP
+    }
 
     uint8_t* ptr = mem_block;
     ctx.jobs = (zxc_stream_job_t*)ptr;
@@ -574,10 +628,10 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     ptr += ctx.ring_size * alloc_in;
     uint8_t* buf_out = ptr;
 
-    ZXC_MEMSET(buf_in, 0, ctx.ring_size * alloc_in);
+    ZXC_MEMSET(mem_block, 0, alloc_size);
 
     for (size_t i = 0; i < ctx.ring_size; i++) {
-        ctx.jobs[i].job_id = i;
+        ctx.jobs[i].job_id = (int)i;
         ctx.jobs[i].status = JOB_STATUS_FREE;
         ctx.jobs[i].in_buf = buf_in + (i * alloc_in);
         ctx.jobs[i].in_cap = alloc_in - ZXC_PAD_SIZE;
@@ -594,13 +648,51 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
 
     pthread_t* const workers = malloc((size_t)num_workers * sizeof(pthread_t));
     if (UNLIKELY(!workers)) {
+        // LCOV_EXCL_START
         zxc_aligned_free(mem_block);
         return ZXC_ERROR_MEMORY;
+        // LCOV_EXCL_STOP
     }
-    for (int i = 0; i < num_workers; i++)
-        pthread_create(&workers[i], NULL, zxc_stream_worker, &ctx);
+    int started_workers = 0;
+    for (int i = 0; i < num_workers; i++) {
+        if (UNLIKELY(pthread_create(&workers[i], NULL, zxc_stream_worker, &ctx) != 0)) break;
+        started_workers++;
+    }
+    if (UNLIKELY(started_workers == 0)) {
+        // LCOV_EXCL_START
+        pthread_cond_destroy(&ctx.cond_writer);
+        pthread_cond_destroy(&ctx.cond_worker);
+        pthread_cond_destroy(&ctx.cond_reader);
+        pthread_mutex_destroy(&ctx.lock);
+        free(workers);
+        zxc_aligned_free(mem_block);
+        return ZXC_ERROR_MEMORY;
+        // LCOV_EXCL_STOP
+    }
 
-    writer_args_t w_args = {&ctx, f_out, 0, 0, 0};
+    writer_args_t w_args = {&ctx, f_out, 0, 0, 0, NULL, 0, 0};
+
+    /* Seekable: allocate initial block-size tracking array */
+    if (mode == 1 && seekable) {
+        w_args.seek_cap = 64;
+        w_args.seek_comp = (uint32_t*)malloc(w_args.seek_cap * sizeof(uint32_t));
+        // LCOV_EXCL_START
+        if (UNLIKELY(!w_args.seek_comp)) {
+            pthread_mutex_lock(&ctx.lock);
+            ctx.shutdown_workers = 1;
+            pthread_cond_broadcast(&ctx.cond_worker);
+            pthread_mutex_unlock(&ctx.lock);
+            for (int i = 0; i < started_workers; i++) pthread_join(workers[i], NULL);
+            pthread_cond_destroy(&ctx.cond_writer);
+            pthread_cond_destroy(&ctx.cond_worker);
+            pthread_cond_destroy(&ctx.cond_reader);
+            pthread_mutex_destroy(&ctx.lock);
+            free(workers);
+            zxc_aligned_free(mem_block);
+            return ZXC_ERROR_MEMORY;
+        }
+        // LCOV_EXCL_STOP
+    }
 
     if (mode == 1 && f_out) {
         uint8_t h[ZXC_FILE_HEADER_SIZE];
@@ -611,7 +703,22 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
         w_args.total_bytes = ZXC_FILE_HEADER_SIZE;
     }
     pthread_t writer_th;
-    pthread_create(&writer_th, NULL, zxc_async_writer, &w_args);
+    if (UNLIKELY(pthread_create(&writer_th, NULL, zxc_async_writer, &w_args) != 0)) {
+        // LCOV_EXCL_START
+        pthread_mutex_lock(&ctx.lock);
+        ctx.shutdown_workers = 1;
+        pthread_cond_broadcast(&ctx.cond_worker);
+        pthread_mutex_unlock(&ctx.lock);
+        for (int i = 0; i < started_workers; i++) pthread_join(workers[i], NULL);
+        pthread_cond_destroy(&ctx.cond_writer);
+        pthread_cond_destroy(&ctx.cond_worker);
+        pthread_cond_destroy(&ctx.cond_reader);
+        pthread_mutex_destroy(&ctx.lock);
+        free(workers);
+        zxc_aligned_free(mem_block);
+        return ZXC_ERROR_MEMORY;
+        // LCOV_EXCL_STOP
+    }
 
     int read_idx = 0;
     int read_eof = 0;
@@ -621,7 +728,8 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     while (!read_eof && !ctx.io_error) {
         zxc_stream_job_t* const job = &ctx.jobs[read_idx];
         pthread_mutex_lock(&ctx.lock);
-        while (job->status != JOB_STATUS_FREE) pthread_cond_wait(&ctx.cond_reader, &ctx.lock);
+        while (job->status != JOB_STATUS_FREE && !ctx.io_error)
+            pthread_cond_wait(&ctx.cond_reader, &ctx.lock);
         pthread_mutex_unlock(&ctx.lock);
 
         if (UNLIKELY(ctx.io_error)) break;
@@ -670,7 +778,8 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
                     fread(job->in_buf + ZXC_BLOCK_HEADER_SIZE, 1, body_total, f_in);
 
                 if (UNLIKELY(body_read != body_total)) {
-                    read_eof = 1;
+                    ctx.io_error = 1;
+                    break;
                 } else if (has_crc) {
                     // Update Global Hash for Decompression
                     const uint32_t b_crc =
@@ -698,7 +807,8 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
 
     zxc_stream_job_t* const end_job = &ctx.jobs[read_idx];
     pthread_mutex_lock(&ctx.lock);
-    while (end_job->status != JOB_STATUS_FREE) pthread_cond_wait(&ctx.cond_reader, &ctx.lock);
+    while (end_job->status != JOB_STATUS_FREE && !ctx.io_error)
+        pthread_cond_wait(&ctx.cond_reader, &ctx.lock);
     end_job->result_sz = -1;
     end_job->status = JOB_STATUS_PROCESSED;
     pthread_cond_broadcast(&ctx.cond_writer);
@@ -709,39 +819,99 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     ctx.shutdown_workers = 1;
     pthread_cond_broadcast(&ctx.cond_worker);
     pthread_mutex_unlock(&ctx.lock);
-    for (int i = 0; i < num_workers; i++) pthread_join(workers[i], NULL);
+    for (int i = 0; i < started_workers; i++) pthread_join(workers[i], NULL);
 
-    // Write EOF Block if compression and no error
+    pthread_cond_destroy(&ctx.cond_writer);
+    pthread_cond_destroy(&ctx.cond_worker);
+    pthread_cond_destroy(&ctx.cond_reader);
+    pthread_mutex_destroy(&ctx.lock);
+
+    // Write EOF Block + optional Seek Table + Footer if compression and no error
     if (mode == 1 && !ctx.io_error && w_args.total_bytes >= 0) {
-        uint8_t final_buf[ZXC_BLOCK_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE];
-        uint8_t* const eof_buf = final_buf;
-        uint8_t* const footer = final_buf + ZXC_BLOCK_HEADER_SIZE;
-
-        zxc_block_header_t eof_bh = {
+        /* EOF block */
+        uint8_t eof_buf[ZXC_BLOCK_HEADER_SIZE];
+        const zxc_block_header_t eof_bh = {
             .block_type = ZXC_BLOCK_EOF, .block_flags = 0, .reserved = 0, .comp_size = 0};
         zxc_write_block_header(eof_buf, ZXC_BLOCK_HEADER_SIZE, &eof_bh);
-        zxc_write_file_footer(footer, ZXC_FILE_FOOTER_SIZE, total_src_bytes, w_args.global_hash,
+        if (UNLIKELY(f_out &&
+                     fwrite(eof_buf, 1, ZXC_BLOCK_HEADER_SIZE, f_out) != ZXC_BLOCK_HEADER_SIZE))
+            ctx.io_error = 1;
+        else
+            w_args.total_bytes += ZXC_BLOCK_HEADER_SIZE;
+
+        /* Seekable: write SEK block between EOF and footer */
+        if (!ctx.io_error && w_args.seek_comp && w_args.seek_count > 0) {
+            const size_t st_size = zxc_seek_table_size(w_args.seek_count);
+            uint8_t* const st_buf = (uint8_t*)malloc(st_size);
+            if (st_buf) {
+                const int64_t st_val =
+                    zxc_write_seek_table(st_buf, st_size, w_args.seek_comp, w_args.seek_count);
+                if (st_val > 0 && f_out &&
+                    fwrite(st_buf, 1, (size_t)st_val, f_out) == (size_t)st_val)
+                    w_args.total_bytes += st_val;
+                free(st_buf);
+            }
+        }
+
+        /* Footer */
+        uint8_t footer_buf[ZXC_FILE_FOOTER_SIZE];
+        zxc_write_file_footer(footer_buf, ZXC_FILE_FOOTER_SIZE, total_src_bytes, w_args.global_hash,
                               checksum_enabled);
-
-        if (UNLIKELY(f_out && fwrite(final_buf, 1, sizeof(final_buf), f_out) != sizeof(final_buf)))
-            return ZXC_ERROR_IO;
-
-        w_args.total_bytes += sizeof(final_buf);
+        if (UNLIKELY(f_out &&
+                     fwrite(footer_buf, 1, ZXC_FILE_FOOTER_SIZE, f_out) != ZXC_FILE_FOOTER_SIZE))
+            ctx.io_error = 1;
+        else
+            w_args.total_bytes += ZXC_FILE_FOOTER_SIZE;
     } else if (mode == 0 && !ctx.io_error) {
-        // Verification: Expect 12-byte footer
+        /*
+         * After the EOF block, the stream may contain:
+         *   (a) [FOOTER 12B]                  - no seekable table
+         *   (b) [SEK header 8B] [payload] [FOOTER 12B] - seekable archive
+         */
+        uint8_t peek_buf[ZXC_BLOCK_HEADER_SIZE];
         uint8_t footer[ZXC_FILE_FOOTER_SIZE];
-        if (UNLIKELY(fread(footer, 1, ZXC_FILE_FOOTER_SIZE, f_in) != ZXC_FILE_FOOTER_SIZE)) {
+
+        if (UNLIKELY(fread(peek_buf, 1, ZXC_BLOCK_HEADER_SIZE, f_in) != ZXC_BLOCK_HEADER_SIZE)) {
             ctx.io_error = 1;
         } else {
-            // Verify Footer Content: Source Size and Global Checksum
+            zxc_block_header_t peek_bh;
+            const int is_sek =
+                (zxc_read_block_header(peek_buf, ZXC_BLOCK_HEADER_SIZE, &peek_bh) == ZXC_OK &&
+                 peek_bh.block_type == ZXC_BLOCK_SEK);
+
+            if (is_sek) {
+                /* Drain the SEK payload (read + discard) */
+                size_t remaining = (size_t)peek_bh.comp_size;
+                uint8_t discard[512];
+                while (remaining > 0 && !ctx.io_error) {
+                    const size_t chunk = remaining < sizeof(discard) ? remaining : sizeof(discard);
+                    if (UNLIKELY(fread(discard, 1, chunk, f_in) != chunk)) ctx.io_error = 1;
+                    remaining -= chunk;
+                }
+                /* Read full 12-byte footer */
+                if (!ctx.io_error &&
+                    UNLIKELY(fread(footer, 1, ZXC_FILE_FOOTER_SIZE, f_in) != ZXC_FILE_FOOTER_SIZE))
+                    ctx.io_error = 1;
+            } else {
+                /* peek_buf contains the first 8 bytes of the 12-byte footer.
+                 * Read the remaining 4 bytes and assemble. */
+                ZXC_MEMCPY(footer, peek_buf, ZXC_BLOCK_HEADER_SIZE);
+                const size_t tail = ZXC_FILE_FOOTER_SIZE - ZXC_BLOCK_HEADER_SIZE; /* 4 */
+                if (UNLIKELY(fread(footer + ZXC_BLOCK_HEADER_SIZE, 1, tail, f_in) != tail))
+                    ctx.io_error = 1;
+            }
+        }
+
+        /* Verify Footer Content: Source Size and Global Checksum */
+        if (!ctx.io_error) {
             int valid = (zxc_le64(footer) == (uint64_t)w_args.total_bytes);
             if (valid && checksum_enabled && ctx.file_has_checksum)
                 valid = (zxc_le32(footer + sizeof(uint64_t)) == d_global_hash);
-
             if (UNLIKELY(!valid)) ctx.io_error = 1;
         }
     }
 
+    free(w_args.seek_comp);
     free(workers);
     zxc_aligned_free(mem_block);
 
@@ -755,6 +925,7 @@ int64_t zxc_stream_compress(FILE* f_in, FILE* f_out, const zxc_compress_opts_t* 
 
     const int n_threads = opts ? opts->n_threads : 0;
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
+    const int seekable = opts ? opts->seekable : 0;
     const int level = (opts && opts->level > 0) ? opts->level : ZXC_LEVEL_DEFAULT;
     const size_t block_size =
         (opts && opts->block_size > 0) ? opts->block_size : ZXC_BLOCK_SIZE_DEFAULT;
@@ -764,7 +935,7 @@ int64_t zxc_stream_compress(FILE* f_in, FILE* f_out, const zxc_compress_opts_t* 
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return ZXC_ERROR_BAD_BLOCK_SIZE;
 
     return zxc_stream_engine_run(f_in, f_out, n_threads, 1, level, block_size, checksum_enabled,
-                                 zxc_compress_chunk_wrapper, cb, ud);
+                                 seekable, zxc_compress_chunk_wrapper, cb, ud);
 }
 
 int64_t zxc_stream_decompress(FILE* f_in, FILE* f_out, const zxc_decompress_opts_t* opts) {
@@ -775,7 +946,7 @@ int64_t zxc_stream_decompress(FILE* f_in, FILE* f_out, const zxc_decompress_opts
     zxc_progress_callback_t cb = opts ? opts->progress_cb : NULL;
     void* ud = opts ? opts->user_data : NULL;
 
-    return zxc_stream_engine_run(f_in, f_out, n_threads, 0, 0, 0, checksum_enabled,
+    return zxc_stream_engine_run(f_in, f_out, n_threads, 0, 0, 0, checksum_enabled, 0,
                                  (zxc_chunk_processor_t)zxc_decompress_chunk_wrapper, cb, ud);
 }
 

--- a/lz/zxc/src/lib/zxc_internal.h
+++ b/lz/zxc/src/lib/zxc_internal.h
@@ -28,6 +28,7 @@
 
 #include <assert.h>
 #include <inttypes.h>
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -77,8 +78,12 @@ extern "C" {
  * - @c ZXC_USE_AVX2   - AVX2 available.
  * - @c ZXC_USE_NEON64 - AArch64 NEON available.
  * - @c ZXC_USE_NEON32 - ARMv7 NEON available.
+ *
+ * Define @c ZXC_DISABLE_SIMD to gate all hand-written SIMD paths (intrinsics,
+ * inline assembly).  Compiler auto-vectorisation is unaffected.
  * @{
  */
+#ifndef ZXC_DISABLE_SIMD
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 #include <immintrin.h>
 #include <nmmintrin.h>
@@ -108,6 +113,7 @@ extern "C" {
 #endif
 #endif
 #endif
+#endif    /* ZXC_DISABLE_SIMD */
 /** @} */ /* end of SIMD Intrinsics */
 
 /**
@@ -284,17 +290,13 @@ extern "C" {
 /** @brief Size of stdio I/O buffers (1 MB). */
 #define ZXC_IO_BUFFER_SIZE (1024 * 1024)
 /** @brief Maximum number of threads allowed for streaming operations. */
-#define ZXC_MAX_THREADS 1024
+#define ZXC_MAX_THREADS 512
 /** @brief Safety padding appended to buffers to tolerate overruns. */
 #define ZXC_PAD_SIZE 32
-/** @brief Number of bits per byte (constant 8). */
-#define ZXC_BITS_PER_BYTE 8
 /** @brief Assumed CPU cache line size for alignment. */
 #define ZXC_CACHE_LINE_SIZE 64
 /** @brief Bitmask for cache-line alignment checks. */
 #define ZXC_ALIGNMENT_MASK (ZXC_CACHE_LINE_SIZE - 1)
-/** @brief Maximum byte length of a variable-byte encoded integer. */
-#define ZXC_VBYTE_MAX_LEN 5
 /** @brief Allocation-safe max vbyte length (sufficient for < 2 MB blocks). */
 #define ZXC_VBYTE_ALLOC_LEN 3
 
@@ -333,13 +335,30 @@ extern "C" {
 /** @brief Number of sections in a GHI block. */
 #define ZXC_GHI_SECTIONS 3
 
-/** @brief Checksum algorithm id for rapidhash (default). */
-#define ZXC_CHECKSUM_RAPIDHASH 0x00U
+/** @brief Checksum algorithm id for RapidHash (default, sole implementation). */
+#define ZXC_CHECKSUM_RAPIDHASH 0
 
 /** @brief Size of the global checksum appended after EOF block (4 bytes). */
 #define ZXC_GLOBAL_CHECKSUM_SIZE 4
 /** @brief File footer size: original_size(8) + global_checksum(4). */
 #define ZXC_FILE_FOOTER_SIZE 12
+
+/** @name Seekable Format Constants
+ *  @brief Seek table block appended between EOF block and footer.
+ *
+ *  The seek table is optional (opt-in at compression time) and allows
+ *  random-access decompression by recording per-block compressed and
+ *  decompressed sizes.  It uses a standard ZXC block header with
+ *  @c block_type = @ref ZXC_BLOCK_SEK.
+ *
+ *  Detection from the end of the file: the reader derives @c num_blocks
+ *  from the file footer (total decompressed size) and file header (block size).
+ *  It then seeks backward to validate the SEK block header.
+ *  @{ */
+/** @brief Per-block entry size: comp_size(4) only.  decomp_size is derived
+ *  from the file header's block_size (all blocks except the last are full). */
+#define ZXC_SEEK_ENTRY_SIZE 4
+/** @} */ /* end of Seekable Format Constants */
 
 /** @name GLO Token Constants
  *  @brief 4-bit literal length / 4-bit match length / 16-bit offset.
@@ -382,13 +401,16 @@ extern "C" {
 /** @name LZ77 Constants
  *  @brief Hash table geometry, sliding window, and match parameters.
  *
- *  The hash table uses 14 bits for addressing (16 384 entries), doubled to
- *  keep the load factor below 0.5.  Each entry stores
- *  `(epoch << 18) | offset`, totalling 64 KB of memory.
+ *  The hash table uses a split layout with 15-bit addressing (32 768 buckets):
+ *  - `hash_positions[]`: uint32_t, stores `(epoch << offset_bits) | position` (128 KB).
+ *  - `hash_tags[]`:      uint8_t, stores an 8-bit tag for fast rejection (32 KB).
+ *  Total: 160 KB.  The tag table fits in L1 cache, enabling a
+ *  "filter-first" access pattern that avoids cold loads into hash_positions
+ *  on the ~60-75% of lookups where the tag mismatches.
  *  The 64 KB sliding window allows `chain_table` to use `uint16_t`.
  *  @{ */
-/** @brief Address bits for the LZ77 hash table (2^14 = 16 384 max). */
-#define ZXC_LZ_HASH_BITS 14
+/** @brief Address bits for the LZ77 hash table (2^15 = 32 768 buckets). */
+#define ZXC_LZ_HASH_BITS 15
 /** @brief Marsaglia multiplicative hash constant for 4-byte hashing. */
 #define ZXC_LZ_HASH_PRIME1 0x2D35182DU
 /** @brief Marsaglia/Vigna xorshift* multiplier for 5-byte hashing. */
@@ -403,15 +425,6 @@ extern "C" {
 #define ZXC_LZ_OFFSET_BIAS 1
 /** @brief Maximum allowed offset distance. */
 #define ZXC_LZ_MAX_DIST (ZXC_LZ_WINDOW_SIZE - 1)
-/**
- * @brief Number of bits reserved for epoch tracking in compressed pointers.
- * Derived from chunk size: 2^18 = ZXC_BLOCK_SIZE_DEFAULT => 32 - 18 = 14 bits.
- */
-#define ZXC_EPOCH_BITS 14
-/** @brief Mask to extract the offset bits from a compressed pointer. */
-#define ZXC_OFFSET_MASK ((1U << (32 - ZXC_EPOCH_BITS)) - 1)
-/** @brief Maximum number of epochs supported by the compression system. */
-#define ZXC_MAX_EPOCH (1U << ZXC_EPOCH_BITS)
 /** @} */
 
 /** @name Hash Prime Constants
@@ -432,10 +445,13 @@ extern "C" {
  * @param v Must be a power of two (undefined for zero).
  * @return Floor of log2(v).
  */
-static ZXC_ALWAYS_INLINE uint32_t zxc_log2_u32(uint32_t v) {
-    uint32_t r = 0;
-    while (v >>= 1) r++;
-    return r;
+static ZXC_ALWAYS_INLINE uint32_t zxc_log2_u32(const uint32_t v) {
+#ifdef _MSC_VER
+    unsigned long index;
+    return (v == 0) ? 0 : (_BitScanReverse(&index, v) ? index : 0);
+#else
+    return (v == 0) ? 0 : (uint32_t)(31 - __builtin_clz(v));
+#endif
 }
 
 /**
@@ -453,14 +469,46 @@ static ZXC_ALWAYS_INLINE int zxc_validate_block_size(const size_t bs) {
 /**
  * @struct zxc_lz77_params_t
  * @brief Search parameters for LZ77 compression levels.
+ *
+ * Each compression level maps to a specific set of parameters that control the
+ * trade-off between compression speed and ratio.  Higher search depths and lazy
+ * matching improve ratio at the expense of throughput; larger step values
+ * accelerate literal scanning but may miss short matches.
  */
 typedef struct {
-    int search_depth;    /**< Maximum number of matches to check in hash chain. */
-    int sufficient_len;  /**< Stop searching if match length >= this value. */
-    int use_lazy;        /**< Enable lazy matching (check next position for better match). */
-    int lazy_attempts;   /**< Maximum matches to check during lazy matching. */
-    uint32_t step_base;  /**< Base step size for literal advancement. */
-    uint32_t step_shift; /**< Shift amount for distance-based stepping. */
+    /** Maximum number of candidates explored in the hash chain per position.
+     *  Higher values find better matches but increase CPU cost linearly. */
+    int search_depth;
+
+    /** "Good enough" match length: once a match reaches this threshold the
+     *  chain walk stops immediately, avoiding wasted effort on an already
+     *  excellent match. */
+    int sufficient_len;
+
+    /** Enable lazy matching.  When set, after finding a match at position
+     *  @c ip the compressor probes @c ip+1 (and @c ip+2 for level >= 4) to
+     *  see if a longer match exists.  If so, a literal is emitted and the
+     *  better match is taken instead.  Improves ratio but costs extra work. */
+    int use_lazy;
+
+    /** Maximum number of candidates explored during lazy evaluation (same
+     *  semantics as @ref search_depth but applied to the ip+1 / ip+2 probes).
+     *  Only meaningful when @ref use_lazy is non-zero. */
+    int lazy_attempts;
+
+    /** Skip lazy evaluation when the current match length already reaches
+     *  this threshold: a match this long is unlikely to be beaten at the
+     *  next byte.  Set to 0 when @ref use_lazy is disabled. */
+    int lazy_len_threshold;
+
+    /** Base step size when advancing through unmatched literals.
+     *  1 = test every byte (best ratio), 4 = skip aggressively (fastest). */
+    uint32_t step_base;
+
+    /** Acceleration factor for step size: @c step = step_base + (distance >> step_shift).
+     *  A larger value keeps the step conservative (grows slowly with distance);
+     *  a smaller value ramps up quickly, skipping more in long literal runs. */
+    uint32_t step_shift;
 } zxc_lz77_params_t;
 
 /**
@@ -473,14 +521,15 @@ typedef struct {
  * @return zxc_lz77_params_t The LZ77 parameters structure corresponding to the specified level.
  */
 static ZXC_ALWAYS_INLINE zxc_lz77_params_t zxc_get_lz77_params(const int level) {
-    if (level >= 5) return (zxc_lz77_params_t){64, 256, 1, 16, 1, 31};
-    // search_depth, sufficient_len, use_lazy, lazy_attempts, step_base, step_shift
+    if (level >= 5) return (zxc_lz77_params_t){64, 256, 1, 16, 128, 1, 8};
+    // search_depth, sufficient_len, use_lazy, lazy_attempts, lazy_len_threshold, step_base,
+    // step_shift
     static const zxc_lz77_params_t table[5] = {
-        {4, 16, 0, 0, 4, 4},  // fallback
-        {4, 16, 0, 0, 4, 4},  // level 1
-        {6, 24, 0, 0, 3, 6},  // level 2
-        {3, 18, 1, 4, 1, 4},  // level 3
-        {3, 18, 1, 4, 1, 5}   // level 4
+        {3, 16, 0, 0, 0, 4, 4},    // fallback
+        {3, 16, 0, 0, 0, 4, 4},    // level 1
+        {3, 18, 0, 0, 0, 3, 6},    // level 2
+        {3, 16, 1, 4, 128, 1, 4},  // level 3
+        {3, 18, 1, 4, 128, 1, 5}   // level 4
     };
     return table[level < 1 ? 1 : level];
 }
@@ -500,6 +549,8 @@ static ZXC_ALWAYS_INLINE zxc_lz77_params_t zxc_get_lz77_params(const int level) 
  *   Uses Delta Encoding + ZigZag + Bitpacking.
  * - `ZXC_BLOCK_GHI` (3): General-purpose high-velocity mode using LZ77 with advanced
  * techniques (lazy matching, step skipping) for maximum ratio. Includes 3 sections descriptors.
+ * - `ZXC_BLOCK_SEK` (254): Seek table block. Contains per-block compressed/decompressed sizes
+ *   for random-access decompression. Placed between EOF block and file footer.
  * - `ZXC_BLOCK_EOF` (255): End of file marker.
  */
 typedef enum {
@@ -507,6 +558,7 @@ typedef enum {
     ZXC_BLOCK_GLO = 1,
     ZXC_BLOCK_NUM = 2,
     ZXC_BLOCK_GHI = 3,
+    ZXC_BLOCK_SEK = 254,
     ZXC_BLOCK_EOF = 255
 } zxc_block_type_t;
 
@@ -518,17 +570,8 @@ typedef enum {
  * or offsets) are stored within a block.
  * - `ZXC_SECTION_ENCODING_RAW`: Data is stored uncompressed.
  * - `ZXC_SECTION_ENCODING_RLE`: Run-Length Encoding.
- * - `ZXC_SECTION_ENCODING_BITPACK`: Bitpacking for integer values.
- * - `ZXC_SECTION_ENCODING_FSE`: Finite State Entropy (Reserved).
- * - `ZXC_SECTION_ENCODING_BITPACK_FSE`: Combined Bitpacking and FSE (Reserved).
  */
-typedef enum {
-    ZXC_SECTION_ENCODING_RAW = 0,
-    ZXC_SECTION_ENCODING_RLE = 1,
-    ZXC_SECTION_ENCODING_BITPACK = 2,
-    ZXC_SECTION_ENCODING_FSE = 3,         // Reserved
-    ZXC_SECTION_ENCODING_BITPACK_FSE = 4  // Reserved
-} zxc_section_encoding_t;
+typedef enum { ZXC_SECTION_ENCODING_RAW = 0, ZXC_SECTION_ENCODING_RLE = 1 } zxc_section_encoding_t;
 
 /**
  * @struct zxc_gnr_header_t
@@ -764,13 +807,13 @@ static ZXC_ALWAYS_INLINE uint8_t zxc_hash8(const uint8_t* p) {
  * @return uint16_t The computed hash value.
  */
 static ZXC_ALWAYS_INLINE uint16_t zxc_hash16(const uint8_t* p) {
-    const uint64_t h1 = zxc_le64(p);
-    const uint64_t h2 = zxc_le64(p + 8);
-    uint64_t h = h1 ^ h2 ^ ZXC_HASH_PRIME2;
+    const uint64_t v1 = zxc_le64(p);
+    const uint64_t v2 = zxc_le64(p + 8);
+    uint64_t h = v1 ^ v2 ^ ZXC_HASH_PRIME2;
     h ^= h << 13;
     h ^= h >> 7;
     h ^= h << 17;
-    uint32_t res = (uint32_t)((h >> 32) ^ h);
+    const uint32_t res = (uint32_t)((h >> 32) ^ h);
     return (uint16_t)((res >> 16) ^ res);
 }
 
@@ -866,8 +909,15 @@ static ZXC_ALWAYS_INLINE int zxc_ctz64(const uint64_t x) {
     unsigned long r;
     _BitScanForward64(&r, x);
     return (int)r;
+#elif defined(_MSC_VER)
+    // Use two 32-bit scans to avoid fragile 64-bit De Bruijn multiplication.
+    unsigned long r;
+    const uint32_t lo = (uint32_t)x;
+    if (_BitScanForward(&r, lo)) return (int)r;
+    _BitScanForward(&r, (uint32_t)(x >> 32));
+    return 32 + (int)r;
 #else
-    // Fallback De Bruijn
+    // Fallback De Bruijn for non-GCC/non-MSVC compilers
     static const int Debruijn64[64] = {
         0,  1,  48, 2,  57, 49, 28, 3,  61, 58, 50, 42, 38, 29, 17, 4,  62, 55, 59, 36, 53, 51,
         43, 22, 45, 39, 33, 30, 24, 18, 12, 5,  63, 47, 56, 27, 60, 41, 37, 16, 54, 35, 52, 21,
@@ -982,14 +1032,10 @@ void zxc_aligned_free(void* ptr);
  */
 static ZXC_ALWAYS_INLINE uint32_t zxc_checksum(const void* RESTRICT input, const size_t len,
                                                const uint8_t hash_method) {
-    uint64_t hash;
-    if (LIKELY(hash_method == ZXC_CHECKSUM_RAPIDHASH))
-        hash = rapidhash(input, len);
-    else
-        // Default fallthrough to rapidhash for unknown types (safe default)
-        hash = rapidhash(input, len);
+    (void)hash_method; /* single algorithm for now; extend when adding more */
+    const uint64_t hash = rapidhash(input, len);
 
-    return (uint32_t)(hash ^ (hash >> (sizeof(uint32_t) * ZXC_BITS_PER_BYTE)));
+    return (uint32_t)(hash ^ (hash >> (sizeof(uint32_t) * CHAR_BIT)));
 }
 
 /**
@@ -1025,7 +1071,7 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_hash_combine_rotate(const uint32_t hash,
 static ZXC_ALWAYS_INLINE uint64_t zxc_le_partial(const uint8_t* p, size_t n) {
 #ifdef ZXC_BIG_ENDIAN
     uint64_t v = 0;
-    for (size_t i = 0; i < n; i++) v |= (uint64_t)p[i] << (i * 8);
+    for (size_t i = 0; i < n; i++) v |= (uint64_t)p[i] << (i * CHAR_BIT);
     return v;
 #else
     uint64_t v = 0;
@@ -1053,11 +1099,11 @@ static ZXC_ALWAYS_INLINE void zxc_br_init(zxc_bit_reader_t* RESTRICT br,
     if (UNLIKELY(size < sizeof(uint64_t))) {
         br->accum = zxc_le_partial(src, size);
         br->ptr += size;
-        br->bits = (int)(size * 8);
+        br->bits = (int)(size * CHAR_BIT);
     } else {
         br->accum = zxc_le64(br->ptr);
         br->ptr += sizeof(uint64_t);
-        br->bits = sizeof(uint64_t) * 8;
+        br->bits = sizeof(uint64_t) * CHAR_BIT;
     }
 }
 
@@ -1078,16 +1124,16 @@ static ZXC_ALWAYS_INLINE void zxc_br_ensure(zxc_bit_reader_t* RESTRICT br, const
         br->bits = safe_bits;
 
         // Mask out garbage bits (retain only valid existing bits)
-#if defined(__BMI2__) && (defined(__x86_64__) || defined(_M_X64))
+#if !defined(ZXC_DISABLE_SIMD) && defined(__BMI2__) && (defined(__x86_64__) || defined(_M_X64))
         br->accum = _bzhi_u64(br->accum, safe_bits);
 #else
-        br->accum &= ((1ULL << safe_bits) - 1);
+        br->accum &= (safe_bits < 64) ? ((1ULL << safe_bits) - 1) : ~0ULL;
 #endif
 
         // Calculate how many bytes we can read
         // We want to fill up to the accumulation capability (64 bits for uint64_t)
         // Bytes needed = (capacity_bits - safe_bits) / 8
-        const int bytes_needed = ((int)(sizeof(uint64_t) * 8) - safe_bits) >> 3;
+        const int bytes_needed = ((int)(sizeof(uint64_t) * CHAR_BIT) - safe_bits) / CHAR_BIT;
 
         // Bounds check: zxc_le64 always reads 8 bytes, so we need at least 8
         const size_t bytes_left = (size_t)(br->end - br->ptr);
@@ -1096,15 +1142,15 @@ static ZXC_ALWAYS_INLINE void zxc_br_ensure(zxc_bit_reader_t* RESTRICT br, const
             const size_t to_read =
                 (bytes_left < (size_t)bytes_needed) ? bytes_left : (size_t)bytes_needed;
             const uint64_t raw = zxc_le_partial(br->ptr, to_read);
-            br->accum |= (raw << safe_bits);
+            br->accum |= (safe_bits < 64) ? (raw << safe_bits) : 0;
             br->ptr += to_read;
-            br->bits = safe_bits + (int)to_read * 8;
+            br->bits = safe_bits + (int)to_read * CHAR_BIT;
         } else {
             // Fast path: full 8-byte read is safe
             const uint64_t raw = zxc_le64(br->ptr);
-            br->accum |= (raw << safe_bits);
+            br->accum |= (safe_bits < 64) ? (raw << safe_bits) : 0;
             br->ptr += bytes_needed;
-            br->bits = safe_bits + bytes_needed * 8;
+            br->bits = safe_bits + bytes_needed * CHAR_BIT;
         }
     }
 }

--- a/lz/zxc/src/lib/zxc_seekable.c
+++ b/lz/zxc/src/lib/zxc_seekable.c
@@ -1,0 +1,908 @@
+/*
+ * ZXC - High-performance lossless compression
+ *
+ * Copyright (c) 2025-2026 Bertrand Lebonnois and contributors.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file zxc_seekable.c
+ * @brief Seekable archive reader (random-access decompression) and seek table writer.
+ *
+ * The seek table is a standard ZXC block (type = ZXC_BLOCK_SEK) appended
+ * between the EOF block and the file footer.  It records the compressed size
+ * of every block (decompressed sizes are derived from the header's block_size),
+ * enabling O(1) lookup + O(block_size) decompression for any byte range.
+ *
+ * On-disk layout of a SEK block:
+ *
+ *   [Block Header (8B)]   block_type=SEK, block_flags=0, comp_size=N*4
+ *   [N x Entry (4B)]      comp_size(u32 LE) per block
+ *
+ * Detection from end of file:
+ *   1. Read file header (first 16 bytes) => block_size
+ *   2. Read file footer (last 12 bytes) => total_decompressed_size
+ *   3. Derive num_blocks = ceil(total_decomp / block_size)
+ *   4. Compute seek block size, read backward to the block header
+ *   5. Validate block_type == ZXC_BLOCK_SEK
+ */
+
+#include "../../include/zxc_seekable.h"
+
+#include "../../include/zxc_error.h"
+#include "../../include/zxc_sans_io.h"
+#include "zxc_internal.h"
+
+/* ========================================================================= */
+/*  Platform Threading & I/O Layer                                           */
+/* ========================================================================= */
+
+// LCOV_EXCL_START - Windows platform layer, not reachable on POSIX CI
+#if defined(_WIN32)
+#include <io.h>      /* _get_osfhandle, _fileno */
+#include <process.h> /* _beginthreadex */
+#include <windows.h>
+
+/* MSVC does not provide fseeko/ftello - map to 64-bit equivalents */
+#if defined(_MSC_VER) && !defined(fseeko)
+#define fseeko _fseeki64
+#define ftello _ftelli64
+#endif
+
+/* Map POSIX threading primitives to Windows equivalents */
+typedef HANDLE zxc_thread_t;
+
+typedef struct {
+    void* (*func)(void*);
+    void* arg;
+} zxc_seek_thread_arg_t;
+
+static unsigned __stdcall zxc_seek_thread_entry(void* p) {
+    zxc_seek_thread_arg_t* a = (zxc_seek_thread_arg_t*)p;
+    void* (*f)(void*) = a->func;
+    void* arg = a->arg;
+    free(a);
+    f(arg);
+    return 0;
+}
+
+static int zxc_seek_thread_create(zxc_thread_t* t, void* (*fn)(void*), void* arg) {
+    zxc_seek_thread_arg_t* wrapper = malloc(sizeof(zxc_seek_thread_arg_t));
+    if (UNLIKELY(!wrapper)) return ZXC_ERROR_MEMORY;
+    wrapper->func = fn;
+    wrapper->arg = arg;
+    uintptr_t handle = _beginthreadex(NULL, 0, zxc_seek_thread_entry, wrapper, 0, NULL);
+    if (UNLIKELY(handle == 0)) {
+        free(wrapper);
+        return ZXC_ERROR_MEMORY;
+    }
+    *t = (HANDLE)handle;
+    return 0;
+}
+
+static void zxc_seek_thread_join(zxc_thread_t t) {
+    WaitForSingleObject(t, INFINITE);
+    CloseHandle(t);
+}
+
+static int zxc_seek_get_num_procs(void) {
+    SYSTEM_INFO si;
+    GetSystemInfo(&si);
+    return (int)si.dwNumberOfProcessors;
+}
+
+/**
+ * @brief Thread-safe positional read (Windows).
+ *
+ * Uses ReadFile + Overlapped to read at a specific offset without moving the
+ * file pointer, making it safe for concurrent access from multiple threads.
+ */
+static int zxc_seek_pread(HANDLE hFile, void* buf, size_t count, uint64_t offset) {
+    OVERLAPPED ov;
+    ZXC_MEMSET(&ov, 0, sizeof(ov));
+    ov.Offset = (DWORD)(offset & 0xFFFFFFFF);
+    ov.OffsetHigh = (DWORD)(offset >> 32);
+    DWORD bytes_read = 0;
+    if (!ReadFile(hFile, buf, (DWORD)count, &bytes_read, &ov)) return ZXC_ERROR_IO;
+    return (bytes_read == (DWORD)count) ? (int)count : ZXC_ERROR_IO;
+}
+// LCOV_EXCL_STOP
+
+#else /* POSIX */
+#include <pthread.h>
+#include <unistd.h>
+
+typedef pthread_t zxc_thread_t;
+
+static int zxc_seek_thread_create(zxc_thread_t* t, void* (*fn)(void*), void* arg) {
+    return pthread_create(t, NULL, fn, arg) == 0 ? 0 : ZXC_ERROR_MEMORY;
+}
+
+static void zxc_seek_thread_join(zxc_thread_t t) { pthread_join(t, NULL); }
+
+static int zxc_seek_get_num_procs(void) {
+    const long n = sysconf(_SC_NPROCESSORS_ONLN);
+    return (n > 0) ? (int)n : 1;
+}
+
+/**
+ * @brief Thread-safe positional read (POSIX).
+ *
+ * Uses pread() which reads at a given offset without modifying the file
+ * descriptor's current position, making it inherently thread-safe.
+ */
+static int zxc_seek_pread(int fd, void* buf, size_t count, uint64_t offset) {
+    const ssize_t r = pread(fd, buf, count, (off_t)offset);
+    return (r == (ssize_t)count) ? (int)count : ZXC_ERROR_IO;
+}
+
+#endif /* _WIN32 */
+
+/* ========================================================================= */
+/*  Seek Table Writer                                                        */
+/* ========================================================================= */
+
+size_t zxc_seek_table_size(const uint32_t num_blocks) {
+    return ZXC_BLOCK_HEADER_SIZE + (size_t)num_blocks * ZXC_SEEK_ENTRY_SIZE;
+}
+
+int64_t zxc_write_seek_table(uint8_t* dst, const size_t dst_capacity, const uint32_t* comp_sizes,
+                             const uint32_t num_blocks) {
+    if (UNLIKELY(num_blocks > UINT32_MAX / ZXC_SEEK_ENTRY_SIZE)) return ZXC_ERROR_OVERFLOW;
+
+    const size_t total = zxc_seek_table_size(num_blocks);
+    if (UNLIKELY(dst_capacity < total)) return ZXC_ERROR_DST_TOO_SMALL;
+    if (UNLIKELY(!dst || !comp_sizes)) return ZXC_ERROR_NULL_INPUT;
+
+    const uint32_t payload_size = num_blocks * ZXC_SEEK_ENTRY_SIZE;
+
+    /* Write standard ZXC block header */
+    const zxc_block_header_t bh = {
+        .block_type = ZXC_BLOCK_SEK, .block_flags = 0, .reserved = 0, .comp_size = payload_size};
+    const int hdr_res = zxc_write_block_header(dst, dst_capacity, &bh);
+    if (UNLIKELY(hdr_res < 0)) return hdr_res;
+    uint8_t* p = dst + hdr_res;
+
+    /* Write entries: comp_size(4) only */
+    for (uint32_t i = 0; i < num_blocks; i++) {
+        zxc_store_le32(p, comp_sizes[i]);
+        p += sizeof(uint32_t);
+    }
+
+    return (int64_t)(p - dst);
+}
+
+/* ========================================================================= */
+/*  Seekable Reader (Opaque Handle)                                          */
+/* ========================================================================= */
+
+struct zxc_seekable_s {
+    /* Source - exactly one is non-NULL */
+    const uint8_t* src;
+    uint64_t src_size;
+    FILE* file;
+
+    /* Native file descriptor for thread-safe pread() I/O */
+#if defined(_WIN32)
+    HANDLE native_handle; /* from GetOSFileHandle or _get_osfhandle */
+#else
+    int fd; /* from fileno() */
+#endif
+
+    /* Parsed seek table */
+    uint32_t num_blocks;
+    uint32_t* comp_sizes;   /* array[num_blocks] */
+    uint64_t* comp_offsets; /* prefix-sum: byte offset in compressed file per block */
+    uint64_t total_decomp;  /* total decompressed size (from footer) */
+
+    /* File header info - block_size is always a power of 2 in [4KB, 2MB],
+     * fits in 21 bits. */
+    uint32_t block_size;
+    int file_has_checksums;
+
+    /* Reusable decompression context (single-threaded path only) */
+    zxc_cctx_t dctx;
+    int dctx_initialized;
+};
+
+/**
+ * @brief Parses the seek table from raw bytes at the end of the archive.
+ *
+ * Detection (backward from end):
+ *   1. Read file header => block_size
+ *   2. Read file footer => total_decomp_size
+ *   3. Derive num_blocks = ceil(total_decomp_size / block_size)
+ *   4. Compute expected seek block position, validate block_type == SEK
+ *   5. Read comp_sizes; derive decomp_sizes from block_size
+ */
+static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_size) {
+    /* Minimum: file_header(16) + eof_block(8) + seek_block_header(8)
+     *          + file_footer(12) = 44 */
+    const size_t MIN_SEEKABLE_SIZE =
+        ZXC_FILE_HEADER_SIZE + ZXC_BLOCK_HEADER_SIZE + ZXC_BLOCK_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE;
+    if (UNLIKELY(data_size < MIN_SEEKABLE_SIZE)) return NULL;
+
+    /* Step 1: validate file header => block_size */
+    size_t block_size_sz = 0;
+    int file_has_chk = 0;
+    if (UNLIKELY(zxc_read_file_header(data, data_size, &block_size_sz, &file_has_chk) != ZXC_OK))
+        return NULL;
+    const uint32_t block_size = (uint32_t)block_size_sz;
+    if (UNLIKELY(block_size == 0)) return NULL;  // LCOV_EXCL_LINE
+
+    /* Step 2: read total decompressed size from the file footer */
+    const uint8_t* const footer_ptr = data + data_size - ZXC_FILE_FOOTER_SIZE;
+    const uint64_t total_decomp = zxc_le64(footer_ptr);
+
+    /* A value of 0 means empty file - no seek table */
+    if (UNLIKELY(total_decomp == 0)) return NULL;
+
+    /* Step 3: derive num_blocks = ceil(total_decomp / block_size) */
+    const uint64_t num_blocks_64 = (total_decomp + block_size - 1) / block_size;
+    if (UNLIKELY(num_blocks_64 > UINT32_MAX)) return NULL;
+    const uint32_t num_blocks = (uint32_t)num_blocks_64;
+
+    /* Step 4: compute seek block position and validate. */
+    const uint64_t entries_total_64 = num_blocks_64 * ZXC_SEEK_ENTRY_SIZE;
+    if (UNLIKELY(entries_total_64 > SIZE_MAX - ZXC_BLOCK_HEADER_SIZE)) return NULL;
+    const size_t entries_total = (size_t)entries_total_64;
+    const size_t seek_block_total = ZXC_BLOCK_HEADER_SIZE + entries_total;
+    if (UNLIKELY(seek_block_total + ZXC_FILE_FOOTER_SIZE > data_size)) return NULL;
+    const uint8_t* const seek_block_start =
+        data + data_size - ZXC_FILE_FOOTER_SIZE - seek_block_total;
+    if (UNLIKELY(seek_block_start < data)) return NULL;
+
+    /* Read and validate SEK block header */
+    zxc_block_header_t bh;
+    if (UNLIKELY(zxc_read_block_header(seek_block_start, seek_block_total, &bh) != ZXC_OK))
+        return NULL;
+    if (UNLIKELY(bh.block_type != ZXC_BLOCK_SEK)) return NULL;
+    if (UNLIKELY(bh.comp_size != (uint32_t)entries_total)) return NULL;
+
+    /* Step 5: allocate handle and parse entries */
+    zxc_seekable* const s = (zxc_seekable*)calloc(1, sizeof(zxc_seekable));
+    // LCOV_EXCL_START
+    if (UNLIKELY(!s)) return NULL;
+    // LCOV_EXCL_STOP
+
+    s->num_blocks = num_blocks;
+    s->block_size = block_size;
+    s->file_has_checksums = file_has_chk;
+    s->src = data;
+    s->src_size = (uint64_t)data_size;
+
+    /* Allocate arrays */
+    s->comp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
+    s->comp_offsets = (uint64_t*)calloc((size_t)num_blocks + 1, sizeof(uint64_t));
+    // LCOV_EXCL_START
+    if (UNLIKELY(!s->comp_sizes || !s->comp_offsets)) {
+        zxc_seekable_free(s);
+        return NULL;
+    }
+    // LCOV_EXCL_STOP
+    s->total_decomp = total_decomp;
+
+    /* Parse comp_sizes and build compressed prefix sums.
+     * Validate each comp_size against data_size to prevent prefix-sum overflow
+     * and out-of-bounds reads during decompression. */
+    const uint8_t* ep = seek_block_start + ZXC_BLOCK_HEADER_SIZE;
+    uint64_t comp_acc = ZXC_FILE_HEADER_SIZE; /* blocks start after file header */
+    for (uint32_t i = 0; i < num_blocks; i++) {
+        s->comp_sizes[i] = zxc_le32(ep);
+        ep += sizeof(uint32_t);
+
+        /* Reject entries below minimum (block header) or larger than the file */
+        if (UNLIKELY(s->comp_sizes[i] < ZXC_BLOCK_HEADER_SIZE ||
+                     s->comp_sizes[i] > (uint64_t)data_size)) {
+            zxc_seekable_free(s);
+            return NULL;
+        }
+        s->comp_offsets[i] = comp_acc;
+        comp_acc += s->comp_sizes[i];
+        /* Reject if cumulative offset exceeds file size (inconsistent table) */
+        if (UNLIKELY(comp_acc > (uint64_t)data_size)) {
+            zxc_seekable_free(s);
+            return NULL;
+        }
+    }
+    s->comp_offsets[num_blocks] = comp_acc;
+
+    /* Verify prefix-sum lands exactly at the EOF block position.
+     * Expected layout: [header 16][data blocks][EOF 8][SEK block][footer 12]
+     * So comp_acc (end of data blocks) + EOF(8) == seek_block_start. */
+    const uint64_t expected_eof_offset =
+        (uint64_t)(seek_block_start - data) - ZXC_BLOCK_HEADER_SIZE;
+    if (UNLIKELY(comp_acc != expected_eof_offset)) {
+        zxc_seekable_free(s);
+        return NULL;
+    }
+
+    /* Validate that an actual EOF block header exists at the computed offset */
+    if (UNLIKELY(comp_acc + ZXC_BLOCK_HEADER_SIZE > data_size)) {
+        zxc_seekable_free(s);
+        return NULL;
+    }
+    zxc_block_header_t eof_bh;
+    if (UNLIKELY(zxc_read_block_header(data + comp_acc, ZXC_BLOCK_HEADER_SIZE, &eof_bh) != ZXC_OK ||
+                 eof_bh.block_type != ZXC_BLOCK_EOF)) {
+        zxc_seekable_free(s);
+        return NULL;
+    }
+
+    return s;
+}
+
+zxc_seekable* zxc_seekable_open(const void* src, const size_t src_size) {
+    if (UNLIKELY(!src || src_size == 0)) return NULL;
+    return zxc_seekable_parse((const uint8_t*)src, src_size);
+}
+
+zxc_seekable* zxc_seekable_open_file(FILE* f) {
+    if (UNLIKELY(!f)) return NULL;
+
+    const long long saved_pos = ftello(f);
+    if (UNLIKELY(saved_pos < 0)) return NULL;  // LCOV_EXCL_LINE
+
+    // LCOV_EXCL_START
+    if (UNLIKELY(fseeko(f, 0, SEEK_END) != 0)) {
+        fseeko(f, saved_pos, SEEK_SET);
+        return NULL;
+    }
+    // LCOV_EXCL_STOP
+
+    const long long file_size = ftello(f);
+    // LCOV_EXCL_START
+    if (UNLIKELY(file_size <= 0)) {
+        fseeko(f, saved_pos, SEEK_SET);
+        return NULL;
+    }
+    // LCOV_EXCL_STOP
+
+    /* For simplicity and correctness: read the file into memory.
+     * The seek table parsing needs the file header. */
+    if ((size_t)file_size <= 64 * 1024 * 1024) {
+        /* File <= 64 MB: read it all into memory */
+        uint8_t* const full = (uint8_t*)malloc((size_t)file_size);
+        // LCOV_EXCL_START
+        if (UNLIKELY(!full)) {
+            fseeko(f, saved_pos, SEEK_SET);
+            return NULL;
+        }
+        if (UNLIKELY(fseeko(f, 0, SEEK_SET) != 0 ||
+                     fread(full, 1, (size_t)file_size, f) != (size_t)file_size)) {
+            free(full);
+            fseeko(f, saved_pos, SEEK_SET);
+            return NULL;
+        }
+        // LCOV_EXCL_STOP
+        fseeko(f, saved_pos, SEEK_SET);
+        zxc_seekable* const s = zxc_seekable_parse(full, (size_t)file_size);
+        if (s) {
+            s->src = NULL;
+            s->src_size = (uint64_t)file_size;
+            s->file = f;
+#if defined(_WIN32)
+            s->native_handle = (HANDLE)(intptr_t)_get_osfhandle(_fileno(f));
+#else
+            s->fd = fileno(f);
+#endif
+        }
+        free(full);
+        return s;
+    }
+
+    // LCOV_EXCL_START - large file path (>64MB), not reachable in unit tests
+    /* Large file: read header + footer separately */
+    uint8_t header[ZXC_FILE_HEADER_SIZE];
+    if (UNLIKELY(fseeko(f, 0, SEEK_SET) != 0 ||
+                 fread(header, 1, ZXC_FILE_HEADER_SIZE, f) != ZXC_FILE_HEADER_SIZE)) {
+        fseeko(f, saved_pos, SEEK_SET);
+        return NULL;
+    }
+
+    size_t bs_sz = 0;
+    int fhc = 0;
+    if (UNLIKELY(zxc_read_file_header(header, ZXC_FILE_HEADER_SIZE, &bs_sz, &fhc) != ZXC_OK)) {
+        fseeko(f, saved_pos, SEEK_SET);
+        return NULL;
+    }
+    const uint32_t bs = (uint32_t)bs_sz;
+
+    /* Read footer (12 bytes) to get total_decomp_size */
+    uint8_t footer_buf[ZXC_FILE_FOOTER_SIZE];
+    if (UNLIKELY(fseeko(f, file_size - (long long)ZXC_FILE_FOOTER_SIZE, SEEK_SET) != 0 ||
+                 fread(footer_buf, 1, ZXC_FILE_FOOTER_SIZE, f) != ZXC_FILE_FOOTER_SIZE)) {
+        fseeko(f, saved_pos, SEEK_SET);
+        return NULL;
+    }
+
+    const uint64_t total_decomp = zxc_le64(footer_buf);
+    if (UNLIKELY(total_decomp == 0)) {
+        fseeko(f, saved_pos, SEEK_SET);
+        return NULL;
+    }
+
+    /* Derive num_blocks = ceil(total_decomp / block_size).
+     * Guard against uint32_t overflow. */
+    const uint64_t num_blocks_64 = (total_decomp + bs - 1) / bs;
+    if (UNLIKELY(num_blocks_64 > UINT32_MAX)) {
+        fseeko(f, saved_pos, SEEK_SET);
+        return NULL;
+    }
+    const uint32_t num_blocks = (uint32_t)num_blocks_64;
+
+    /* Guard against size_t multiplication overflow. */
+    const uint64_t entries_total_64 = (uint64_t)num_blocks * ZXC_SEEK_ENTRY_SIZE;
+    if (UNLIKELY(entries_total_64 > SIZE_MAX - ZXC_BLOCK_HEADER_SIZE)) {
+        fseeko(f, saved_pos, SEEK_SET);
+        return NULL;
+    }
+
+    /* Read the full seek block */
+    const size_t seek_block_total = ZXC_BLOCK_HEADER_SIZE + (size_t)entries_total_64;
+    uint8_t* const seek_buf = (uint8_t*)malloc(seek_block_total);
+    if (UNLIKELY(!seek_buf)) {
+        fseeko(f, saved_pos, SEEK_SET);
+        return NULL;
+    }
+
+    const long long seek_offset =
+        file_size - (long long)ZXC_FILE_FOOTER_SIZE - (long long)seek_block_total;
+    if (UNLIKELY(seek_offset < 0 || fseeko(f, seek_offset, SEEK_SET) != 0 ||
+                 fread(seek_buf, 1, seek_block_total, f) != seek_block_total)) {
+        free(seek_buf);
+        fseeko(f, saved_pos, SEEK_SET);
+        return NULL;
+    }
+    fseeko(f, saved_pos, SEEK_SET);
+
+    /* Validate block header */
+    zxc_block_header_t bh;
+    if (UNLIKELY(zxc_read_block_header(seek_buf, seek_block_total, &bh) != ZXC_OK) ||
+        bh.block_type != ZXC_BLOCK_SEK || bh.comp_size != (uint32_t)entries_total_64) {
+        free(seek_buf);
+        return NULL;
+    }
+
+    /* Build seekable handle */
+    zxc_seekable* const s = (zxc_seekable*)calloc(1, sizeof(zxc_seekable));
+    if (UNLIKELY(!s)) {
+        free(seek_buf);
+        return NULL;
+    }
+
+    s->file = f;
+    s->src = NULL;
+#if defined(_WIN32)
+    s->native_handle = (HANDLE)(intptr_t)_get_osfhandle(_fileno(f));
+#else
+    s->fd = fileno(f);
+#endif
+    s->src_size = (uint64_t)file_size;
+    s->num_blocks = num_blocks;
+    s->block_size = bs;
+    s->file_has_checksums = fhc;
+
+    s->comp_sizes = (uint32_t*)calloc(num_blocks, sizeof(uint32_t));
+    s->comp_offsets = (uint64_t*)calloc((size_t)num_blocks + 1, sizeof(uint64_t));
+    if (UNLIKELY(!s->comp_sizes || !s->comp_offsets)) {
+        free(seek_buf);
+        zxc_seekable_free(s);
+        return NULL;
+    }
+    s->total_decomp = total_decomp;
+
+    const uint8_t* ep = seek_buf + ZXC_BLOCK_HEADER_SIZE;
+    uint64_t comp_acc = ZXC_FILE_HEADER_SIZE;
+    for (uint32_t i = 0; i < num_blocks; i++) {
+        s->comp_sizes[i] = zxc_le32(ep);
+        ep += sizeof(uint32_t);
+
+        /* Reject entries larger than the entire file */
+        if (UNLIKELY(s->comp_sizes[i] > (uint64_t)file_size)) {
+            free(seek_buf);
+            zxc_seekable_free(s);
+            return NULL;
+        }
+        s->comp_offsets[i] = comp_acc;
+        comp_acc += s->comp_sizes[i];
+    }
+    s->comp_offsets[num_blocks] = comp_acc;
+
+    free(seek_buf);
+    return s;
+    // LCOV_EXCL_STOP
+}
+
+uint32_t zxc_seekable_get_num_blocks(const zxc_seekable* s) { return s ? s->num_blocks : 0; }
+
+uint64_t zxc_seekable_get_decompressed_size(const zxc_seekable* s) {
+    return s ? s->total_decomp : 0;
+}
+
+uint32_t zxc_seekable_get_block_comp_size(const zxc_seekable* s, const uint32_t block_idx) {
+    if (UNLIKELY(!s || block_idx >= s->num_blocks)) return 0;
+    return s->comp_sizes[block_idx];
+}
+
+uint32_t zxc_seekable_get_block_decomp_size(const zxc_seekable* s, const uint32_t block_idx) {
+    if (UNLIKELY(!s || block_idx >= s->num_blocks)) return 0;
+    const uint64_t start = (uint64_t)block_idx * (uint64_t)s->block_size;
+    const uint64_t remaining = s->total_decomp - start;
+    return (remaining >= (uint64_t)s->block_size) ? s->block_size : (uint32_t)remaining;
+}
+
+/* ========================================================================= */
+/*  Random-Access Decompression                                              */
+/* ========================================================================= */
+
+/** @brief O(1) block lookup: block_index = offset / block_size. */
+static uint32_t zxc_seek_find_block(const uint32_t block_size, const uint64_t offset) {
+    return (uint32_t)(offset / (uint64_t)block_size);
+}
+
+/** @brief O(1) decompressed offset for block @p idx. */
+static uint64_t zxc_seek_decomp_offset(const uint32_t block_size, const uint32_t idx) {
+    return (uint64_t)idx * (uint64_t)block_size;
+}
+
+/** @brief O(1) decompressed size for block @p idx. */
+static uint32_t zxc_seek_decomp_size(const uint32_t block_size, const uint64_t total_decomp,
+                                     const uint32_t idx) {
+    const uint64_t start = (uint64_t)idx * (uint64_t)block_size;
+    const uint64_t remaining = total_decomp - start;
+    return (remaining >= (uint64_t)block_size) ? block_size : (uint32_t)remaining;
+}
+
+/**
+ * @brief Reads a compressed block from buffer or file.
+ */
+static int zxc_seek_read_block(const zxc_seekable* s, const uint32_t block_idx, uint8_t* buf,
+                               const size_t buf_cap) {
+    const uint64_t off = s->comp_offsets[block_idx];
+    const uint32_t csz = s->comp_sizes[block_idx];
+    if (UNLIKELY(csz > buf_cap)) return ZXC_ERROR_DST_TOO_SMALL;
+
+    if (s->src) {
+        /* Buffer mode */
+        if (UNLIKELY(off + csz > s->src_size)) return ZXC_ERROR_SRC_TOO_SMALL;
+        ZXC_MEMCPY(buf, s->src + off, csz);
+    } else if (s->file) {
+        /* File mode */
+        // LCOV_EXCL_START
+        if (UNLIKELY(fseeko(s->file, (long long)off, SEEK_SET) != 0 ||
+                     fread(buf, 1, csz, s->file) != csz))
+            return ZXC_ERROR_IO;
+        // LCOV_EXCL_STOP
+    } else {
+        return ZXC_ERROR_NULL_INPUT;  // LCOV_EXCL_LINE
+    }
+    return (int)csz;
+}
+
+int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t dst_capacity,
+                                      const uint64_t offset, const size_t len) {
+    if (UNLIKELY(!s || !dst)) return ZXC_ERROR_NULL_INPUT;
+    if (UNLIKELY(len == 0)) return 0;
+    if (UNLIKELY(dst_capacity < len)) return ZXC_ERROR_DST_TOO_SMALL;
+    if (UNLIKELY(offset + len > s->total_decomp)) return ZXC_ERROR_SRC_TOO_SMALL;
+
+    /* Initialize decompression context on first use */
+    if (!s->dctx_initialized) {
+        // LCOV_EXCL_START
+        if (UNLIKELY(zxc_cctx_init(&s->dctx, (size_t)s->block_size, 0, 0, 0) != ZXC_OK))
+            return ZXC_ERROR_MEMORY;
+        // LCOV_EXCL_STOP
+        s->dctx_initialized = 1;
+    }
+
+    /* Ensure work buffer is large enough */
+    const size_t work_sz = (size_t)s->block_size + ZXC_PAD_SIZE;
+    if (s->dctx.work_buf_cap < work_sz) {
+        free(s->dctx.work_buf);
+        s->dctx.work_buf = (uint8_t*)malloc(work_sz);
+        if (UNLIKELY(!s->dctx.work_buf)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
+        s->dctx.work_buf_cap = work_sz;
+    }
+
+    /* Find block range - O(1) division */
+    const uint32_t blk_start = zxc_seek_find_block(s->block_size, offset);
+    const uint32_t blk_end = zxc_seek_find_block(s->block_size, offset + len - 1);
+
+    uint8_t* out = (uint8_t*)dst;
+    size_t remaining = len;
+
+    /* Allocate read buffer for compressed blocks */
+    size_t max_comp = 0;
+    for (uint32_t bi = blk_start; bi <= blk_end; bi++) {
+        if (s->comp_sizes[bi] > max_comp) max_comp = s->comp_sizes[bi];
+    }
+    uint8_t* const read_buf = (uint8_t*)malloc(max_comp + ZXC_PAD_SIZE);
+    if (UNLIKELY(!read_buf)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
+
+    for (uint32_t bi = blk_start; bi <= blk_end; bi++) {
+        /* Read compressed block data */
+        const int read_res = zxc_seek_read_block(s, bi, read_buf, max_comp + ZXC_PAD_SIZE);
+        if (UNLIKELY(read_res < 0)) {
+            free(read_buf);
+            return read_res;
+        }
+
+        /* Decompress the block */
+        const int dec_res = zxc_decompress_chunk_wrapper(&s->dctx, read_buf, (size_t)read_res,
+                                                         s->dctx.work_buf, work_sz);
+        if (UNLIKELY(dec_res < 0)) {
+            free(read_buf);
+            return dec_res;
+        }
+
+        /* Calculate which portion of this block's decompressed data we need */
+        const uint64_t blk_decomp_start = zxc_seek_decomp_offset(s->block_size, bi);
+        const size_t skip = (offset > blk_decomp_start) ? (size_t)(offset - blk_decomp_start) : 0;
+        if (UNLIKELY((size_t)dec_res < skip)) {
+            free(read_buf);
+            return ZXC_ERROR_CORRUPT_DATA;
+        }
+        const size_t avail = (size_t)dec_res - skip;
+        const size_t copy = (avail < remaining) ? avail : remaining;
+
+        ZXC_MEMCPY(out, s->dctx.work_buf + skip, copy);
+        out += copy;
+        remaining -= copy;
+    }
+
+    free(read_buf);
+    return (int64_t)len;
+}
+
+/* ========================================================================= */
+/*  Multi-Threaded Random-Access Decompression (Fork-Join)                   */
+/* ========================================================================= */
+
+/**
+ * @brief Per-block job descriptor for multi-threaded decompression.
+ *
+ * Each worker thread receives a pointer to one of these, performs the read +
+ * decompress + memcpy sequence, and writes the result code into @c result.
+ * The main thread inspects @c result after join.
+ */
+typedef struct {
+    const zxc_seekable* s; /* shared handle (read-only) */
+    uint32_t block_idx;    /* block to decompress */
+    uint8_t* dst;          /* output pointer within caller's buffer */
+    size_t skip;           /* bytes to skip at start of decompressed block */
+    size_t copy_len;       /* bytes to copy into dst */
+    int result;            /* 0 = OK, < 0 = error */
+} zxc_seek_mt_job_t;
+
+/**
+ * @brief Thread-safe block read using pread (for file mode) or memcpy (buffer mode).
+ */
+static int zxc_seek_read_block_mt(const zxc_seekable* s, const uint32_t block_idx, uint8_t* buf,
+                                  const size_t buf_cap) {
+    const uint64_t off = s->comp_offsets[block_idx];
+    const uint32_t csz = s->comp_sizes[block_idx];
+    if (UNLIKELY(csz > buf_cap)) return ZXC_ERROR_DST_TOO_SMALL;
+
+    if (s->src) {
+        /* Buffer mode - memcpy is inherently thread-safe on const data */
+        if (UNLIKELY(off + csz > s->src_size)) return ZXC_ERROR_SRC_TOO_SMALL;
+        ZXC_MEMCPY(buf, s->src + off, csz);
+    } else if (s->file) {
+        /* File mode - use pread for concurrent, lock-free reads */
+#if defined(_WIN32)
+        const int r = zxc_seek_pread(s->native_handle, buf, csz, off);
+#else
+        const int r = zxc_seek_pread(s->fd, buf, csz, off);
+#endif
+        if (UNLIKELY(r < 0)) return r;
+    } else {
+        return ZXC_ERROR_NULL_INPUT;  // LCOV_EXCL_LINE
+    }
+    return (int)csz;
+}
+
+/**
+ * @brief Worker thread entry point for multi-threaded seekable decompression.
+ *
+ * Each worker:
+ *   1. Allocates a thread-local decompression context.
+ *   2. Reads the compressed block via pread (thread-safe).
+ *   3. Decompresses into a local work buffer.
+ *   4. Copies the requested sub-range into the caller's output buffer.
+ */
+static void* zxc_seek_mt_worker(void* arg) {
+    zxc_seek_mt_job_t* const job = (zxc_seek_mt_job_t*)arg;
+    const zxc_seekable* const s = job->s;
+    const uint32_t bi = job->block_idx;
+
+    /* Thread-local decompression context (mode=0 for decompress-only) */
+    zxc_cctx_t dctx;
+    // LCOV_EXCL_START
+    if (UNLIKELY(zxc_cctx_init(&dctx, (size_t)s->block_size, 0, 0, 0) != ZXC_OK)) {
+        job->result = ZXC_ERROR_MEMORY;
+        return NULL;
+    }
+    // LCOV_EXCL_STOP
+
+    /* Allocate work buffer for decompressed output */
+    const size_t work_sz = (size_t)s->block_size + ZXC_PAD_SIZE;
+    dctx.work_buf = (uint8_t*)malloc(work_sz);
+    // LCOV_EXCL_START
+    if (UNLIKELY(!dctx.work_buf)) {
+        zxc_cctx_free(&dctx);
+        job->result = ZXC_ERROR_MEMORY;
+        return NULL;
+    }
+    // LCOV_EXCL_STOP
+    dctx.work_buf_cap = work_sz;
+
+    /* Read compressed block */
+    const uint32_t csz = s->comp_sizes[bi];
+    uint8_t* const read_buf = (uint8_t*)malloc(csz + ZXC_PAD_SIZE);
+    // LCOV_EXCL_START
+    if (UNLIKELY(!read_buf)) {
+        zxc_cctx_free(&dctx);
+        job->result = ZXC_ERROR_MEMORY;
+        return NULL;
+    }
+    // LCOV_EXCL_STOP
+
+    const int read_res = zxc_seek_read_block_mt(s, bi, read_buf, csz + ZXC_PAD_SIZE);
+    // LCOV_EXCL_START
+    if (UNLIKELY(read_res < 0)) {
+        free(read_buf);
+        zxc_cctx_free(&dctx);
+        job->result = read_res;
+        return NULL;
+    }
+    // LCOV_EXCL_STOP
+
+    /* Decompress */
+    const int dec_res =
+        zxc_decompress_chunk_wrapper(&dctx, read_buf, (size_t)read_res, dctx.work_buf, work_sz);
+    free(read_buf);
+
+    // LCOV_EXCL_START
+    if (UNLIKELY(dec_res < 0)) {
+        zxc_cctx_free(&dctx);
+        job->result = dec_res;
+        return NULL;
+    }
+    if (UNLIKELY((size_t)dec_res < job->skip + job->copy_len)) {
+        zxc_cctx_free(&dctx);
+        job->result = ZXC_ERROR_CORRUPT_DATA;
+        return NULL;
+    }
+    // LCOV_EXCL_STOP
+
+    /* Copy the requested portion directly into the caller's output buffer */
+    ZXC_MEMCPY(job->dst, dctx.work_buf + job->skip, job->copy_len);
+
+    zxc_cctx_free(&dctx);
+    job->result = 0;
+    return NULL;
+}
+
+int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_t dst_capacity,
+                                         const uint64_t offset, const size_t len, int n_threads) {
+    if (UNLIKELY(!s || !dst)) return ZXC_ERROR_NULL_INPUT;
+    if (UNLIKELY(len == 0)) return 0;
+    if (UNLIKELY(dst_capacity < len)) return ZXC_ERROR_DST_TOO_SMALL;
+    if (UNLIKELY(offset + len > s->total_decomp)) return ZXC_ERROR_SRC_TOO_SMALL;
+
+    /* Find block range - O(1) division */
+    const uint32_t blk_start = zxc_seek_find_block(s->block_size, offset);
+    const uint32_t blk_end = zxc_seek_find_block(s->block_size, offset + len - 1);
+    const uint32_t num_jobs = blk_end - blk_start + 1;
+
+    /* Auto-detect thread count (0 = use all available cores) */
+    if (n_threads == 0) n_threads = zxc_seek_get_num_procs();
+
+    /* Fallback to single-threaded path for trivial cases */
+    if (n_threads <= 1 || num_jobs <= 1) {
+        return zxc_seekable_decompress_range(s, dst, dst_capacity, offset, len);
+    }
+
+    /* Cap threads to number of blocks and max limit */
+    if ((uint32_t)n_threads > num_jobs) n_threads = (int)num_jobs;
+    if (n_threads > ZXC_MAX_THREADS) n_threads = ZXC_MAX_THREADS;
+
+    /* Allocate job descriptors */
+    zxc_seek_mt_job_t* const jobs = (zxc_seek_mt_job_t*)calloc(num_jobs, sizeof(zxc_seek_mt_job_t));
+    if (UNLIKELY(!jobs)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
+
+    /* Plan jobs: compute skip, copy_len, and dst pointer for each block */
+    uint8_t* out = (uint8_t*)dst;
+    size_t remaining = len;
+    for (uint32_t i = 0; i < num_jobs; i++) {
+        const uint32_t bi = blk_start + i;
+        const uint64_t blk_decomp_start = zxc_seek_decomp_offset(s->block_size, bi);
+        const size_t skip = (offset > blk_decomp_start) ? (size_t)(offset - blk_decomp_start) : 0;
+        const size_t blk_decomp_sz = zxc_seek_decomp_size(s->block_size, s->total_decomp, bi);
+        if (UNLIKELY(blk_decomp_sz < skip)) {
+            free(jobs);
+            return ZXC_ERROR_CORRUPT_DATA;
+        }
+        const size_t avail = blk_decomp_sz - skip;
+        const size_t copy = (avail < remaining) ? avail : remaining;
+
+        jobs[i].s = s;
+        jobs[i].block_idx = bi;
+        jobs[i].dst = out;
+        jobs[i].skip = skip;
+        jobs[i].copy_len = copy;
+        jobs[i].result = 0;
+
+        out += copy;
+        remaining -= copy;
+    }
+
+    /* Launch worker threads (fork phase) */
+    zxc_thread_t* const threads = (zxc_thread_t*)malloc((size_t)n_threads * sizeof(zxc_thread_t));
+    // LCOV_EXCL_START
+    if (UNLIKELY(!threads)) {
+        free(jobs);
+        return ZXC_ERROR_MEMORY;
+    }
+    // LCOV_EXCL_STOP
+
+    /*
+     * Distribute jobs across threads round-robin style.
+     * If num_jobs > n_threads, some threads handle multiple blocks sequentially.
+     * We process jobs in waves: spawn n_threads at a time, join, repeat.
+     */
+    int error = 0;
+    uint32_t job_idx = 0;
+
+    while (job_idx < num_jobs && !error) {
+        const int wave_size =
+            ((int)(num_jobs - job_idx) < n_threads) ? (int)(num_jobs - job_idx) : n_threads;
+
+        int launched = 0;
+        for (int t = 0; t < wave_size; t++) {
+            // LCOV_EXCL_START
+            if (zxc_seek_thread_create(&threads[t], zxc_seek_mt_worker, &jobs[job_idx + t]) != 0) {
+                /* Failed to create thread - mark remaining jobs as errors */
+                for (uint32_t j = job_idx + (uint32_t)t; j < num_jobs; j++)
+                    jobs[j].result = ZXC_ERROR_MEMORY;
+                error = 1;
+                break;
+            }
+            // LCOV_EXCL_STOP
+            launched++;
+        }
+
+        /* Join phase */
+        for (int t = 0; t < launched; t++) {
+            zxc_seek_thread_join(threads[t]);
+            if (jobs[job_idx + t].result < 0) error = 1;
+        }
+
+        job_idx += (uint32_t)launched;
+    }
+
+    free(threads);
+
+    /* Check for errors */
+    int64_t result = (int64_t)len;
+    if (error) {
+        for (uint32_t i = 0; i < num_jobs; i++) {
+            if (jobs[i].result < 0) {
+                result = (int64_t)jobs[i].result;
+                break;
+            }
+        }
+    }
+
+    free(jobs);
+    return result;
+}
+
+void zxc_seekable_free(zxc_seekable* s) {
+    if (!s) return;
+    if (s->dctx_initialized) zxc_cctx_free(&s->dctx);
+    free(s->comp_sizes);
+    free(s->comp_offsets);
+    free(s);
+}


### PR DESCRIPTION
- Update zxc to v0.10.0
- Enable bmi and lzcnt instructions for zxc on x86_64
- Include the zxc_seekable.o object file in the ZXC_FILES list in the Makefile to ensure all necessary components are built for the zxc codec.