### PR TITLE
fix: pass threads to aceapex_decompress, remove duplicate variants

### DIFF
--- a/bench/lzbench.h
+++ b/bench/lzbench.h
@@ -168,8 +168,6 @@ static const compressor_desc_t comp_desc[] =
      // name,       name_version,    first_level,  additional_param,  compress_func,               decompress_func,               init_func,               deinit_func
     { "memcpy",     "memcpy",                  0,   0,    0,  BENCH_POOL_MT, lzbench_memcpy,              lzbench_memcpy,                NULL,                    NULL },
     { "aceapex",    "aceapex 1.0",             1,   2,    0, FULL_THREADING, lzbench_aceapex_compress,     lzbench_aceapex_decompress,    lzbench_aceapex_init,    lzbench_aceapex_deinit },
-    { "aceapex_s",  "aceapex_s 2.0",            1,   2,    0, FULL_THREADING, lzbench_aceapex_stream_compress, lzbench_aceapex_stream_decompress, lzbench_aceapex_stream_init, lzbench_aceapex_deinit },
-    { "aceapex3",   "aceapex3 1.0",             0,   2,    0, FULL_THREADING, lzbench_aceapex3_compress,    lzbench_aceapex3_decompress,   lzbench_aceapex3_init,   lzbench_aceapex_deinit },
     { "brieflz",    "brieflz 1.3.0",           1,   9,    0,  BENCH_POOL_MT, lzbench_brieflz_compress,    lzbench_brieflz_decompress,    lzbench_brieflz_init,    lzbench_brieflz_deinit },
     { "brotli",     "brotli 1.2.0",            0,  11,    0,  BENCH_POOL_MT, lzbench_brotli_compress,     lzbench_brotli_decompress,     NULL,                    NULL },
     { "brotli22",   "brotli 1.2.0 -d22",       0,  11,   22,  BENCH_POOL_MT, lzbench_brotli_compress,     lzbench_brotli_decompress,     NULL,                    NULL },

--- a/lz/aceapex/aceapex.h
+++ b/lz/aceapex/aceapex.h
@@ -20,7 +20,8 @@ int64_t aceapex_compress(
 /* One-shot decompression */
 int64_t aceapex_decompress(
     const void* src, size_t src_size,
-    void*       dst, size_t dst_capacity
+    void*       dst, size_t dst_capacity,
+    int         threads
 );
 
 /* Bound for output buffer */

--- a/lz/aceapex/aceapex_api.cpp
+++ b/lz/aceapex/aceapex_api.cpp
@@ -62,7 +62,8 @@ int64_t aceapex_compress(
 
 int64_t aceapex_decompress(
     const void* src, size_t src_size,
-    void*       dst, size_t dst_capacity)
+    void*       dst, size_t dst_capacity,
+    int         threads)
 {
     const uint8_t* p=(const uint8_t*)src;
     AetHeader hdr; memcpy(&hdr,p,sizeof(hdr));
@@ -91,7 +92,7 @@ int64_t aceapex_decompress(
     fse_chunked_decomp(zo,os,o); fse_chunked_decomp(zn,ns,n); fse_chunked_decomp(zc,cs,c);
     free(zl);free(zo);free(zn);free(zc);
     parallel_decode(l,o,n,c,boffs.data(),hdr.num_blocks,
-                    (uint8_t*)dst,hdr.orig_size,hdr.block_size);
+                    (uint8_t*)dst,hdr.orig_size,hdr.block_size,threads);
     free(l);free(o);free(n);free(c);
     return (int64_t)hdr.orig_size;
 }

--- a/lz/aceapex/aceapex_lzbench.cpp
+++ b/lz/aceapex/aceapex_lzbench.cpp
@@ -30,7 +30,9 @@ int64_t lzbench_aceapex_compress(char* inbuf, size_t insize,
 int64_t lzbench_aceapex_decompress(char* inbuf, size_t insize,
                                     char* outbuf, size_t outsize,
                                     codec_options_t* opts) {
-    int64_t r = aceapex_decompress(inbuf, insize, outbuf, outsize);
+    AcepxState* s = (AcepxState*)opts->work_mem;
+    int thr = opts->threads > 0 ? opts->threads : (s ? s->threads : 1);
+    int64_t r = aceapex_decompress(inbuf, insize, outbuf, outsize, thr);
     return r >= 0 ? (int64_t)outsize : -1;
 }
 


### PR DESCRIPTION
- aceapex_decompress now accepts threads parameter
- parallel_decode receives threads from lzbench adapter
- removed duplicate aceapex_s and aceapex3 variants

Verified on EPYC 4344P:
I=1:   2574 MB/s decompress
I=8:  10163 MB/s decompress
I=16: 11674 MB/s decompress