### PR TITLE
Update zxc to v0.11.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 v2.x.y (work in progress)
 - updated tamp to 2.1.0 (thanks to @tansy)
 - added memlz 0.2 beta (thanks to @rrrlasse)
-- added zxc 0.10.0 (thanks to @hellobertrand)
+- added zxc 0.11.0 (thanks to @hellobertrand)
 - updated brotli to 1.2.0 (thanks to @data-man)
 - updated glza to v0.12 (thanks to @tansy)
 - updated kanzi to 2.5.1 (thanks to @flanglet)

--- a/Makefile
+++ b/Makefile
@@ -543,18 +543,19 @@ ifeq "$(DONT_BUILD_ZXC)" "1"
 else
     DEFINES += -DZXC_STATIC_DEFINE
     ZXC_DIR = lz/zxc/src/lib
-    ZXC_FILES = $(ZXC_DIR)/zxc_common.o $(ZXC_DIR)/zxc_driver.o $(ZXC_DIR)/zxc_dispatch.o $(ZXC_DIR)/zxc_seekable.o
-    ZXC_FILES += $(ZXC_DIR)/zxc_compress_default.o $(ZXC_DIR)/zxc_decompress_default.o
+    ZXC_FILES = $(ZXC_DIR)/zxc_common.o $(ZXC_DIR)/zxc_driver.o $(ZXC_DIR)/zxc_dispatch.o $(ZXC_DIR)/zxc_pstream.o $(ZXC_DIR)/zxc_seekable.o
+    ZXC_FILES += $(ZXC_DIR)/zxc_compress_default.o $(ZXC_DIR)/zxc_decompress_default.o $(ZXC_DIR)/zxc_huffman_default.o
 
     ifneq (,$(filter x86_64% amd64% i%86%,$(TARGET_ARCH)))
         ifneq (,$(filter x86_64% amd64%,$(TARGET_ARCH)))
-            ZXC_FILES += $(ZXC_DIR)/zxc_compress_avx2.o $(ZXC_DIR)/zxc_decompress_avx2.o
-            ZXC_FILES += $(ZXC_DIR)/zxc_compress_avx512.o $(ZXC_DIR)/zxc_decompress_avx512.o
+            ZXC_FILES += $(ZXC_DIR)/zxc_compress_avx2.o $(ZXC_DIR)/zxc_decompress_avx2.o $(ZXC_DIR)/zxc_huffman_avx2.o
+            ZXC_FILES += $(ZXC_DIR)/zxc_compress_avx512.o $(ZXC_DIR)/zxc_decompress_avx512.o $(ZXC_DIR)/zxc_huffman_avx512.o
         endif
     endif
 
     ifneq (,$(filter arm% aarch64%,$(TARGET_ARCH)))
-        ZXC_FILES += $(ZXC_DIR)/zxc_compress_neon.o $(ZXC_DIR)/zxc_decompress_neon.o
+        ZXC_FILES += $(ZXC_DIR)/zxc_compress_neon.o $(ZXC_DIR)/zxc_decompress_neon.o $(ZXC_DIR)/zxc_huffman_neon.o
+
         ifneq (,$(filter arm64% aarch64%,$(TARGET_ARCH)))
             NEON_FLAGS = -DZXC_USE_NEON64
         else

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Supported compressors
  - [zling 2018-10-12](https://github.com/richox/libzling) - according to the author using libzling in a production environment is not a good idea
  - [zpaq 7.15](https://github.com/zpaq/zpaq)
  - [zstd 1.5.7](https://github.com/facebook/zstd)
- - [zxc 0.10.0](https://github.com/hellobertrand/zxc)
+ - [zxc 0.11.0](https://github.com/hellobertrand/zxc)
 
 **Warning**: The compressors listed below have security issues and/or are
 no longer maintained. For information about the security of the various compressors,

--- a/bench/lz_codecs.cpp
+++ b/bench/lz_codecs.cpp
@@ -1732,11 +1732,11 @@ char *lzbench_zxc_init(size_t insize, size_t level, size_t)
      *               32768  (32KB)   1 << 15
      *               65536  (64KB)   1 << 16
      *              131072  (128KB)  1 << 17
-     *              262144  (256KB)  1 << 18  (default)
-     *              524288  (512KB)  1 << 19
+     *              262144  (256KB)  1 << 18
+     *              524288  (512KB)  1 << 19  (default)
      *             1048576  (1MB)    1 << 20
      *             2097152  (2MB)    1 << 21
-     * Set to 0 to use the default (256KB). */
+     * Set to 0 to use the default (512KB). */
     copts.block_size = 0;
 
     bench->cctx = zxc_create_cctx(&copts);

--- a/bench/lzbench.h
+++ b/bench/lzbench.h
@@ -259,8 +259,7 @@ static const compressor_desc_t comp_desc[] =
     { "zstd24LDM",  "zstd 1.5.7 --long -d24", 16,  22,   24, FULL_THREADING, lzbench_zstd_LDM_compress,   lzbench_zstd_decompress,       lzbench_zstd_LDM_init,   lzbench_zstd_deinit },
     { "zstdLDM",    "zstd 1.5.7 --long",       1,  22,    0, FULL_THREADING, lzbench_zstd_LDM_compress,   lzbench_zstd_decompress,       lzbench_zstd_LDM_init,   lzbench_zstd_deinit },
     { "zstd_fast",  "zstd 1.5.7 --fast",      -5,  -1,    0, FULL_THREADING, lzbench_zstd_compress,       lzbench_zstd_decompress,       lzbench_zstd_init,       lzbench_zstd_deinit },
-    { "zxc",        "zxc 0.10.0",              1,   5,    0, BENCH_POOL_MT,  lzbench_zxc_compress,        lzbench_zxc_decompress,        lzbench_zxc_init,        lzbench_zxc_deinit },
-
+    { "zxc",        "zxc 0.11.0",              1,   6,    0, BENCH_POOL_MT,  lzbench_zxc_compress,        lzbench_zxc_decompress,        lzbench_zxc_init,        lzbench_zxc_deinit },
 };
 
 const long int LZBENCH_COMPRESSOR_COUNT = sizeof(comp_desc)/sizeof(comp_desc[0]);

--- a/lz/zxc/include/zxc.h
+++ b/lz/zxc/include/zxc.h
@@ -11,6 +11,8 @@
 #include "zxc_buffer.h"     // IWYU pragma: keep
 #include "zxc_constants.h"  // IWYU pragma: keep
 #include "zxc_error.h"      // IWYU pragma: keep
+#include "zxc_opts.h"       // IWYU pragma: keep
+#include "zxc_pstream.h"    // IWYU pragma: keep
 #include "zxc_stream.h"     // IWYU pragma: keep
 
 #endif  // ZXC_H

--- a/lz/zxc/include/zxc_buffer.h
+++ b/lz/zxc/include/zxc_buffer.h
@@ -29,7 +29,7 @@
  * @endcode
  *
  * @see zxc_stream.h  for the streaming (multi-threaded) API.
- * @see zxc_sans_io.h for the low-level sans-I/O building blocks.
+ * @see zxc_pstream.h for single-threaded push-based streaming.
  */
 
 #ifndef ZXC_BUFFER_H
@@ -39,7 +39,7 @@
 #include <stdint.h>
 
 #include "zxc_export.h"
-#include "zxc_stream.h" /* zxc_compress_opts_t, zxc_decompress_opts_t */
+#include "zxc_opts.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -67,7 +67,7 @@ ZXC_EXPORT int zxc_min_level(void);
 /**
  * @brief Returns the maximum supported compression level.
  *
- * Currently returns @ref ZXC_LEVEL_COMPACT (5).
+ * Currently returns @ref ZXC_LEVEL_DENSITY (6).
  *
  * @return Maximum compression level value.
  */
@@ -218,6 +218,25 @@ typedef struct zxc_dctx_s zxc_dctx;
 ZXC_EXPORT uint64_t zxc_compress_block_bound(size_t input_size);
 
 /**
+ * @brief Returns the minimum destination capacity required by
+ *        zxc_decompress_block() for a block of @p uncompressed_size bytes.
+ *
+ * The decoder uses speculative (wild-copy) writes on its fast path and
+ * therefore needs a tail pad beyond the declared uncompressed size.
+ * Passing exactly @c uncompressed_size as @c dst_capacity forces the slow
+ * tail path and may trigger @ref ZXC_ERROR_OVERFLOW on some inputs.
+ *
+ * Use this helper to size the destination buffer. The returned value is
+ * guaranteed to enable the fastest decode path without aliasing or
+ * overrun checks tripping.
+ *
+ * @param[in] uncompressed_size Original uncompressed block size in bytes.
+ * @return Minimum @c dst_capacity to pass to zxc_decompress_block(),
+ *         or 0 if @p uncompressed_size would overflow.
+ */
+ZXC_EXPORT uint64_t zxc_decompress_block_bound(const size_t uncompressed_size);
+
+/**
  * @brief Compresses a single block without file framing.
  *
  * Output format: @c block_header(8B) + payload + optional @c checksum(4B).
@@ -256,6 +275,59 @@ ZXC_EXPORT int64_t zxc_compress_block(zxc_cctx* cctx, const void* src, size_t sr
  */
 ZXC_EXPORT int64_t zxc_decompress_block(zxc_dctx* dctx, const void* src, size_t src_size, void* dst,
                                         size_t dst_capacity, const zxc_decompress_opts_t* opts);
+
+/**
+ * @brief Decompresses a single block with a strict-sized destination buffer.
+ *
+ * Identical semantics to zxc_decompress_block() but accepts
+ * @p dst_capacity == @c uncompressed_size (no trailing @c ZXC_DECOMPRESS_TAIL_PAD
+ * required). Intended for integrations whose destination buffer cannot be
+ * oversized (for example, in-place page-aligned decoding).
+ *
+ * This path is slightly slower than zxc_decompress_block() on the same input
+ * because it avoids the wild-copy overshoot that the fast decoder relies on.
+ * Output is bit-identical to zxc_decompress_block().
+ *
+ * NUM and RAW blocks transparently forward to zxc_decompress_block(); only
+ * GLO/GHI use the strict-tail decoder path.
+ *
+ * @param[in,out] dctx         Reusable decompression context.
+ * @param[in]     src          Compressed block data.
+ * @param[in]     src_size     Compressed data size in bytes.
+ * @param[out]    dst          Destination buffer for decompressed data.
+ * @param[in]     dst_capacity Capacity of the destination buffer (may equal
+ *                             the original uncompressed size exactly).
+ * @param[in]     opts         Decompression options (NULL for defaults).
+ *                             Only @c checksum_enabled is used.
+ *
+ * @return Decompressed size in bytes (> 0) on success,
+ *         or a negative @ref zxc_error_t code on failure.
+ */
+ZXC_EXPORT int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* src, const size_t src_size,
+                                             void* dst, const size_t dst_capacity,
+                                             const zxc_decompress_opts_t* opts);
+
+/**
+ * @brief Estimates the peak memory used by compression for a given block & level.
+ *
+ * Returns the total bytes reserved by @ref zxc_compress_block for a block of
+ * @p src_size bytes: all per-chunk working buffers (chain table, literals,
+ * sequence/token/offset/extras buffers) plus the fixed hash tables and
+ * cache-line alignment padding. At @p level >= 6 the value also includes the
+ * `opt_scratch` region (~8.125 x @p src_size bytes) used by the price-based
+ * optimal parser. That region is lazy-allocated on the first level-6 call
+ * and reused across blocks for the lifetime of the cctx. Scales roughly
+ * linearly with @p src_size.
+ *
+ * Intended for integrators that need an accurate memory-budget figure.
+ *
+ * @param[in] src_size Uncompressed block size in bytes.
+ * @param[in] level    Compression level (1..6). Levels <= 5 share the same
+ *                     persistent cctx footprint; level 6 adds the optimal-
+ *                     parser scratch.
+ * @return Estimated peak cctx memory usage in bytes, or 0 if @p src_size is 0.
+ */
+ZXC_EXPORT uint64_t zxc_estimate_cctx_size(size_t src_size, int level);
 
 /** @} */ /* end of block_api */
 

--- a/lz/zxc/include/zxc_constants.h
+++ b/lz/zxc/include/zxc_constants.h
@@ -25,7 +25,7 @@
 /** @brief Major version number. */
 #define ZXC_VERSION_MAJOR 0
 /** @brief Minor version number. */
-#define ZXC_VERSION_MINOR 10
+#define ZXC_VERSION_MINOR 11
 /** @brief Patch version number. */
 #define ZXC_VERSION_PATCH 0
 
@@ -56,8 +56,8 @@
 #define ZXC_BLOCK_SIZE_MIN_LOG2 12
 /** @brief log2(ZXC_BLOCK_SIZE_MAX) - exponent code for maximum block size. */
 #define ZXC_BLOCK_SIZE_MAX_LOG2 21
-/** @brief Default block size (256 KB). */
-#define ZXC_BLOCK_SIZE_DEFAULT (256 * 1024)
+/** @brief Default block size (512 KB). */
+#define ZXC_BLOCK_SIZE_DEFAULT (512 * 1024)
 /** @brief Minimum allowed block size (4 KB = 2^12). */
 #define ZXC_BLOCK_SIZE_MIN (1U << ZXC_BLOCK_SIZE_MIN_LOG2)
 /** @brief Maximum allowed block size (2 MB = 2^21). */
@@ -84,7 +84,8 @@ typedef enum {
     ZXC_LEVEL_FAST = 2,     /**< Fast compression, good for real-time applications. */
     ZXC_LEVEL_DEFAULT = 3,  /**< Recommended: ratio > LZ4, decode speed > LZ4. */
     ZXC_LEVEL_BALANCED = 4, /**< Good ratio, good decode speed. */
-    ZXC_LEVEL_COMPACT = 5   /**< High density. Best for storage/firmware/assets. */
+    ZXC_LEVEL_COMPACT = 5,  /**< High density. Best for storage/firmware/assets. */
+    ZXC_LEVEL_DENSITY = 6   /**< Maximum density: Huffman-coded literals on top of COMPACT. */
 } zxc_compression_level_t;
 
 /** @} */ /* end of levels */

--- a/lz/zxc/include/zxc_opts.h
+++ b/lz/zxc/include/zxc_opts.h
@@ -1,0 +1,91 @@
+/*
+ * ZXC - High-performance lossless compression
+ *
+ * Copyright (c) 2025-2026 Bertrand Lebonnois and contributors.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file zxc_opts.h
+ * @brief Shared option structures for the ZXC compression APIs.
+ *
+ * Defines @ref zxc_compress_opts_t, @ref zxc_decompress_opts_t and
+ * @ref zxc_progress_callback_t. These types are consumed by every public
+ * ZXC API (one-shot buffer, multi-threaded @c FILE* streaming, push
+ * streaming, seekable).
+ *
+ * This header is never used in isolation: include the API header you
+ * actually use (@c zxc_buffer.h, @c zxc_stream.h, @c zxc_pstream.h, ...)
+ * which pulls this one in transitively.
+ */
+
+#ifndef ZXC_OPTS_H
+#define ZXC_OPTS_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Progress callback function type.
+ *
+ * This callback is invoked periodically during compression/decompression to report
+ * progress. It is called from the writer thread after each block is processed.
+ *
+ * @param[in] bytes_processed Total input bytes processed so far.
+ * @param[in] bytes_total     Total input bytes to process (0 if unknown, e.g., stdin).
+ * @param[in] user_data       User-provided context pointer (passed through from API call).
+ *
+ * @note The callback should be fast and non-blocking. Avoid heavy I/O or mutex locks.
+ */
+typedef void (*zxc_progress_callback_t)(uint64_t bytes_processed, uint64_t bytes_total,
+                                        const void* user_data);
+
+/**
+ * @brief Options for streaming compression.
+ *
+ * Zero-initialise for safe defaults: level 0 maps to ZXC_LEVEL_DEFAULT (3),
+ * block_size 0 maps to ZXC_BLOCK_SIZE_DEFAULT, n_threads 0 means
+ * auto-detect, and all other fields are disabled.
+ *
+ * @code
+ * zxc_compress_opts_t opts = { .level = ZXC_LEVEL_COMPACT };
+ * zxc_stream_compress(f_in, f_out, &opts);
+ * @endcode
+ */
+typedef struct {
+    int n_threads;     /**< Worker thread count (0 = auto-detect CPU cores). */
+    int level;         /**< Compression level 1-5 (0 = default, ZXC_LEVEL_DEFAULT). */
+    size_t block_size; /**< Block size in bytes (0 = default ZXC_BLOCK_SIZE_DEFAULT). Must be power
+                          of 2, [4KB - 2MB]. */
+    int checksum_enabled; /**< 1 to enable per-block and global checksums, 0 to disable. */
+    int seekable;         /**< 1 to append a seek table for random-access decompression. */
+    zxc_progress_callback_t progress_cb; /**< Optional progress callback (NULL to disable). */
+    void* user_data;                     /**< User context pointer passed to progress_cb. */
+} zxc_compress_opts_t;
+
+/**
+ * @brief Options for streaming decompression.
+ *
+ * Zero-initialise for safe defaults.
+ *
+ * @code
+ * zxc_decompress_opts_t opts = { .checksum = 1 };
+ * zxc_stream_decompress(f_in, f_out, &opts);
+ * @endcode
+ */
+typedef struct {
+    int n_threads;        /**< Worker thread count (0 = auto-detect CPU cores). */
+    int checksum_enabled; /**< 1 to verify per-block and global checksums, 0 to skip. */
+    zxc_progress_callback_t progress_cb; /**< Optional progress callback (NULL to disable). */
+    void* user_data;                     /**< User context pointer passed to progress_cb. */
+} zxc_decompress_opts_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ZXC_OPTS_H

--- a/lz/zxc/include/zxc_pstream.h
+++ b/lz/zxc/include/zxc_pstream.h
@@ -1,0 +1,309 @@
+/*
+ * ZXC - High-performance lossless compression
+ *
+ * Copyright (c) 2025-2026 Bertrand Lebonnois and contributors.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file zxc_pstream.h
+ * @brief Push-based, single-threaded streaming compression and decompression.
+ *
+ * This header exposes a non-blocking, caller-driven streaming API, the
+ * counterpart of the @c FILE*-based @ref zxc_stream_compress / @ref
+ * zxc_stream_decompress.  Where the @c FILE* API takes ownership of the
+ * pipeline (it reads until EOF and writes until done), the push API hands the
+ * control back to the caller: feed input chunks when available, drain output
+ * chunks when ready, finalise on demand.
+ *
+ * Use this API when you need to integrate ZXC into:
+ * - a callback-driven library;
+ * - an asynchronous event loop;
+ * - a network protocol that streams data without seeking (HTTP chunked
+ *   transfer, gRPC, custom binary protocols);
+ * - any pipeline where you cannot block on a @c FILE*.
+ *
+ * The API is single-threaded: one context is processed by one thread at a
+ * time.  For multi-threaded compression of a single file end-to-end, use
+ * @ref zxc_stream_compress instead.
+ *
+ * @par Compression usage
+ * @code
+ * zxc_compress_opts_t opts = { .level = 3, .checksum_enabled = 1 };
+ * zxc_cstream* cs = zxc_cstream_create(&opts);
+ *
+ * uint8_t in_buf[64*1024], out_buf[64*1024];
+ * zxc_outbuf_t out = { out_buf, sizeof out_buf, 0 };
+ *
+ * ssize_t n;
+ * while ((n = read_some(in_buf, sizeof in_buf)) > 0) {
+ *     zxc_inbuf_t in = { in_buf, (size_t)n, 0 };
+ *     while (in.pos < in.size) {
+ *         int64_t r = zxc_cstream_compress(cs, &out, &in);
+ *         if (r < 0) goto fatal;
+ *         if (out.pos > 0) { write_to_sink(out_buf, out.pos); out.pos = 0; }
+ *     }
+ * }
+ *
+ * int64_t pending;
+ * do {
+ *     pending = zxc_cstream_end(cs, &out);
+ *     if (pending < 0) goto fatal;
+ *     if (out.pos > 0) { write_to_sink(out_buf, out.pos); out.pos = 0; }
+ * } while (pending > 0);
+ *
+ * zxc_cstream_free(cs);
+ * @endcode
+ *
+ * @see zxc_stream.h  for the multi-threaded @c FILE*-based pipeline.
+ * @see zxc_buffer.h  for one-shot in-memory compression.
+ */
+
+#ifndef ZXC_PSTREAM_H
+#define ZXC_PSTREAM_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "zxc_export.h"
+#include "zxc_opts.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup pstream Push Streaming API
+ * @brief Caller-driven, single-threaded streaming compression and decompression.
+ * @{
+ */
+
+/**
+ * @brief Input buffer descriptor for push streaming.
+ *
+ * The caller fills @c src with bytes to feed in and sets @c size to their
+ * count.  The library advances @c pos as it consumes input; the caller must
+ * not modify @c pos between calls.
+ */
+typedef struct {
+    const void* src; /**< Caller-owned input bytes. */
+    size_t size;     /**< Total bytes available in @c src. */
+    size_t pos;      /**< Bytes already consumed by the library (in/out). */
+} zxc_inbuf_t;
+
+/**
+ * @brief Output buffer descriptor for push streaming.
+ *
+ * The caller provides a writable region of capacity @c size starting at
+ * @c dst.  The library writes starting at @c dst+pos and advances @c pos by
+ * the number of bytes produced.  The caller drains @c [dst, dst+pos) and
+ * resets @c pos to 0 between rounds (or grows @c size).
+ */
+typedef struct {
+    void* dst;   /**< Caller-owned output region. */
+    size_t size; /**< Total capacity available at @c dst. */
+    size_t pos;  /**< Bytes already produced by the library (in/out). */
+} zxc_outbuf_t;
+
+/* Opaque streaming contexts. */
+typedef struct zxc_cstream_s zxc_cstream;
+typedef struct zxc_dstream_s zxc_dstream;
+
+/* ===== Compression =================================================== */
+
+/**
+ * @brief Creates a push compression stream.
+ *
+ * All settings from @p opts are copied into the context.  After this call,
+ * the @p opts struct may be freed or reused.
+ *
+ * Only @c level, @c block_size, and @c checksum_enabled are honoured.
+ * @c n_threads is ignored (this API is single-threaded; use
+ * @ref zxc_stream_compress for the multi-threaded @c FILE* pipeline).
+ *
+ * If @p opts is not @c NULL, the honoured fields must contain valid values.
+ * Invalid option values (for example an unsupported @c block_size) cause
+ * stream creation to fail.
+ *
+ * @param[in] opts  Compression options, or @c NULL for all defaults.
+ * @return Allocated context to be released with @ref zxc_cstream_free,
+ *         or @c NULL if stream creation fails due to memory allocation
+ *         failure or invalid option values in @p opts.
+ */
+ZXC_EXPORT zxc_cstream* zxc_cstream_create(const zxc_compress_opts_t* opts);
+
+/**
+ * @brief Releases a compression stream and all internal buffers.
+ *
+ * Safe to call with @c NULL (no-op).
+ *
+ * @param[in] cs  Stream returned by @ref zxc_cstream_create.
+ */
+ZXC_EXPORT void zxc_cstream_free(zxc_cstream* cs);
+
+/**
+ * @brief Pushes input bytes into the stream and drains compressed output.
+ *
+ * Reads from @c in->src starting at @c in->pos, writes to @c out->dst
+ * starting at @c out->pos, advancing both as data flows.  Each call makes as
+ * much progress as either buffer allows in a single visit:
+ *
+ * - emits the file header on the first invocation (16 B);
+ * - copies input into the internal block accumulator;
+ * - whenever the accumulator is full, compresses one block and writes it
+ *   into @p out (up to @c out->size);
+ * - returns when @p in is fully consumed *and* no more compressed bytes are
+ *   pending, or when @p out has no room left.
+ *
+ * The function is fully reentrant: if @p out fills mid-block, the next call
+ * resumes draining from where the previous left off.  Safe to call with
+ * @c in->size == in->pos (drain-only mode).
+ *
+ * @par Errors
+ * On failure the context becomes errored (sticky): every subsequent call to
+ * @ref zxc_cstream_compress / @ref zxc_cstream_end returns the same negative
+ * code without doing further work.  Only @ref zxc_cstream_free is safe.
+ *
+ * @param[in,out] cs   Compression stream.
+ * @param[in,out] out  Output descriptor; @c pos is advanced by produced bytes.
+ * @param[in,out] in   Input descriptor;  @c pos is advanced by consumed bytes.
+ *
+ * @return @c 0 if @p in was fully consumed and no compressed bytes remain
+ *         pending in the internal staging area;
+ *         @c >0 number of bytes still pending, drain @p out and call again
+ *         with the same (or new) input;
+ *         @c <0 a @ref zxc_error_t code.
+ */
+ZXC_EXPORT int64_t zxc_cstream_compress(zxc_cstream* cs, zxc_outbuf_t* out, zxc_inbuf_t* in);
+
+/**
+ * @brief Finalises the stream: flushes pending data, writes EOF block + footer.
+ *
+ * Must be called after the last @ref zxc_cstream_compress invocation to
+ * produce a valid ZXC file.  Like @ref zxc_cstream_compress, this function
+ * is reentrant: if @p out fills before everything is drained, it returns a
+ * positive count and the caller drains and calls again.
+ *
+ * After @ref zxc_cstream_end returns @c 0, the stream is in DONE state and
+ * any further call returns @c ZXC_ERROR_NULL_INPUT (use @ref
+ * zxc_cstream_free to release).
+ *
+ * @param[in,out] cs   Compression stream.
+ * @param[in,out] out  Output descriptor.
+ *
+ * @return @c 0 finalisation complete (file is now valid);
+ *         @c >0 bytes still pending, drain @p out and call again;
+ *         @c <0 a @ref zxc_error_t code.
+ */
+ZXC_EXPORT int64_t zxc_cstream_end(zxc_cstream* cs, zxc_outbuf_t* out);
+
+/**
+ * @brief Suggested input chunk size for best throughput.
+ *
+ * Equal to the configured block size (default 512 KB).  The caller may
+ * supply any input chunk; this is purely a performance hint.
+ *
+ * @param[in] cs  Compression stream.
+ * @return Suggested @c in_buf capacity in bytes, or 0 if @p cs is @c NULL.
+ */
+ZXC_EXPORT size_t zxc_cstream_in_size(const zxc_cstream* cs);
+
+/**
+ * @brief Suggested output chunk size to never trigger a partial drain.
+ *
+ * Sized to hold one full compressed block plus framing overhead.  Smaller
+ * outputs work but may force the caller into an extra drain loop.
+ *
+ * @param[in] cs  Compression stream.
+ * @return Suggested @c out_buf capacity in bytes, or 0 if @p cs is @c NULL.
+ */
+ZXC_EXPORT size_t zxc_cstream_out_size(const zxc_cstream* cs);
+
+/* ===== Decompression ================================================= */
+
+/**
+ * @brief Creates a push decompression stream.
+ *
+ * All settings from @p opts are copied into the context.  Only
+ * @c checksum_enabled is honoured (controls whether per-block and global
+ * checksums are verified when present).
+ *
+ * @param[in] opts  Decompression options, or @c NULL for defaults.
+ * @return Allocated context to be released with @ref zxc_dstream_free,
+ *         or @c NULL on allocation failure.
+ */
+ZXC_EXPORT zxc_dstream* zxc_dstream_create(const zxc_decompress_opts_t* opts);
+
+/**
+ * @brief Releases a decompression stream.  Safe to call with @c NULL.
+ *
+ * @param[in] ds  Stream returned by @ref zxc_dstream_create.
+ */
+ZXC_EXPORT void zxc_dstream_free(zxc_dstream* ds);
+
+/**
+ * @brief Pushes compressed input and drains decompressed output.
+ *
+ * Internally runs a parser state machine: file header -> per-block
+ * (header + payload + optional checksum) -> EOF block -> optional SEK block ->
+ * file footer.  Each call makes as much progress as @p in and @p out allow.
+ *
+ * @par End of stream
+ * When the decoder reaches the file footer and validates it, the stream
+ * enters DONE state.  Subsequent calls return @c 0 without producing more
+ * output, even if extra bytes remain in @p in (those trailing bytes are
+ * silently ignored, the caller may use the residual @c in->pos to detect
+ * how much real data was consumed).
+ *
+ * @par Errors
+ * Sticky: once a negative code is returned, further calls keep returning it.
+ *
+ * @param[in,out] ds   Decompression stream.
+ * @param[in,out] out  Output descriptor; @c pos advanced by produced bytes.
+ * @param[in,out] in   Input descriptor;  @c pos advanced by consumed bytes.
+ *
+ * @return @c >0 number of decompressed bytes written into @p out this call;
+ *         @c 0 stream complete (DONE) or no progress possible (caller should
+ *         feed more input);
+ *         @c <0 a @ref zxc_error_t code.
+ */
+ZXC_EXPORT int64_t zxc_dstream_decompress(zxc_dstream* ds, zxc_outbuf_t* out, zxc_inbuf_t* in);
+
+/**
+ * @brief Reports whether the decoder has fully consumed a valid stream.
+ *
+ * Returns @c 1 iff the parser has reached the file footer **and** validated
+ * it.  Callers that have finished feeding input use this to detect truncated
+ * streams: if @ref zxc_dstream_decompress returns @c 0 with no output and
+ * @ref zxc_dstream_finished returns @c 0, the input ended prematurely.
+ *
+ * @param[in] ds  Decompression stream.
+ * @return @c 1 if DONE, @c 0 otherwise (including errored).
+ */
+ZXC_EXPORT int zxc_dstream_finished(const zxc_dstream* ds);
+
+/**
+ * @brief Suggested input chunk size for the decompressor.
+ *
+ * @param[in] ds  Decompression stream.
+ * @return Suggested @c in_buf capacity in bytes, or 0 if @p ds is @c NULL.
+ */
+ZXC_EXPORT size_t zxc_dstream_in_size(const zxc_dstream* ds);
+
+/**
+ * @brief Suggested output chunk size for the decompressor.
+ *
+ * Sized to hold at least one full decompressed block.
+ *
+ * @param[in] ds  Decompression stream.
+ * @return Suggested @c out_buf capacity in bytes, or 0 if @p ds is @c NULL.
+ */
+ZXC_EXPORT size_t zxc_dstream_out_size(const zxc_dstream* ds);
+
+/** @} */ /* end of pstream */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZXC_PSTREAM_H */

--- a/lz/zxc/include/zxc_sans_io.h
+++ b/lz/zxc/include/zxc_sans_io.h
@@ -20,9 +20,6 @@
  * -# Compress or decompress individual blocks via the chunk wrappers.
  * -# Write the footer with zxc_write_file_footer().
  * -# Release the context with zxc_cctx_free().
- *
- * @see zxc_buffer.h  for the simple one-shot API.
- * @see zxc_stream.h  for the multi-threaded streaming API.
  */
 
 #ifndef ZXC_SANS_IO_H
@@ -93,12 +90,17 @@ typedef struct {
     uint8_t* literals;       /**< Buffer for literal bytes. */
 
     /* Cold zone: configuration / scratch / resizeable. */
-    uint8_t* lit_buffer;   /**< Scratch buffer for literals (RLE). */
-    size_t lit_buffer_cap; /**< Current capacity of the scratch buffer. */
-    uint8_t* work_buf;     /**< Padded scratch buffer for buffer-API decompression. */
-    size_t work_buf_cap;   /**< Capacity of the work buffer. */
-    int checksum_enabled;  /**< 1 if checksum calculation/verification is enabled. */
-    int compression_level; /**< Compression level. */
+    uint8_t* lit_buffer;    /**< Scratch buffer for literals (RLE). */
+    size_t lit_buffer_cap;  /**< Current capacity of the scratch buffer. */
+    uint8_t* work_buf;      /**< Padded scratch buffer for buffer-API decompression. */
+    size_t work_buf_cap;    /**< Capacity of the work buffer. */
+    uint8_t* opt_scratch;   /**< Optimal-parser DP scratch (level >= 6 only,
+                                 lazy-allocated, packs dp/parent_len/parent_off/actions).
+                                 Also reused as transient scratch for the
+                                 length-limited Huffman code-length builder. */
+    size_t opt_scratch_cap; /**< Current capacity of opt_scratch in bytes. */
+    int checksum_enabled;   /**< 1 if checksum calculation/verification is enabled. */
+    int compression_level;  /**< Compression level. */
 
     /* Block-size derived parameters (computed once at init). */
     size_t chunk_size;    /**< Effective block size in bytes. */

--- a/lz/zxc/include/zxc_seekable.h
+++ b/lz/zxc/include/zxc_seekable.h
@@ -31,9 +31,6 @@
  * int64_t n = zxc_seekable_decompress_range(s, out, out_cap, offset, len);
  * zxc_seekable_free(s);
  * @endcode
- *
- * @see zxc_buffer.h  for the standard one-shot API.
- * @see zxc_stream.h  for multi-threaded streaming.
  */
 
 #ifndef ZXC_SEEKABLE_H

--- a/lz/zxc/include/zxc_stream.h
+++ b/lz/zxc/include/zxc_stream.h
@@ -19,17 +19,17 @@
  * 3. **Writer thread**  - orders the results and writes them to `f_out`.
  *
  * @see zxc_buffer.h  for the simple one-shot buffer API.
- * @see zxc_sans_io.h for low-level sans-I/O building blocks.
+ * @see zxc_pstream.h for single-threaded push-based streaming.
  */
 
 #ifndef ZXC_STREAM_H
 #define ZXC_STREAM_H
 
-#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 
 #include "zxc_export.h"
+#include "zxc_opts.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,61 +40,6 @@ extern "C" {
  * @brief Multi-threaded, FILE*-based compression and decompression.
  * @{
  */
-
-/**
- * @brief Progress callback function type.
- *
- * This callback is invoked periodically during compression/decompression to report
- * progress. It is called from the writer thread after each block is processed.
- *
- * @param[in] bytes_processed Total input bytes processed so far.
- * @param[in] bytes_total     Total input bytes to process (0 if unknown, e.g., stdin).
- * @param[in] user_data       User-provided context pointer (passed through from API call).
- *
- * @note The callback should be fast and non-blocking. Avoid heavy I/O or mutex locks.
- */
-typedef void (*zxc_progress_callback_t)(uint64_t bytes_processed, uint64_t bytes_total,
-                                        const void* user_data);
-
-/**
- * @brief Options for streaming compression.
- *
- * Zero-initialise for safe defaults: level 0 maps to ZXC_LEVEL_DEFAULT (3),
- * block_size 0 maps to ZXC_BLOCK_SIZE_DEFAULT, n_threads 0 means
- * auto-detect, and all other fields are disabled.
- *
- * @code
- * zxc_compress_opts_t opts = { .level = ZXC_LEVEL_COMPACT };
- * zxc_stream_compress(f_in, f_out, &opts);
- * @endcode
- */
-typedef struct {
-    int n_threads;     /**< Worker thread count (0 = auto-detect CPU cores). */
-    int level;         /**< Compression level 1-5 (0 = default, ZXC_LEVEL_DEFAULT). */
-    size_t block_size; /**< Block size in bytes (0 = default ZXC_BLOCK_SIZE_DEFAULT). Must be power
-                          of 2, [4KB - 2MB]. */
-    int checksum_enabled; /**< 1 to enable per-block and global checksums, 0 to disable. */
-    int seekable;         /**< 1 to append a seek table for random-access decompression. */
-    zxc_progress_callback_t progress_cb; /**< Optional progress callback (NULL to disable). */
-    void* user_data;                     /**< User context pointer passed to progress_cb. */
-} zxc_compress_opts_t;
-
-/**
- * @brief Options for streaming decompression.
- *
- * Zero-initialise for safe defaults.
- *
- * @code
- * zxc_decompress_opts_t opts = { .checksum = 1 };
- * zxc_stream_decompress(f_in, f_out, &opts);
- * @endcode
- */
-typedef struct {
-    int n_threads;        /**< Worker thread count (0 = auto-detect CPU cores). */
-    int checksum_enabled; /**< 1 to verify per-block and global checksums, 0 to skip. */
-    zxc_progress_callback_t progress_cb; /**< Optional progress callback (NULL to disable). */
-    void* user_data;                     /**< User context pointer passed to progress_cb. */
-} zxc_decompress_opts_t;
 
 /**
  * @brief Compresses data from an input stream to an output stream.

--- a/lz/zxc/src/lib/zxc_common.c
+++ b/lz/zxc/src/lib/zxc_common.c
@@ -86,36 +86,32 @@ int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int m
 
     if (mode == 0) return ZXC_OK;
 
-    const size_t max_seq = chunk_size / sizeof(uint32_t) + 256;
+    const size_t max_seq = chunk_size / ZXC_LZ_MIN_MATCH_LEN + 16;
     const size_t sz_hash_pos = ZXC_LZ_HASH_SIZE * sizeof(uint32_t);
     const size_t sz_hash_tags = ZXC_LZ_HASH_SIZE * sizeof(uint8_t);
-    const size_t sz_chain = chunk_size * sizeof(uint16_t);
-    const size_t sz_sequences = max_seq * sizeof(uint32_t);
-    const size_t sz_tokens = max_seq * sizeof(uint8_t);
-    const size_t sz_offsets = max_seq * sizeof(uint16_t);
-    const size_t sz_extras =
-        max_seq * 2 *
-        ZXC_VBYTE_ALLOC_LEN;  // Max 3 bytes per LL/ML VByte (21 bits, sufficient for <= 2MB block)
+    const size_t sz_chain = ZXC_LZ_WINDOW_SIZE * sizeof(uint16_t);
+    /* buf_sequences (GHI, level <= 2) aliases buf_offsets + buf_tokens (GLO,
+     * level >= 3). Mutually exclusive per block; sized for the larger. */
+    const size_t sz_seq_union = max_seq * sizeof(uint32_t);
+    /* Varint bytes per LL/ML: scales with chunk_size. */
+    const size_t vbyte_len = (offset_bits + 6) / 7;
+    const size_t sz_extras = max_seq * 2 * vbyte_len;
     const size_t sz_lit = chunk_size + ZXC_PAD_SIZE;
 
-    // Calculate sizes with alignment padding (64 bytes for cache line alignment)
+    /* Calculate sizes with alignment padding (64 bytes for cache line alignment) */
     size_t total_size = 0;
     const size_t off_hash_pos = total_size;
-    total_size += (sz_hash_pos + ZXC_ALIGNMENT_MASK) & ~ZXC_ALIGNMENT_MASK;
+    total_size += ZXC_ALIGN_CL(sz_hash_pos);
     const size_t off_hash_tags = total_size;
-    total_size += (sz_hash_tags + ZXC_ALIGNMENT_MASK) & ~ZXC_ALIGNMENT_MASK;
+    total_size += ZXC_ALIGN_CL(sz_hash_tags);
     const size_t off_chain = total_size;
-    total_size += (sz_chain + ZXC_ALIGNMENT_MASK) & ~ZXC_ALIGNMENT_MASK;
-    const size_t off_sequences = total_size;
-    total_size += (sz_sequences + ZXC_ALIGNMENT_MASK) & ~ZXC_ALIGNMENT_MASK;
-    const size_t off_tokens = total_size;
-    total_size += (sz_tokens + ZXC_ALIGNMENT_MASK) & ~ZXC_ALIGNMENT_MASK;
-    const size_t off_offsets = total_size;
-    total_size += (sz_offsets + ZXC_ALIGNMENT_MASK) & ~ZXC_ALIGNMENT_MASK;
+    total_size += ZXC_ALIGN_CL(sz_chain);
+    const size_t off_seq_union = total_size;
+    total_size += ZXC_ALIGN_CL(sz_seq_union);
     const size_t off_extras = total_size;
-    total_size += (sz_extras + ZXC_ALIGNMENT_MASK) & ~ZXC_ALIGNMENT_MASK;
+    total_size += ZXC_ALIGN_CL(sz_extras);
     const size_t off_lit = total_size;
-    total_size += (sz_lit + ZXC_ALIGNMENT_MASK) & ~ZXC_ALIGNMENT_MASK;
+    total_size += ZXC_ALIGN_CL(sz_lit);
 
     uint8_t* const mem = (uint8_t*)zxc_aligned_malloc(total_size, ZXC_CACHE_LINE_SIZE);
     if (UNLIKELY(!mem)) return ZXC_ERROR_MEMORY;
@@ -124,9 +120,9 @@ int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int m
     ctx->hash_table = (uint32_t*)(mem + off_hash_pos);
     ctx->hash_tags = (uint8_t*)(mem + off_hash_tags);
     ctx->chain_table = (uint16_t*)(mem + off_chain);
-    ctx->buf_sequences = (uint32_t*)(mem + off_sequences);
-    ctx->buf_tokens = (uint8_t*)(mem + off_tokens);
-    ctx->buf_offsets = (uint16_t*)(mem + off_offsets);
+    ctx->buf_sequences = (uint32_t*)(mem + off_seq_union);
+    ctx->buf_offsets = (uint16_t*)(mem + off_seq_union);
+    ctx->buf_tokens = (uint8_t*)(mem + off_seq_union) + max_seq * sizeof(uint16_t);
     ctx->buf_extras = (uint8_t*)(mem + off_extras);
     ctx->literals = (uint8_t*)(mem + off_lit);
 
@@ -162,6 +158,11 @@ void zxc_cctx_free(zxc_cctx_t* ctx) {
         ctx->work_buf = NULL;
     }
 
+    if (ctx->opt_scratch) {
+        zxc_aligned_free(ctx->opt_scratch);
+        ctx->opt_scratch = NULL;
+    }
+
     ctx->hash_table = NULL;
     ctx->hash_tags = NULL;
     ctx->chain_table = NULL;
@@ -174,6 +175,7 @@ void zxc_cctx_free(zxc_cctx_t* ctx) {
     ctx->epoch = 0;
     ctx->lit_buffer_cap = 0;
     ctx->work_buf_cap = 0;
+    ctx->opt_scratch_cap = 0;
 }
 
 /*
@@ -615,6 +617,69 @@ uint64_t zxc_compress_block_bound(const size_t input_size) {
 }
 
 /*
+ * @brief Returns the minimum dst_capacity required by zxc_decompress_block().
+ *
+ * The decoder uses speculative wild-copy writes on its fast path.
+ * Sizing the destination to uncompressed_size + ZXC_PAD_SIZE*66 guarantees
+ * the fast path is always reachable and that tail bounds checks never
+ * spuriously reject the last literals of a valid block.
+ */
+uint64_t zxc_decompress_block_bound(const size_t uncompressed_size) {
+    if (UNLIKELY(uncompressed_size > SIZE_MAX - ZXC_DECOMPRESS_TAIL_PAD)) return 0;
+    return (uint64_t)uncompressed_size + ZXC_DECOMPRESS_TAIL_PAD;
+}
+
+/*
+ * @brief Estimates the total buffer bytes allocated inside a cctx for a block.
+ *
+ * Mirrors the persistent allocation layout in zxc_cctx_init(): each sub-buffer
+ * is rounded up to the cache-line boundary, so the returned value matches the
+ * single aligned allocation performed by the initializer.
+ *
+ * For @p level >= 6 the figure also includes ctx->opt_scratch (~8.125 bytes
+ * per chunk_size byte: dp + parent_len + parent_off + a 1-bit-per-position
+ * match-end bitmap), the cache-line-aligned scratch used by the optimal
+ * parser. It is lazy-allocated on the first level-6 call and persists for
+ * the lifetime of the cctx (no per-block malloc/free).
+ */
+uint64_t zxc_estimate_cctx_size(const size_t src_size, const int level) {
+    if (UNLIKELY(src_size == 0)) return 0;
+
+    const size_t chunk_size = zxc_block_size_ceil(src_size);
+    const uint32_t offset_bits = zxc_log2_u32((uint32_t)chunk_size);
+    const size_t max_seq = chunk_size / ZXC_LZ_MIN_MATCH_LEN + 16;
+    const size_t vbyte_len = (offset_bits + 6) / 7;
+
+    uint64_t total = 0;
+    total += ZXC_ALIGN_CL(ZXC_LZ_HASH_SIZE * sizeof(uint32_t));   /* hash_table */
+    total += ZXC_ALIGN_CL(ZXC_LZ_HASH_SIZE * sizeof(uint8_t));    /* hash_tags */
+    total += ZXC_ALIGN_CL(ZXC_LZ_WINDOW_SIZE * sizeof(uint16_t)); /* chain_table (ring) */
+    /* sequences / tokens+offsets alias the same region (see zxc_cctx_init). */
+    total += ZXC_ALIGN_CL(max_seq * sizeof(uint32_t)); /* seq_union */
+    total += ZXC_ALIGN_CL(max_seq * 2 * vbyte_len);    /* buf_extras */
+    total += ZXC_ALIGN_CL(chunk_size + ZXC_PAD_SIZE);  /* literals */
+
+    /* The opaque wrapper struct allocated by zxc_create_cctx() adds a tiny
+     * fixed overhead (< 128 B) that is negligible next to the per-chunk
+     * buffers above and is intentionally omitted. */
+
+    if (level >= ZXC_LEVEL_DENSITY) {
+        const size_t n_bm_words = (chunk_size + 1 + 63) / 64;
+        size_t opt = ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint32_t)); /* dp             */
+        opt += ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint16_t));       /* parent_len     */
+        opt += ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint16_t));       /* parent_off     */
+        opt += ZXC_ALIGN_CL(n_bm_words * sizeof(uint64_t));             /* match_end_bits */
+        /* opt_scratch is sized to hold both the DP arrays and (transiently)
+         * the package-merge scratch for the Huffman code-length builder;
+         * report the larger of the two. */
+        const size_t huf = ZXC_ALIGN_CL(ZXC_HUF_BUILD_SCRATCH_SIZE);
+        total += (opt > huf) ? opt : huf;
+    }
+
+    return total;
+}
+
+/*
  * ============================================================================
  * ERROR CODE UTILITIES
  * ============================================================================
@@ -682,9 +747,9 @@ int zxc_min_level(void) { return ZXC_LEVEL_FASTEST; }
 /*
  * @brief Returns the maximum supported compression level.
  *
- * Returns the value of ZXC_LEVEL_COMPACT (currently 5).
+ * Returns the value of ZXC_LEVEL_DENSITY (currently 6).
  */
-int zxc_max_level(void) { return ZXC_LEVEL_COMPACT; }
+int zxc_max_level(void) { return ZXC_LEVEL_DENSITY; }
 
 /*
  * @brief Returns the default compression level.

--- a/lz/zxc/src/lib/zxc_compress.c
+++ b/lz/zxc/src/lib/zxc_compress.c
@@ -15,19 +15,24 @@
  * by @ref zxc_dispatch.c.
  */
 
-#include "../../include/zxc_error.h"
-#include "../../include/zxc_sans_io.h"
-#include "zxc_internal.h"
-
 /*
  * Function Multi-Versioning Support
- * If ZXC_FUNCTION_SUFFIX is defined (e.g. _avx2), rename the public entry point.
+ * If ZXC_FUNCTION_SUFFIX is defined (e.g. _avx2, _neon), rename the public
+ * entry point AND the Huffman entry points consumed by this TU. The defines
+ * sit before zxc_internal.h so that the prototypes the header declares are
+ * also rewritten with the suffix, keeping callers and callees consistent.
  */
 #ifdef ZXC_FUNCTION_SUFFIX
 #define ZXC_CAT_IMPL(x, y) x##y
 #define ZXC_CAT(x, y) ZXC_CAT_IMPL(x, y)
 #define zxc_compress_chunk_wrapper ZXC_CAT(zxc_compress_chunk_wrapper, ZXC_FUNCTION_SUFFIX)
+#define zxc_huf_build_code_lengths ZXC_CAT(zxc_huf_build_code_lengths, ZXC_FUNCTION_SUFFIX)
+#define zxc_huf_encode_section ZXC_CAT(zxc_huf_encode_section, ZXC_FUNCTION_SUFFIX)
 #endif
+
+#include "../../include/zxc_error.h"
+#include "../../include/zxc_sans_io.h"
+#include "zxc_internal.h"
 
 /**
  * @brief Computes a hash value for either a 4-byte or 5-byte sequence.
@@ -92,25 +97,42 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_mm256_reduce_max_epu32(__m256i v) {
  */
 static ZXC_ALWAYS_INLINE size_t zxc_write_varint(uint8_t* RESTRICT dst, const uint32_t val) {
     // 1 byte: 0xxxxxxx (7 bits) = 2^7 = 128
-    if (LIKELY(val < (1 << 7))) {
+    if (LIKELY(val < (1U << 7))) {
         dst[0] = (uint8_t)val;
         return 1;
     }
 
     // 2 bytes: 10xxxxxx xxxxxxxx (14 bits) = 2^14 = 16384
-    if (LIKELY(val < (1 << 14))) {
+    if (LIKELY(val < (1U << 14))) {
         dst[0] = (uint8_t)(0x80 | (val & 0x3F));
         dst[1] = (uint8_t)(val >> 6);
         return 2;
     }
 
     // 3 bytes: 110xxxxx xxxxxxxx xxxxxxxx (21 bits) = 2^21 = 2097152
-    // Max varint value is bounded by ZXC_BLOCK_SIZE_MAX (2MB = 2^21).
-    // ZXC_VBYTE_ALLOC_LEN == 3 guarantees this is the last reachable path.
-    dst[0] = (uint8_t)(0xC0 | (val & 0x1F));
-    dst[1] = (uint8_t)(val >> 5);
-    dst[2] = (uint8_t)(val >> 13);
-    return ZXC_VBYTE_ALLOC_LEN;
+    if (LIKELY(val < (1U << 21))) {
+        dst[0] = (uint8_t)(0xC0 | (val & 0x1F));
+        dst[1] = (uint8_t)(val >> 5);
+        dst[2] = (uint8_t)(val >> 13);
+        return 3;
+    }
+
+    // 4 bytes: 1110xxxx xxxxxxxx xxxxxxxx xxxxxxxx (28 bits) = 2^28 = 268435456
+    if (val < (1U << 28)) {
+        dst[0] = (uint8_t)(0xE0 | (val & 0x0F));
+        dst[1] = (uint8_t)(val >> 4);
+        dst[2] = (uint8_t)(val >> 12);
+        dst[3] = (uint8_t)(val >> 20);
+        return 4;
+    }
+
+    // 5 bytes: 11110xxx xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx (32 bits)
+    dst[0] = (uint8_t)(0xF0 | (val & 0x07));
+    dst[1] = (uint8_t)(val >> 3);
+    dst[2] = (uint8_t)(val >> 11);
+    dst[3] = (uint8_t)(val >> 19);
+    dst[4] = (uint8_t)(val >> 27);
+    return 5;
 }
 
 /**
@@ -172,20 +194,20 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
     // Current position in the input buffer expressed as a 32-bit index.
     const uint32_t cur_pos = (uint32_t)(ip - src);
 
-    // Split table reads: tag table + position table
+    // Tag-first filter on fast levels.
     const uint8_t stored_tag = hash_tags[h];
-    const uint32_t raw_head = hash_table[h];
+    uint32_t match_idx;
+    if (level <= ZXC_LEVEL_FAST && stored_tag != cur_tag) {
+        match_idx = 0;
+    } else {
+        const uint32_t raw_head = hash_table[h];
+        match_idx = ((raw_head & ~offset_mask) == epoch_mark) ? (raw_head & offset_mask) : 0;
+    }
 
-    // If the epoch in raw_head matches the current epoch_mark, extract the
-    // stored position; otherwise treat this bucket as empty (index 0).
-    uint32_t match_idx = ((raw_head & ~offset_mask) == epoch_mark) ? (raw_head & offset_mask) : 0;
-
-    // Decide whether to skip the head entry of the hash chain.
+    // skip_head still drives the chain walk on level >= 3 (advances past the
+    // mismatched head without comparing). On level <= 2 it is always 0 here:
+    // either match_idx == 0 (filter-skip) or stored_tag == cur_tag.
     const int skip_head = (match_idx != 0) & (stored_tag != cur_tag);
-
-    // If we should skip the head and level is low (<= 2), we drop the match entirely.
-    const uint32_t drop_mask = (uint32_t)((skip_head & (level <= 2)) - 1);
-    match_idx &= drop_mask;
 
     // Split table writes
     hash_table[h] = epoch_mark | cur_pos;
@@ -194,7 +216,7 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
     // Branchless chain table update
     const uint32_t dist = cur_pos - match_idx;
     const uint32_t valid_mask = -((int32_t)((match_idx != 0) & (dist < ZXC_LZ_WINDOW_SIZE)));
-    chain_table[cur_pos] = (uint16_t)(dist & valid_mask);
+    chain_table[cur_pos & ZXC_LZ_WINDOW_MASK] = (uint16_t)(dist & valid_mask);
 
     if (match_idx == 0) return best;
 
@@ -203,7 +225,7 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
     // Optimization: If head tag doesn't match, advance immediately without loading the first
     // mismatch.
     if (skip_head) {
-        const uint16_t delta = chain_table[match_idx];
+        const uint16_t delta = chain_table[match_idx & ZXC_LZ_WINDOW_MASK];
         const uint32_t next_idx = match_idx - delta;
         match_idx = (delta != 0) ? next_idx : 0;
         attempts--;
@@ -272,16 +294,14 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
                 const uint8x16_t v_ref = vld1q_u8(ref + mlen);
                 const uint8x16_t v_cmp = vceqq_u8(v_src, v_ref);
 #if defined(ZXC_USE_NEON64)
-                if (vminvq_u8(v_cmp) == 0xFF)
+                /* Compress 128-bit byte-mask -> 64-bit nibble-mask via
+                 * SHRN: each 0x00/0xFF byte becomes a 0x0/0xF nibble. */
+                const uint64_t mask = vget_lane_u64(
+                    vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(v_cmp), 4)), 0);
+                if (LIKELY(mask == ~(uint64_t)0)) {
                     mlen += 16;
-                else {
-                    uint8x16_t v_diff = vmvnq_u8(v_cmp);
-                    uint64_t lo = vgetq_lane_u64(vreinterpretq_u64_u8(v_diff), 0);
-                    if (lo != 0)
-                        mlen += (zxc_ctz64(lo) >> 3);
-                    else
-                        mlen +=
-                            8 + (zxc_ctz64(vgetq_lane_u64(vreinterpretq_u64_u8(v_diff), 1)) >> 3);
+                } else {
+                    mlen += (uint32_t)(zxc_ctz64(~mask) >> 2);
                     goto _match_len_done;
                 }
 #else
@@ -329,7 +349,7 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
             if (UNLIKELY(best.len >= (uint32_t)p.sufficient_len || ip + best.len >= iend)) break;
         }
 
-        const uint16_t delta = chain_table[match_idx];
+        const uint16_t delta = chain_table[match_idx & ZXC_LZ_WINDOW_MASK];
         const uint32_t next_idx = match_idx - delta;
         ZXC_PREFETCH_READ(src + next_idx);
 
@@ -386,7 +406,7 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
                 max_lazy2 = l2 > max_lazy2 ? l2 : max_lazy2;
             }
 
-            const uint16_t delta = chain_table[next_idx];
+            const uint16_t delta = chain_table[next_idx & ZXC_LZ_WINDOW_MASK];
             if (UNLIKELY(delta == 0)) break;
             next_idx -= delta;
             is_lazy_first = 0;
@@ -394,7 +414,7 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
 
         // --- Lazy evaluation at ip+2 (computed in parallel, no dependency on lazy 1) ---
         uint32_t max_lazy3 = 0;
-        if (level >= 4 && ip + 2 < mflimit) {
+        if (level >= ZXC_LEVEL_BALANCED && ip + 2 < mflimit) {
             const uint64_t val3_8 = zxc_le64(ip + 2);
             const uint32_t val3 = (uint32_t)val3_8;
             const uint32_t h3 = zxc_hash_func(val3_8, use_hash5);
@@ -428,7 +448,7 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
                     max_lazy3 = l3 > max_lazy3 ? l3 : max_lazy3;
                 }
 
-                const uint16_t delta = chain_table[idx3];
+                const uint16_t delta = chain_table[idx3 & ZXC_LZ_WINDOW_MASK];
                 if (UNLIKELY(delta == 0)) break;
                 idx3 -= delta;
                 is_first3 = 0;
@@ -641,6 +661,476 @@ static int zxc_encode_block_num(const zxc_cctx_t* RESTRICT ctx, const uint8_t* R
 }
 
 /**
+ * @brief Update dp[p + L_start .. p + L_end) with a constant transition
+ *        cost, in parallel where the target ISA allows.
+ *
+ * For each L in [L_start, L_end), if @p nxt is strictly less than the
+ * current dp[p+L], rewrite dp/parent_len/parent_off in lockstep: same
+ * semantics as the scalar update inside ::zxc_lz77_optimal_parse_glo.
+ * Caller guarantees @p nxt is independent of L (the cost of the L-th
+ * transition does not vary across the requested span).
+ *
+ * Vectorized prologue per ISA, falling through to a scalar tail:
+ *   - AVX-512 BW + VL : 16-wide via vpcmpud + vmask{store,storeu}.
+ *                       Falls back to AVX2 if VL is absent.
+ *   - AVX2            : 8-wide via biased vpcmpgt + vpblendvb (no 32-bit
+ *                       unsigned cmpgt before AVX-512). parent_off is
+ *                       updated with a packed 8x16 mask + 128-bit blend.
+ *   - NEON64 / NEON32 : 4-wide via vcgtq_u32 + vbslq_u32, with vmovn_u32
+ *                       to narrow the mask for the 4x16 parent_off update.
+ *
+ * @param[in,out] dp         DP cost array; dp[p + L] is relaxed when
+ *                           @p nxt < dp[p + L].
+ * @param[in,out] parent_len Backtrack length array, written in lockstep
+ *                           with @p dp; receives the L of the relaxing
+ *                           transition.
+ * @param[in,out] parent_off Backtrack offset array, written in lockstep;
+ *                           receives @p off_biased on relaxation.
+ * @param[in]     p          Source DP position the transitions originate
+ *                           from. Indexing into the three arrays is
+ *                           `p + L`.
+ * @param[in]     L          Initial L value (start of the span, inclusive).
+ * @param[in]     L_end      End of the span (exclusive). Must satisfy
+ *                           @p L_end <= UINT16_MAX so every written length
+ *                           fits in @c parent_len's @c uint16_t cells.
+ * @param[in]     nxt        Constant successor cost `dp[p] + transition`,
+ *                           shared across the [L, L_end) span.
+ * @param[in]     off_biased Match offset minus ::ZXC_LZ_OFFSET_BIAS, the
+ *                           value stored when a transition wins.
+ * @return The first L value not processed (i.e., @p L_end on success).
+ */
+// codeql[cpp/unused-static-function]: false positive
+static ZXC_ALWAYS_INLINE size_t zxc_opt_dp_update_const_cost(
+    uint32_t* RESTRICT dp, uint16_t* RESTRICT parent_len, uint16_t* RESTRICT parent_off,
+    const size_t p, size_t L, const size_t L_end, const uint32_t nxt, const uint16_t off_biased) {
+#if defined(ZXC_USE_AVX512) && defined(__AVX512VL__)
+    if (L + 16 <= L_end) {
+        const __m512i v_inc =
+            _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+        const __m512i v_nxt = _mm512_set1_epi32((int)nxt);
+        const __m256i v_off = _mm256_set1_epi16((int16_t)off_biased);
+        for (; L + 16 <= L_end; L += 16) {
+            const __m512i v_L_lanes = _mm512_add_epi32(v_inc, _mm512_set1_epi32((int)L));
+            const __m512i v_dp = _mm512_loadu_si512((const void*)&dp[p + L]);
+            const __mmask16 m = _mm512_cmplt_epu32_mask(v_nxt, v_dp);
+            _mm512_mask_storeu_epi32(&dp[p + L], m, v_nxt);
+            const __m256i v_L_u16 = _mm512_cvtusepi32_epi16(v_L_lanes);
+            _mm256_mask_storeu_epi16((void*)&parent_len[p + L], m, v_L_u16);
+            _mm256_mask_storeu_epi16((void*)&parent_off[p + L], m, v_off);
+        }
+    }
+#elif defined(ZXC_USE_AVX2)
+    if (L + 8 <= L_end) {
+        const __m256i v_inc = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
+        const __m256i v_nxt = _mm256_set1_epi32((int)nxt);
+        const __m256i v_bias = _mm256_set1_epi32((int)0x80000000);
+        const __m256i v_nxt_b = _mm256_xor_si256(v_nxt, v_bias);
+        const __m128i v_off = _mm_set1_epi16((int16_t)off_biased);
+        for (; L + 8 <= L_end; L += 8) {
+            const __m256i v_L_lanes = _mm256_add_epi32(v_inc, _mm256_set1_epi32((int)L));
+            const __m256i v_dp = _mm256_loadu_si256((const __m256i*)&dp[p + L]);
+            /* Unsigned-compare-via-bias trick:
+             *   (dp ^ 0x80000000) > (nxt ^ 0x80000000)  iff  dp > nxt
+             * because XOR with the sign bit maps unsigned ordering to
+             * signed ordering. AVX2 only has signed cmpgt for 32-bit. */
+            const __m256i v_dp_b = _mm256_xor_si256(v_dp, v_bias);
+            const __m256i v_mask = _mm256_cmpgt_epi32(v_dp_b, v_nxt_b);
+            const __m256i v_dp_new = _mm256_blendv_epi8(v_dp, v_nxt, v_mask);
+            _mm256_storeu_si256((__m256i*)&dp[p + L], v_dp_new);
+            /* Pack 8x int32 mask -> 8x int16 mask with signed saturation:
+             * 0xFFFFFFFF -> 0xFFFF, 0x00000000 -> 0x0000. */
+            const __m128i v_mask16 = _mm_packs_epi32(_mm256_castsi256_si128(v_mask),
+                                                     _mm256_extracti128_si256(v_mask, 1));
+            const __m128i v_L_u16 = _mm_packus_epi32(_mm256_castsi256_si128(v_L_lanes),
+                                                     _mm256_extracti128_si256(v_L_lanes, 1));
+            const __m128i v_pl = _mm_loadu_si128((const __m128i*)&parent_len[p + L]);
+            const __m128i v_pl_new = _mm_blendv_epi8(v_pl, v_L_u16, v_mask16);
+            _mm_storeu_si128((__m128i*)&parent_len[p + L], v_pl_new);
+            const __m128i v_po = _mm_loadu_si128((const __m128i*)&parent_off[p + L]);
+            const __m128i v_po_new = _mm_blendv_epi8(v_po, v_off, v_mask16);
+            _mm_storeu_si128((__m128i*)&parent_off[p + L], v_po_new);
+        }
+    }
+#elif defined(ZXC_USE_NEON64) || defined(ZXC_USE_NEON32)
+    if (L + 4 <= L_end) {
+        static const uint32_t k_inc_array[4] = {0, 1, 2, 3};
+        const uint32x4_t v_inc = vld1q_u32(k_inc_array);
+        const uint32x4_t v_nxt = vdupq_n_u32(nxt);
+        const uint16x4_t v_off = vdup_n_u16(off_biased);
+        for (; L + 4 <= L_end; L += 4) {
+            const uint32x4_t v_L_lanes = vaddq_u32(v_inc, vdupq_n_u32((uint32_t)L));
+            const uint32x4_t v_dp = vld1q_u32(&dp[p + L]);
+            const uint32x4_t v_mask = vcgtq_u32(v_dp, v_nxt);
+            vst1q_u32(&dp[p + L], vbslq_u32(v_mask, v_nxt, v_dp));
+            const uint16x4_t v_mask16 = vmovn_u32(v_mask);
+            const uint16x4_t v_L_u16 = vqmovn_u32(v_L_lanes);
+            const uint16x4_t v_pl = vld1_u16(&parent_len[p + L]);
+            vst1_u16(&parent_len[p + L], vbsl_u16(v_mask16, v_L_u16, v_pl));
+            const uint16x4_t v_po = vld1_u16(&parent_off[p + L]);
+            vst1_u16(&parent_off[p + L], vbsl_u16(v_mask16, v_off, v_po));
+        }
+    }
+#endif
+    /* Scalar tail (and full path on archs without SIMD).
+     * L < L_end <= UINT16_MAX (caller precondition), so the cast is lossless. */
+    for (; L < L_end; L++) {
+        if (nxt < dp[p + L]) {
+            dp[p + L] = nxt;
+            parent_len[p + L] = (uint16_t)L;
+            parent_off[p + L] = off_biased;
+        }
+    }
+    return L;
+}
+
+/**
+ * @brief Estimate per-block literal cost from a sampled histogram passed
+ *        through the actual length-limited Huffman builder.
+ *
+ * Strategy: build a strided sample of @p src (4096 entries), run the same
+ * length-limited Huffman code construction the encoder uses, and report the
+ * sample-weighted average code length. This is the predicted bits/byte
+ * for Huffman-encoded literals on this distribution: no calibration
+ * constants, no per-corpus tuning. The cap at 8 reflects that RAW is
+ * always available at exactly that cost; if Huffman doesn't beat 8 on the
+ * sample, the encoder will pick RAW and 8 is the right price.
+ *
+ * @param[in] src     Source buffer for the block.
+ * @param[in] src_sz  Length of @p src in bytes.
+ * @param[in] scratch Package-merge scratch (pre-allocated in the cctx for
+ *                    level >= 6). May be `NULL`, in which case the builder
+ *                    allocates its own working memory.
+ * @return Estimated literal cost in bits, in `[1, 8]`.
+ */
+// codeql[cpp/unused-static-function]: false positive
+static uint32_t zxc_opt_estimate_lit_bits(const uint8_t* RESTRICT src, const size_t src_sz,
+                                          void* RESTRICT scratch) {
+    if (UNLIKELY(src_sz < ZXC_OPT_LIT_SAMPLE_MIN)) return CHAR_BIT;
+
+    uint32_t hist[ZXC_HUF_NUM_SYMBOLS] = {0};
+    const size_t step = (src_sz > 4096) ? (src_sz >> 12) : 1U;
+    size_t sampled = 0;
+    for (size_t i = 0; i < src_sz; i += step) {
+        hist[src[i]]++;
+        sampled++;
+    }
+
+    uint8_t code_len[ZXC_HUF_NUM_SYMBOLS];
+    if (UNLIKELY(zxc_huf_build_code_lengths(hist, code_len, scratch) != ZXC_OK)) return CHAR_BIT;
+
+    /* Sample-weighted sum of code lengths == predicted total Huffman bits
+     * for the sample. Divide by sample count for bits/byte, rounded up
+     * (DP works in integer bits; rounding up errs on the conservative
+     * side, slightly favoring matches over fractional-cost literals). */
+    uint64_t total_bits = 0;
+    for (int k = 0; k < ZXC_HUF_NUM_SYMBOLS; k++) {
+        total_bits += (uint64_t)hist[k] * (uint64_t)code_len[k];
+    }
+    const uint32_t avg = (uint32_t)((total_bits + sampled - 1) / sampled);
+
+    /* Cap at RAW cost: if Huffman can't beat 8 bits/byte on the sample,
+     * the encoder will pick RAW anyway and 8 is the actual literal cost. */
+    return (avg < CHAR_BIT) ? avg : CHAR_BIT;
+}
+
+/**
+ * @brief Static price-based optimal LZ77 parser for level 6.
+ *
+ * Forward DP over the block's positions: `dp[p]` = min bit cost to encode
+ * `src[0..p)`. Per-position transitions are
+ *   - literal: `dp[p+1] = min(dp[p+1], dp[p] + lit_cost`
+ *   - match  : `dp[p+L] = min(dp[p+L], dp[p] + match_cost(L))` for L in
+ *              `[MIN_MATCH, max_L]`
+ * where `max_L` is the longest match found by ::zxc_lz77_find_best_match at
+ * `p` (with lazy disabled, the DP itself handles position-based
+ * optimization). Backtracking from `dp[src_sz]` reconstructs the
+ * optimal token sequence.
+ *
+ * Complexity guard: ::ZXC_OPT_LONG_MATCH_SKIP causes ::zxc_lz77_find_best_match
+ * to be skipped at positions strictly inside a long match, without this
+ * guard, highly repetitive data (e.g. Lorem-loop with multi-MB matches at
+ * every offset) makes the parser quadratic and unit tests run for minutes.
+ * The inner sub-length update loop visits every L from `MIN_MATCH` to
+ * `max_L`; the skip threshold means each long-match region only pays its
+ * O(L) cost once at the starting position, keeping total work O(N).
+ *
+ * @param[in,out] ctx           Compression context. The lazy-allocated
+ *                              `opt_scratch` field provides the DP arrays;
+ *                              it is grown on first use and reused on
+ *                              subsequent blocks.
+ * @param[in]  src              Source buffer to parse.
+ * @param[in]  src_sz           Length of @p src in bytes.
+ * @param[in,out] hash_table    LZ77 hash table (epoch | position entries).
+ * @param[in,out] hash_tags     8-bit fast-rejection tags paired with @p hash_table.
+ * @param[in,out] chain_table   Hash-chain link table (ring buffer).
+ * @param[in]  epoch_mark       Current epoch shifted into the high bits.
+ * @param[in]  offset_mask      Mask isolating the position bits in chain entries.
+ * @param[in]  level            Compression level (used to size the matcher).
+ * @param[out] literals         Buffer receiving the gathered literal bytes.
+ * @param[out] buf_tokens       Buffer receiving the per-sequence token bytes.
+ * @param[out] buf_offsets      Buffer receiving the per-sequence offsets.
+ * @param[out] buf_extras       Buffer receiving variable-length overflow data.
+ * @param[out] seq_c_out        Number of emitted sequences.
+ * @param[out] lit_c_out        Number of literal bytes written into @p literals.
+ * @param[out] extras_sz_out    Number of bytes written into @p buf_extras.
+ * @param[out] max_offset_out   Largest biased offset emitted (used by the caller
+ *                              to choose 1-byte vs 2-byte offset encoding).
+ *
+ * @return `ZXC_OK` on success, or `ZXC_ERROR_MEMORY` if the DP scratch
+ *         allocations fail.
+ */
+static int zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
+                                      const size_t src_sz, uint32_t* RESTRICT hash_table,
+                                      uint8_t* RESTRICT hash_tags, uint16_t* RESTRICT chain_table,
+                                      const uint32_t epoch_mark, const uint32_t offset_mask,
+                                      const int level, uint8_t* RESTRICT literals,
+                                      uint8_t* RESTRICT buf_tokens, uint16_t* RESTRICT buf_offsets,
+                                      uint8_t* RESTRICT buf_extras, uint32_t* RESTRICT seq_c_out,
+                                      size_t* RESTRICT lit_c_out, size_t* RESTRICT extras_sz_out,
+                                      uint16_t* RESTRICT max_offset_out) {
+    zxc_lz77_params_t lzp_opt = zxc_get_lz77_params(level);
+    lzp_opt.use_lazy = 0;  // guard
+
+    const uint8_t* const iend = src + src_sz;
+
+    /* Block too small for any match: emit all as literals. */
+    if (UNLIKELY(src_sz < 13)) {
+        if (src_sz > 0) ZXC_MEMCPY(literals, src, src_sz);
+        *lit_c_out = src_sz;
+        *seq_c_out = 0;
+        *extras_sz_out = 0;
+        *max_offset_out = 0;
+        return ZXC_OK;
+    }
+
+    const size_t mflimit_pos = src_sz - 12;
+    const uint8_t* const mflimit = src + mflimit_pos;
+
+    /* DP arrays carved from ctx->opt_scratch: a single allocation lazy-
+     * grown on the first level-6 call and reused across blocks. Each
+     * sub-buffer is cache-line padded so the next one starts on a 64 B
+     * boundary. The total `needed` matches zxc_estimate_cctx_size() keep
+     * the formula in sync.
+     *
+     *   dp             : (chunk+1) x uint32_t: min cost to reach position p.
+     *   parent_len     : (chunk+1) x uint16_t: 0 = literal, >= MIN_MATCH = match.
+     *   parent_off     : (chunk+1) x uint16_t: biased match offset (distance-1).
+     *   match_end_bits : ceil((chunk+1)/64) x uint64_t: 1 bit per position,
+     *                                                  set when that position
+     *                                                  is the end of a match
+     *                                                  on the chosen DP path.
+     *                                                  Replaces a forward-order
+     *                                                  actions[] stack at 1/64
+     *                                                  the cost.
+     *
+     * The same buffer is reused as transient scratch for the length-limited
+     * Huffman code-length builder (see zxc_opt_estimate_lit_bits below and
+     * the Huffman selection in zxc_encode_block_glo): the package-merge
+     * scratch is needed before the DP runs and again after the parse has
+     * been read out, so the lifetimes never overlap. The capacity is the
+     * larger of the two demands. */
+    const size_t chunk = ctx->chunk_size;
+    const size_t sz_dp = ZXC_ALIGN_CL((chunk + 1) * sizeof(uint32_t));
+    const size_t sz_pl = ZXC_ALIGN_CL((chunk + 1) * sizeof(uint16_t));
+    const size_t sz_po = ZXC_ALIGN_CL((chunk + 1) * sizeof(uint16_t));
+    const size_t n_bm_words = (chunk + 1 + 63) / 64;
+    const size_t sz_bm = ZXC_ALIGN_CL(n_bm_words * sizeof(uint64_t));
+    const size_t dp_needed = sz_dp + sz_pl + sz_po + sz_bm;
+    const size_t needed =
+        (dp_needed > ZXC_HUF_BUILD_SCRATCH_SIZE) ? dp_needed : ZXC_HUF_BUILD_SCRATCH_SIZE;
+
+    if (UNLIKELY(ctx->opt_scratch_cap < needed)) {
+        if (ctx->opt_scratch) zxc_aligned_free(ctx->opt_scratch);
+        ctx->opt_scratch = (uint8_t*)zxc_aligned_malloc(needed, ZXC_CACHE_LINE_SIZE);
+        if (UNLIKELY(!ctx->opt_scratch)) {
+            ctx->opt_scratch_cap = 0;
+            return ZXC_ERROR_MEMORY;
+        }
+        ctx->opt_scratch_cap = needed;
+    }
+
+    /* Per-block literal cost: */
+    const uint32_t lit_cost = zxc_opt_estimate_lit_bits(src, src_sz, ctx->opt_scratch);
+
+    uint32_t* const dp = (uint32_t*)ctx->opt_scratch;
+    uint16_t* const parent_len = (uint16_t*)(ctx->opt_scratch + sz_dp);
+    uint16_t* const parent_off = (uint16_t*)(ctx->opt_scratch + sz_dp + sz_pl);
+    uint64_t* const match_end_bits = (uint64_t*)(ctx->opt_scratch + sz_dp + sz_pl + sz_po);
+
+    dp[0] = 0;
+    ZXC_MEMSET(dp + 1, 0xFF, src_sz * sizeof(uint32_t));
+    ZXC_MEMSET(parent_len, 0, sz_pl + sz_po + sz_bm);
+
+    /* Forward DP: visit every position, update reachable successors.
+     * `skip_until` skips find_best_match at positions strictly inside the
+     * last long match, the DP transition from the start of the match
+     * already covers dp[p+1..p+L], and re-searching at every intra-match
+     * position is what makes the parser quadratic on repetitive inputs. */
+    size_t skip_until = 0;
+    for (size_t p = 0; p < mflimit_pos; p++) {
+        if (UNLIKELY(dp[p] == UINT32_MAX)) continue;
+
+        /* Literal transition. */
+        const uint32_t lit_next = dp[p] + lit_cost;
+        if (lit_next < dp[p + 1]) {
+            dp[p + 1] = lit_next;
+            parent_len[p + 1] = 0;
+        }
+
+        if (p < skip_until) continue;
+
+        /* Match transition: call find_best_match (no lazy, no backtrack via
+         * anchor=ip). Iterate sub-lengths since any L <= max_L matches at the
+         * same offset and may end at a more useful DP position. */
+        const uint8_t* ip = src + p;
+        const zxc_match_t m =
+            zxc_lz77_find_best_match(src, ip, iend, mflimit, /*anchor=*/ip, hash_table, hash_tags,
+                                     chain_table, epoch_mark, offset_mask, level, lzp_opt);
+
+        if (m.ref) {
+            const uint32_t off = (uint32_t)(ip - m.ref);
+            if (off > 0 && off <= ZXC_LZ_WINDOW_SIZE) {
+                const size_t L_max_raw = (m.len > src_sz - p) ? (src_sz - p) : (size_t)m.len;
+                const size_t L_max = (L_max_raw > UINT16_MAX) ? UINT16_MAX : L_max_raw;
+
+                /* The L-iteration cost function is piecewise constant in
+                 * varint segments. Split the [MIN_MATCH, L_max] span into:
+                 *   1. cheap   : v < ML_MASK            -> cost = base
+                 *   2. varint1 : v in [ML_MASK, ML_MASK + 128) -> cost = base + 8
+                 *   3. varint2+: v >= ML_MASK + 128     -> cost = base + 16, +24, ...
+                 *
+                 * Steps 1 and 2 use constant nxt and are vectorized via
+                 * the helper. Step 3 is rare (typical matches are short)
+                 * and stays scalar. */
+                const uint16_t off_biased = (uint16_t)(off - ZXC_LZ_OFFSET_BIAS);
+                const size_t L_max_plus = L_max + 1;
+                size_t L = ZXC_LZ_MIN_MATCH_LEN;
+
+                /* 1. Cheap range. */
+                {
+                    const size_t L_cheap_end = ZXC_LZ_MIN_MATCH_LEN + ZXC_TOKEN_ML_MASK;
+                    const size_t L_end = (L_max_plus < L_cheap_end) ? L_max_plus : L_cheap_end;
+                    const uint32_t nxt = dp[p] + ZXC_OPT_MATCH_COST_BASE;
+                    L = zxc_opt_dp_update_const_cost(dp, parent_len, parent_off, p, L, L_end, nxt,
+                                                     off_biased);
+                }
+
+                /* 2. First varint level (1-byte extension). */
+                if (L < L_max_plus) {
+                    const size_t L_v1_end = ZXC_LZ_MIN_MATCH_LEN + ZXC_TOKEN_ML_MASK + 128;
+                    const size_t L_end = (L_max_plus < L_v1_end) ? L_max_plus : L_v1_end;
+                    const uint32_t nxt = dp[p] + ZXC_OPT_MATCH_COST_BASE + CHAR_BIT;
+                    L = zxc_opt_dp_update_const_cost(dp, parent_len, parent_off, p, L, L_end, nxt,
+                                                     off_biased);
+                }
+
+                /* 3. Higher varint levels: variable cost, kept scalar.
+                 * Reached only by L >= ML_MASK + 128 + MIN_MATCH, so the
+                 * v >= ML_MASK guard from the original loop is implied. */
+                for (; L < L_max_plus; L++) {
+                    uint32_t cost = ZXC_OPT_MATCH_COST_BASE;
+                    uint32_t v = (uint32_t)(L - ZXC_LZ_MIN_MATCH_LEN) - ZXC_TOKEN_ML_MASK;
+                    cost += CHAR_BIT;
+                    while (v >= 128) {
+                        v >>= 7;
+                        cost += CHAR_BIT;
+                    }
+                    const uint32_t nxt = dp[p] + cost;
+                    if (nxt < dp[p + L]) {
+                        dp[p + L] = nxt;
+                        parent_len[p + L] = (uint16_t)L;
+                        parent_off[p + L] = off_biased;
+                    }
+                }
+                if (UNLIKELY(L_max >= ZXC_OPT_LONG_MATCH_SKIP)) skip_until = p + L_max - 1;
+            }
+        }
+    }
+
+    /* Last 12 bytes can only be literals (matches must end before iend). */
+    for (size_t p = mflimit_pos; p < src_sz; p++) {
+        if (UNLIKELY(dp[p] == UINT32_MAX)) continue;
+        const uint32_t lit_next = dp[p] + lit_cost;
+        if (lit_next < dp[p + 1]) {
+            dp[p + 1] = lit_next;
+            parent_len[p + 1] = 0;
+        }
+    }
+
+    /* Backtrack from src_sz to 0: only match endpoints are recorded (one bit
+     * per position in match_end_bits). Literals between matches are implicit
+     * runs of unmarked positions and are reconstructed during forward emission
+     * via lit_start tracking, so they need no backtrack storage. */
+    {
+        size_t pos = src_sz;
+        while (pos > 0) {
+            const uint32_t L = parent_len[pos];
+            if (L == 0) {
+                pos -= 1;
+            } else {
+                match_end_bits[pos >> 6] |= (uint64_t)1 << (pos & 63);
+                pos -= L;
+            }
+        }
+    }
+
+    /* Forward emission: walk match_end_bits word-by-word, peeling set bits
+     * with ctzll. Each set bit gives a match endpoint; parent_len/parent_off
+     * at that position recover (length, offset). */
+    uint32_t seq_c = 0;
+    size_t lit_c = 0;
+    size_t extras_sz = 0;
+    uint16_t max_offset = 0;
+    size_t lit_start = 0;
+
+    for (size_t word_idx = 0; word_idx < n_bm_words; word_idx++) {
+        uint64_t w = match_end_bits[word_idx];
+        while (w) {
+            const size_t pos = (word_idx << 6) + (size_t)zxc_ctz64(w);
+            w &= w - 1;
+            const uint32_t L = parent_len[pos];
+            const uint16_t off_biased = parent_off[pos];
+            const size_t match_start = pos - L;
+
+            const size_t LL = match_start - lit_start;
+            if (LL > 0) {
+                ZXC_MEMCPY(literals + lit_c, src + lit_start, LL);
+                lit_c += LL;
+            }
+            const uint32_t ll = (uint32_t)LL;
+            const uint32_t ml = L - ZXC_LZ_MIN_MATCH_LEN;
+            const uint8_t ll_code = (ll >= ZXC_TOKEN_LL_MASK) ? ZXC_TOKEN_LL_MASK : (uint8_t)ll;
+            const uint8_t ml_code = (ml >= ZXC_TOKEN_ML_MASK) ? ZXC_TOKEN_ML_MASK : (uint8_t)ml;
+            buf_tokens[seq_c] = (ll_code << ZXC_TOKEN_LIT_BITS) | ml_code;
+            buf_offsets[seq_c] = off_biased;
+            if (off_biased > max_offset) max_offset = off_biased;
+
+            if (UNLIKELY(ll >= ZXC_TOKEN_LL_MASK))
+                extras_sz += zxc_write_varint(buf_extras + extras_sz, ll - ZXC_TOKEN_LL_MASK);
+            if (UNLIKELY(ml >= ZXC_TOKEN_ML_MASK))
+                extras_sz += zxc_write_varint(buf_extras + extras_sz, ml - ZXC_TOKEN_ML_MASK);
+
+            seq_c++;
+            lit_start = pos;
+        }
+    }
+
+    /* Tail literals after the last match (or all literals if no match). */
+    if (lit_start < src_sz) {
+        const size_t tail = src_sz - lit_start;
+        ZXC_MEMCPY(literals + lit_c, src + lit_start, tail);
+        lit_c += tail;
+    }
+
+    *seq_c_out = seq_c;
+    *lit_c_out = lit_c;
+    *extras_sz_out = extras_sz;
+    *max_offset_out = max_offset;
+
+    return ZXC_OK;
+}
+
+/**
  * @brief Encodes a data block using the General (GLO) compression format.
  *
  * This function implements the core LZ77 compression logic. It dynamically
@@ -718,10 +1208,28 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
     size_t extras_sz = 0;
     uint16_t max_offset = 0;  // Track max offset for 1-byte/2-byte mode decision
 
+    /* Level 6+: price-based optimal parser (fills outputs and skips the
+     * lazy loop + last_lits handling below via `goto parse_done`). */
+    if (level >= ZXC_LEVEL_DENSITY) {
+        const int rc_opt = zxc_lz77_optimal_parse_glo(
+            ctx, src, src_sz, hash_table, hash_tags, chain_table, epoch_mark, offset_mask, level,
+            literals, buf_tokens, buf_offsets, buf_extras, &seq_c, &lit_c, &extras_sz, &max_offset);
+        if (UNLIKELY(rc_opt != ZXC_OK)) return rc_opt;
+        goto parse_done;
+    }
+
     while (LIKELY(ip < mflimit)) {
         const size_t dist = (size_t)(ip - anchor);
         size_t step = lzp.step_base + (dist >> lzp.step_shift);
         if (UNLIKELY(ip + step >= mflimit)) step = 1;
+
+        if (LIKELY(ip + step + sizeof(uint64_t) <= iend)) {
+            const uint64_t v_next = zxc_le64(ip + step);
+            // cppcheck-suppress unreadVariable
+            const uint32_t h_next = zxc_hash_func(v_next, 1);
+            ZXC_PREFETCH_READ(&hash_tags[h_next]);
+            ZXC_PREFETCH_READ(&hash_table[h_next]);
+        }
 
         const zxc_match_t m =
             zxc_lz77_find_best_match(src, ip, iend, mflimit, anchor, hash_table, hash_tags,
@@ -761,22 +1269,22 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
 
             seq_c++;
 
-            if (m.len > 2 && level > 4) {
+            if (m.len > 2 && level > ZXC_LEVEL_BALANCED) {
                 const uint8_t* match_end = ip + m.len;
                 if (match_end < iend - 7) {
                     const uint32_t pos_u = (uint32_t)((match_end - 2) - src);
                     const uint64_t val_u8 = zxc_le64(match_end - 2);
                     const uint32_t val_u = (uint32_t)val_u8;
-                    const uint32_t h_u =
-                        zxc_hash_func(val_u8, 1);  // Only for level > 4, uses hash5
+                    const uint32_t h_u = zxc_hash_func(val_u8, 1);
                     const uint32_t prev_head = hash_table[h_u];
                     const uint32_t prev_idx =
                         (prev_head & ~offset_mask) == epoch_mark ? (prev_head & offset_mask) : 0;
                     hash_table[h_u] = epoch_mark | pos_u;
                     hash_tags[h_u] = (uint8_t)(val_u ^ (val_u >> 16));
-                    chain_table[pos_u] = (prev_idx > 0 && (pos_u - prev_idx) < ZXC_LZ_WINDOW_SIZE)
-                                             ? (uint16_t)(pos_u - prev_idx)
-                                             : 0;
+                    chain_table[pos_u & ZXC_LZ_WINDOW_MASK] =
+                        (prev_idx > 0 && (pos_u - prev_idx) < ZXC_LZ_WINDOW_SIZE)
+                            ? (uint16_t)(pos_u - prev_idx)
+                            : 0;
                 }
             }
 
@@ -793,6 +1301,7 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         lit_c += last_lits;
     }
 
+parse_done:;
     // --- RLE ANALYSIS ---
     size_t rle_size = 0;
     int enc_lit = ZXC_SECTION_ENCODING_RAW;
@@ -834,17 +1343,13 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
             while (p <= p_end - 16) {
                 const uint8x16_t v = vld1q_u8(p);
                 const uint8x16_t eq = vceqq_u8(v, vb);
-                if (vminvq_u8(eq) == 0xFF) {
+                /* SHRN nibble-mask: see find_best_match above for rationale. */
+                const uint64_t mask =
+                    vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(eq), 4)), 0);
+                if (LIKELY(mask == ~(uint64_t)0)) {
                     p += 16;
                 } else {
-                    const uint8x16_t not_eq = vmvnq_u8(eq);
-                    const uint64_t lo = vgetq_lane_u64(vreinterpretq_u64_u8(not_eq), 0);
-                    if (lo != 0) {
-                        p += (zxc_ctz64(lo) >> 3);
-                    } else {
-                        const uint64_t hi = vgetq_lane_u64(vreinterpretq_u64_u8(not_eq), 1);
-                        p += 8 + (zxc_ctz64(hi) >> 3);
-                    }
+                    p += (size_t)(zxc_ctz64(~mask) >> 2);
                     goto _run_done;
                 }
             }
@@ -940,16 +1445,16 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
                     uint8x16_t v3 = vld1q_u8(p + 3);
                     uint8x16_t eq =
                         vandq_u8(vceqq_u8(v0, v1), vandq_u8(vceqq_u8(v1, v2), vceqq_u8(v2, v3)));
-                    if (vmaxvq_u8(eq) == 0) {
+                    /* Dual of the run scan: searching for the FIRST set
+                     * nibble (a position where 4 consecutive bytes match).
+                     * mask == 0 means no break found in this 16-byte
+                     * window. Same SHRN compression as elsewhere. */
+                    const uint64_t mask = vget_lane_u64(
+                        vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(eq), 4)), 0);
+                    if (LIKELY(mask == 0)) {
                         p += 16;
                     } else {
-                        uint64_t lo = vgetq_lane_u64(vreinterpretq_u64_u8(eq), 0);
-                        if (lo != 0) {
-                            p += (zxc_ctz64(lo) >> 3);
-                        } else {
-                            uint64_t hi = vgetq_lane_u64(vreinterpretq_u64_u8(eq), 1);
-                            p += 8 + (zxc_ctz64(hi) >> 3);
-                        }
+                        p += (size_t)(zxc_ctz64(mask) >> 2);
                         goto _lit_done;
                     }
                 }
@@ -1010,6 +1515,64 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         if (rle_size < lit_c - (lit_c >> 5)) enc_lit = ZXC_SECTION_ENCODING_RLE;
     }
 
+    /* Level >= 6: also evaluate Huffman as a 3rd literal-encoding candidate.
+     * Build a histogram and length-limited canonical code lengths, compute the
+     * exact byte size of the 4-way interleaved bitstream + 134-byte header,
+     * and switch to HUFFMAN if it beats the current choice by >= 3%. */
+    uint8_t huf_code_len[ZXC_HUF_NUM_SYMBOLS];
+    size_t huf_total_size = SIZE_MAX;
+    if (level >= ZXC_LEVEL_DENSITY && lit_c >= ZXC_HUF_MIN_LITERALS) {
+        uint32_t freq0[ZXC_HUF_NUM_SYMBOLS] = {0};
+        uint32_t freq1[ZXC_HUF_NUM_SYMBOLS] = {0};
+        uint32_t freq2[ZXC_HUF_NUM_SYMBOLS] = {0};
+        uint32_t freq3[ZXC_HUF_NUM_SYMBOLS] = {0};
+        {
+            size_t i = 0;
+            for (; i + 4 <= lit_c; i += 4) {
+                freq0[literals[i + 0]]++;
+                freq1[literals[i + 1]]++;
+                freq2[literals[i + 2]]++;
+                freq3[literals[i + 3]]++;
+            }
+            for (; i < lit_c; i++) freq0[literals[i]]++;
+        }
+        uint32_t freq[ZXC_HUF_NUM_SYMBOLS];
+        for (int k = 0; k < ZXC_HUF_NUM_SYMBOLS; k++) {
+            freq[k] = freq0[k] + freq1[k] + freq2[k] + freq3[k];
+        }
+
+        if (zxc_huf_build_code_lengths(freq, huf_code_len, ctx->opt_scratch) == ZXC_OK) {
+            const size_t Q = (lit_c + ZXC_HUF_NUM_STREAMS - 1) / ZXC_HUF_NUM_STREAMS;
+            size_t streams_bytes = 0;
+            for (int s = 0; s < ZXC_HUF_NUM_STREAMS; s++) {
+                size_t start = (size_t)s * Q;
+                size_t stop = start + Q;
+                if (start > lit_c) start = lit_c;
+                if (stop > lit_c) stop = lit_c;
+                uint64_t b0 = 0, b1 = 0, b2 = 0, b3 = 0;
+                size_t i = start;
+
+                for (; i + 4 <= stop; i += 4) {
+                    b0 += huf_code_len[literals[i + 0]];
+                    b1 += huf_code_len[literals[i + 1]];
+                    b2 += huf_code_len[literals[i + 2]];
+                    b3 += huf_code_len[literals[i + 3]];
+                }
+                uint64_t bits = b0 + b1 + b2 + b3;
+                for (; i < stop; i++) bits += huf_code_len[literals[i]];
+                streams_bytes += (size_t)((bits + 7) / 8);
+            }
+            huf_total_size = ZXC_HUF_HEADER_SIZE + streams_bytes;
+            const size_t baseline =
+                (enc_lit == ZXC_SECTION_ENCODING_RLE) ? rle_size : (size_t)lit_c;
+            /* Threshold: 3% savings (1/32) over the chosen RAW/RLE baseline.
+             * Same heuristic as the RAW/RLE switch above. */
+            if (huf_total_size < baseline - (baseline >> 5)) {
+                enc_lit = ZXC_SECTION_ENCODING_HUFFMAN;
+            }
+        }
+    }
+
     zxc_block_header_t bh = {.block_type = ZXC_BLOCK_GLO};
     uint8_t* const p = dst + ZXC_BLOCK_HEADER_SIZE;
     size_t rem = dst_cap - ZXC_BLOCK_HEADER_SIZE;
@@ -1026,8 +1589,10 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
                                  .enc_off = (uint8_t)use_8bit_off};
 
     zxc_section_desc_t desc[ZXC_GLO_SECTIONS] = {0};
-    desc[0].sizes = (uint64_t)(enc_lit == ZXC_SECTION_ENCODING_RLE ? rle_size : lit_c) |
-                    ((uint64_t)lit_c << 32);
+    const size_t lit_section_size = (enc_lit == ZXC_SECTION_ENCODING_RLE)       ? rle_size
+                                    : (enc_lit == ZXC_SECTION_ENCODING_HUFFMAN) ? huf_total_size
+                                                                                : (size_t)lit_c;
+    desc[0].sizes = (uint64_t)lit_section_size | ((uint64_t)lit_c << 32);
     desc[1].sizes = (uint64_t)seq_c | ((uint64_t)seq_c << 32);
     desc[2].sizes = (uint64_t)off_stream_size | ((uint64_t)off_stream_size << 32);
     desc[3].sizes = (uint64_t)extras_sz | ((uint64_t)extras_sz << 32);
@@ -1046,7 +1611,13 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
 
     if (UNLIKELY(rem < sz_lit)) return ZXC_ERROR_DST_TOO_SMALL;
 
-    if (enc_lit == ZXC_SECTION_ENCODING_RLE) {
+    if (enc_lit == ZXC_SECTION_ENCODING_HUFFMAN) {
+        const int written =
+            zxc_huf_encode_section(literals, (size_t)lit_c, huf_code_len, p_curr, rem);
+        if (UNLIKELY(written < 0)) return written;
+        if (UNLIKELY((size_t)written != huf_total_size)) return ZXC_ERROR_DST_TOO_SMALL;
+        p_curr += written;
+    } else if (enc_lit == ZXC_SECTION_ENCODING_RLE) {
         // Write RLE - optimized single-pass encoding
         const uint8_t* lit_ptr = literals;
         const uint8_t* const lit_end = literals + lit_c;
@@ -1224,6 +1795,14 @@ static int zxc_encode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         if (UNLIKELY(ip + step >= mflimit)) step = 1;
 
         ZXC_PREFETCH_READ(ip + step * 4 + ZXC_CACHE_LINE_SIZE);
+
+        if (LIKELY(ip + step + sizeof(uint64_t) <= iend)) {
+            const uint64_t v_next = zxc_le64(ip + step);
+            // cppcheck-suppress unreadVariable
+            const uint32_t h_next = zxc_hash_func(v_next, 0);
+            ZXC_PREFETCH_READ(&hash_tags[h_next]);
+            ZXC_PREFETCH_READ(&hash_table[h_next]);
+        }
 
         const zxc_match_t m =
             zxc_lz77_find_best_match(src, ip, iend, mflimit, anchor, hash_table, hash_tags,

--- a/lz/zxc/src/lib/zxc_decompress.c
+++ b/lz/zxc/src/lib/zxc_decompress.c
@@ -14,19 +14,25 @@
  * @c ZXC_FUNCTION_SUFFIX to produce per-ISA variants.
  */
 
-#include "../../include/zxc_error.h"
-#include "../../include/zxc_sans_io.h"
-#include "zxc_internal.h"
-
 /*
  * Function Multi-Versioning Support
- * If ZXC_FUNCTION_SUFFIX is defined (e.g. _avx2), rename the public entry point.
+ * If ZXC_FUNCTION_SUFFIX is defined (e.g. _avx2, _neon), rename the public
+ * entry point AND the Huffman decoder consumed by this TU. The defines sit
+ * before zxc_internal.h so that the prototypes the header declares are also
+ * rewritten with the suffix, keeping callers and callees consistent.
  */
 #ifdef ZXC_FUNCTION_SUFFIX
 #define ZXC_CAT_IMPL(x, y) x##y
 #define ZXC_CAT(x, y) ZXC_CAT_IMPL(x, y)
 #define zxc_decompress_chunk_wrapper ZXC_CAT(zxc_decompress_chunk_wrapper, ZXC_FUNCTION_SUFFIX)
+#define zxc_decompress_chunk_wrapper_safe \
+    ZXC_CAT(zxc_decompress_chunk_wrapper_safe, ZXC_FUNCTION_SUFFIX)
+#define zxc_huf_decode_section ZXC_CAT(zxc_huf_decode_section, ZXC_FUNCTION_SUFFIX)
 #endif
+
+#include "../../include/zxc_error.h"
+#include "../../include/zxc_sans_io.h"
+#include "zxc_internal.h"
 
 /**
  * @brief Consumes a specified number of bits from the bit reader buffer without
@@ -360,14 +366,14 @@ static int zxc_decode_block_num(const uint8_t* RESTRICT src, const size_t src_si
     uint32_t deltas[ZXC_NUM_DEC_BATCH];
 
     while (vals_remaining > 0) {
-        if (UNLIKELY(offset + ZXC_NUM_CHUNK_HEADER_SIZE > src_size)) return ZXC_ERROR_SRC_TOO_SMALL;
+        if (UNLIKELY(offset > src_size - ZXC_NUM_CHUNK_HEADER_SIZE)) return ZXC_ERROR_SRC_TOO_SMALL;
 
         const uint16_t nvals = zxc_le16(src + offset);
         const uint16_t bits = zxc_le16(src + offset + 2);
         const uint32_t psize = zxc_le32(src + offset + 12);  // padding + nvals + bits
         offset += ZXC_NUM_CHUNK_HEADER_SIZE;
 
-        if (UNLIKELY(nvals > vals_remaining || src_size < offset + psize ||
+        if (UNLIKELY(nvals > vals_remaining || psize > src_size - offset ||
                      (size_t)(d_end - d_ptr) < (size_t)nvals * sizeof(uint32_t) ||
                      bits > (sizeof(uint32_t) * CHAR_BIT)))
             return ZXC_ERROR_CORRUPT_DATA;
@@ -478,179 +484,12 @@ static int zxc_decode_block_num(const uint8_t* RESTRICT src, const size_t src_si
     return (int)(d_ptr - dst);
 }
 
-/**
- * @brief Decodes a General Low (GLO) format compressed block.
- *
- * This function handles the decoding of a compressed block formatted with the
- * internal GLO structure. The decompressed size is derived from Section
- * Descriptors within the compressed payload.
- *
- * @param[in,out] ctx Pointer to the compression context (`zxc_cctx_t`) containing
- * @param[in] src Pointer to the source buffer containing compressed data.
- * @param[in] src_size Size of the source buffer in bytes.
- * @param[out] dst Pointer to the destination buffer for decompressed data.
- * @param[in] dst_capacity Maximum capacity of the destination buffer.
- *
- * @return The number of bytes written to the destination buffer on success, or
- * a negative zxc_error_t code on failure (e.g., invalid header, buffer overflow, or corrupted
- * data).
- */
-static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
-                                const size_t src_size, uint8_t* RESTRICT dst,
-                                const size_t dst_capacity) {
-    zxc_gnr_header_t gh;
-    zxc_section_desc_t desc[ZXC_GLO_SECTIONS];
-
-    if (UNLIKELY(zxc_read_glo_header_and_desc(src, src_size, &gh, desc) != ZXC_OK))
-        return ZXC_ERROR_BAD_HEADER;
-
-    const uint8_t* p_data =
-        src + ZXC_GLO_HEADER_BINARY_SIZE + ZXC_GLO_SECTIONS * ZXC_SECTION_DESC_BINARY_SIZE;
-    const uint8_t* p_curr = p_data;
-
-    // --- Literal Stream Setup ---
-    const uint8_t* l_ptr;
-    const uint8_t* l_end;
-    uint8_t* rle_buf = NULL;
-
-    size_t lit_stream_size = (size_t)(desc[0].sizes & ZXC_SECTION_SIZE_MASK);
-
-    if (gh.enc_lit == ZXC_SECTION_ENCODING_RLE) {
-        const size_t required_size = (size_t)(desc[0].sizes >> 32);
-
-        if (required_size > 0) {
-            if (UNLIKELY(required_size > dst_capacity)) return ZXC_ERROR_DST_TOO_SMALL;
-
-            if (ctx->lit_buffer_cap < required_size + ZXC_PAD_SIZE) {
-                uint8_t* new_buf = (uint8_t*)realloc(ctx->lit_buffer, required_size + ZXC_PAD_SIZE);
-                if (UNLIKELY(!new_buf)) {
-                    free(ctx->lit_buffer);
-                    ctx->lit_buffer = NULL;
-                    ctx->lit_buffer_cap = 0;
-                    return ZXC_ERROR_MEMORY;
-                }
-                ctx->lit_buffer = new_buf;
-                ctx->lit_buffer_cap = required_size + ZXC_PAD_SIZE;
-            }
-
-            rle_buf = ctx->lit_buffer;
-            if (UNLIKELY(!rle_buf || lit_stream_size > (size_t)(src + src_size - p_curr)))
-                return ZXC_ERROR_CORRUPT_DATA;
-
-            const uint8_t* r_ptr = p_curr;
-            const uint8_t* r_end = r_ptr + lit_stream_size;
-            uint8_t* w_ptr = rle_buf;
-            const uint8_t* const w_end = rle_buf + required_size;
-
-            while (r_ptr < r_end && w_ptr < w_end) {
-                uint8_t token = *r_ptr++;
-                if (LIKELY(!(token & ZXC_LIT_RLE_FLAG))) {
-                    // Raw copy (most common path): use ZXC_PAD_SIZE-byte wild copies
-                    // token is 7-bit (0-127), so len is 1-128 bytes
-                    const uint32_t len = (uint32_t)token + 1;
-                    if (UNLIKELY(w_ptr + len > w_end || r_ptr + len > r_end))
-                        return ZXC_ERROR_CORRUPT_DATA;
-
-                    // Destination has ZXC_PAD_SIZE bytes of safe overrun space.
-                    // Source may not - check before wild copy.
-                    // Fast path: source has ZXC_PAD_SIZE-byte read headroom (most common)
-                    if (LIKELY(r_ptr + ZXC_PAD_SIZE <= r_end)) {
-                        // Single 32-byte copy covers len <= ZXC_PAD_SIZE (most tokens)
-                        zxc_copy32(w_ptr, r_ptr);
-
-                        if (UNLIKELY(len > ZXC_PAD_SIZE)) {
-                            // Unroll: max len=128, so max 4 copies total
-                            // Use unconditional stores with overlap - faster than branches
-                            if (len <= 2 * ZXC_PAD_SIZE) {
-                                zxc_copy32(w_ptr + len - ZXC_PAD_SIZE, r_ptr + len - ZXC_PAD_SIZE);
-                            } else if (len <= 3 * ZXC_PAD_SIZE) {
-                                zxc_copy32(w_ptr + ZXC_PAD_SIZE, r_ptr + ZXC_PAD_SIZE);
-                                zxc_copy32(w_ptr + len - ZXC_PAD_SIZE, r_ptr + len - ZXC_PAD_SIZE);
-                            } else {
-                                zxc_copy32(w_ptr + ZXC_PAD_SIZE, r_ptr + ZXC_PAD_SIZE);
-                                zxc_copy32(w_ptr + 2 * ZXC_PAD_SIZE, r_ptr + 2 * ZXC_PAD_SIZE);
-                                zxc_copy32(w_ptr + len - ZXC_PAD_SIZE, r_ptr + len - ZXC_PAD_SIZE);
-                            }
-                        }
-                    } else {
-                        // Near end of source: safe copy (rare cold path)
-                        ZXC_MEMCPY(w_ptr, r_ptr, len);
-                    }
-
-                    w_ptr += len;
-                    r_ptr += len;
-                } else {
-                    // RLE run: fill with single byte
-                    const uint32_t len = (token & ZXC_LIT_LEN_MASK) + 4;
-                    if (UNLIKELY(w_ptr + len > w_end || r_ptr >= r_end))
-                        return ZXC_ERROR_CORRUPT_DATA;
-                    ZXC_MEMSET(w_ptr, *r_ptr++, len);
-                    w_ptr += len;
-                }
-            }
-            if (UNLIKELY(w_ptr != w_end)) return ZXC_ERROR_CORRUPT_DATA;
-            l_ptr = rle_buf;
-            l_end = rle_buf + required_size;
-        } else {
-            l_ptr = p_curr;
-            l_end = p_curr;
-        }
-    } else {
-        l_ptr = p_curr;
-        l_end = p_curr + lit_stream_size;
-    }
-
-    p_curr += lit_stream_size;
-
-    // --- Stream Pointers & Validation ---
-    const size_t sz_tokens = (size_t)(desc[1].sizes & ZXC_SECTION_SIZE_MASK);
-    const size_t sz_offsets = (size_t)(desc[2].sizes & ZXC_SECTION_SIZE_MASK);
-    const size_t sz_extras = (size_t)(desc[3].sizes & ZXC_SECTION_SIZE_MASK);
-
-    // Validate stream sizes match sequence count (early rejection of malformed data)
-    const size_t expected_off_size =
-        (gh.enc_off == 1) ? (size_t)gh.n_sequences : (size_t)gh.n_sequences * 2;
-
-    const uint8_t* t_ptr = p_curr;
-    const uint8_t* o_ptr = t_ptr + sz_tokens;
-    const uint8_t* e_ptr = o_ptr + sz_offsets;
-    const uint8_t* const e_end = e_ptr + sz_extras;  // For vbyte overflow detection
-
-    // Validate streams don't overflow source buffer +
-    // Validate stream sizes match sequence count (early rejection of malformed data)
-    if (UNLIKELY((e_end != src + src_size) || sz_tokens < gh.n_sequences ||
-                 sz_offsets < expected_off_size))
-        return ZXC_ERROR_CORRUPT_DATA;
-
-    uint8_t* d_ptr = dst;
-    const uint8_t* const d_end = dst + dst_capacity;
-    // Destination safe margin for 4x loop: max output without varint extension.
-    // ll_max = 14, ml_max = 14 + 5 = 19, per-seq = 33, 4x = 132.
-    // Add ZXC_PAD_SIZE (32) for the wild zxc_copy32 overshoot + 4 safety = 168.
-    const uint8_t* const d_end_safe = d_end - (132 + ZXC_PAD_SIZE + 4);
-
-    // Literal stream safe threshold for 4x-unrolled loops.
-    // Without varint extension, max ll per sequence = ZXC_TOKEN_LL_MASK - 1 = 14.
-    // For 4 sequences: 4 * 14 = 56. With this margin, l_ptr checks are only needed
-    // on the cold varint path, keeping the hot path free of l_ptr overhead.
-    const size_t glo_sz_lit = (size_t)(l_end - l_ptr);
-    const size_t glo_margin_4x = 4 * (ZXC_TOKEN_LL_MASK - 1);  // 56
-    const size_t glo_margin_1x = ZXC_TOKEN_LL_MASK - 1;        // 14
-    const uint8_t* const l_end_safe_4x =
-        (glo_sz_lit > glo_margin_4x) ? l_end - glo_margin_4x : l_ptr;
-    const uint8_t* const l_end_safe_1x =
-        (glo_sz_lit > glo_margin_1x) ? l_end - glo_margin_1x : l_ptr;
-
-    uint32_t n_seq = gh.n_sequences;
-
-    // Track bytes written for offset validation
-    // For 1-byte offsets (enc_off==1): validate until 256 bytes written (max 8-bit offset)
-    // For 2-byte offsets (enc_off==0): validate until 65536 bytes written (max 16-bit offset)
-    // After threshold, all offsets are guaranteed valid (can't exceed written bytes)
-    size_t written = 0;
-
-// --- Factored sub-macros for literal copy + match copy ---
-// Used by DECODE_SEQ_SAFE and DECODE_SEQ_FAST to avoid duplication.
+/* ==========================================================================
+ * Shared decode macros for the GLO and GHI decoders (fast + safe variants).
+ * Defined at file scope to avoid four identical copies inside each function.
+ * They reference the local names l_ptr, d_ptr, written that every call site
+ * has in scope. #undef-ed at the end of the last consumer.
+ * ========================================================================== */
 
 // Copy literals from l_ptr to d_ptr using 32-byte wild copies
 #define DECODE_COPY_LITERALS(ll)              \
@@ -738,191 +577,605 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
         DECODE_COPY_MATCH(ml, off);  \
     } while (0)
 
+/**
+ * @brief Decodes a General Low (GLO) format compressed block.
+ *
+ * This function handles the decoding of a compressed block formatted with the
+ * internal GLO structure. The decompressed size is derived from Section
+ * Descriptors within the compressed payload.
+ *
+ * @param[in,out] ctx Pointer to the compression context (`zxc_cctx_t`) containing
+ * @param[in] src Pointer to the source buffer containing compressed data.
+ * @param[in] src_size Size of the source buffer in bytes.
+ * @param[out] dst Pointer to the destination buffer for decompressed data.
+ * @param[in] dst_capacity Maximum capacity of the destination buffer.
+ *
+ * @return The number of bytes written to the destination buffer on success, or
+ * a negative zxc_error_t code on failure (e.g., invalid header, buffer overflow, or corrupted
+ * data).
+ */
+/**
+ * @brief Unified GLO decoder body shared by the fast and safe variants.
+ *
+ * @p safe must be a compile-time constant (0 or 1). The two 4x-unrolled loops
+ * are duplicated verbatim inside @c if(safe)/else branches so each variant
+ * keeps single-assignment @c const save pointers. After constant propagation
+ * only one branch survives per wrapper, yielding codegen equivalent to the
+ * hand-written pair.
+ */
+static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(zxc_cctx_t* RESTRICT ctx,
+                                                       const uint8_t* RESTRICT src,
+                                                       const size_t src_size, uint8_t* RESTRICT dst,
+                                                       const size_t dst_capacity, const int safe) {
+    zxc_gnr_header_t gh;
+    zxc_section_desc_t desc[ZXC_GLO_SECTIONS];
+
+    if (UNLIKELY(zxc_read_glo_header_and_desc(src, src_size, &gh, desc) != ZXC_OK))
+        return ZXC_ERROR_BAD_HEADER;
+
+    const uint8_t* p_data =
+        src + ZXC_GLO_HEADER_BINARY_SIZE + ZXC_GLO_SECTIONS * ZXC_SECTION_DESC_BINARY_SIZE;
+    const uint8_t* p_curr = p_data;
+
+    // --- Literal Stream Setup ---
+    const uint8_t* l_ptr;
+    const uint8_t* l_end;
+    uint8_t* rle_buf = NULL;
+
+    size_t lit_stream_size = (size_t)(desc[0].sizes & ZXC_SECTION_SIZE_MASK);
+
+    if (gh.enc_lit == ZXC_SECTION_ENCODING_HUFFMAN) {
+        const size_t required_size = (size_t)(desc[0].sizes >> 32);
+        if (UNLIKELY(lit_stream_size > (size_t)(src + src_size - p_curr)))
+            return ZXC_ERROR_CORRUPT_DATA;
+        if (required_size == 0) {
+            l_ptr = p_curr;
+            l_end = p_curr;
+        } else {
+            if (UNLIKELY(required_size > dst_capacity || required_size > SIZE_MAX - ZXC_PAD_SIZE))
+                return ZXC_ERROR_DST_TOO_SMALL;
+            const size_t alloc_size = required_size + ZXC_PAD_SIZE;
+            if (UNLIKELY(ctx->lit_buffer_cap < alloc_size)) {
+                uint8_t* new_buf = (uint8_t*)realloc(ctx->lit_buffer, alloc_size);
+                if (UNLIKELY(!new_buf)) {
+                    free(ctx->lit_buffer);
+                    ctx->lit_buffer = NULL;
+                    ctx->lit_buffer_cap = 0;
+                    return ZXC_ERROR_MEMORY;
+                }
+                ctx->lit_buffer = new_buf;
+                ctx->lit_buffer_cap = alloc_size;
+            }
+            const int rc =
+                zxc_huf_decode_section(p_curr, lit_stream_size, ctx->lit_buffer, required_size);
+            if (UNLIKELY(rc != ZXC_OK)) return rc;
+            l_ptr = ctx->lit_buffer;
+            l_end = ctx->lit_buffer + required_size;
+        }
+    } else if (gh.enc_lit == ZXC_SECTION_ENCODING_RLE) {
+        const size_t required_size = (size_t)(desc[0].sizes >> 32);
+
+        if (required_size > 0) {
+            if (UNLIKELY(required_size > dst_capacity || required_size > SIZE_MAX - ZXC_PAD_SIZE))
+                return ZXC_ERROR_DST_TOO_SMALL;
+            const size_t alloc_size = required_size + ZXC_PAD_SIZE;
+
+            if (UNLIKELY(ctx->lit_buffer_cap < alloc_size)) {
+                uint8_t* new_buf = (uint8_t*)realloc(ctx->lit_buffer, alloc_size);
+                if (UNLIKELY(!new_buf)) {
+                    free(ctx->lit_buffer);
+                    ctx->lit_buffer = NULL;
+                    ctx->lit_buffer_cap = 0;
+                    return ZXC_ERROR_MEMORY;
+                }
+                ctx->lit_buffer = new_buf;
+                ctx->lit_buffer_cap = alloc_size;
+            }
+
+            rle_buf = ctx->lit_buffer;
+            if (UNLIKELY(!rle_buf || lit_stream_size > (size_t)(src + src_size - p_curr)))
+                return ZXC_ERROR_CORRUPT_DATA;
+
+            const uint8_t* r_ptr = p_curr;
+            const uint8_t* r_end = r_ptr + lit_stream_size;
+            uint8_t* w_ptr = rle_buf;
+            const uint8_t* const w_end = rle_buf + required_size;
+
+            while (r_ptr < r_end && w_ptr < w_end) {
+                uint8_t token = *r_ptr++;
+                if (LIKELY(!(token & ZXC_LIT_RLE_FLAG))) {
+                    // Raw copy (most common path): use ZXC_PAD_SIZE-byte wild copies
+                    // token is 7-bit (0-127), so len is 1-128 bytes
+                    const uint32_t len = (uint32_t)token + 1;
+                    if (UNLIKELY(w_ptr + len > w_end || r_ptr + len > r_end))
+                        return ZXC_ERROR_CORRUPT_DATA;
+
+                    // Destination has ZXC_PAD_SIZE bytes of safe overrun space.
+                    // Source may not - check before wild copy.
+                    // Fast path: source has ZXC_PAD_SIZE-byte read headroom (most common)
+                    if (LIKELY(r_ptr + ZXC_PAD_SIZE <= r_end)) {
+                        // Single 32-byte copy covers len <= ZXC_PAD_SIZE (most tokens)
+                        zxc_copy32(w_ptr, r_ptr);
+
+                        if (UNLIKELY(len > ZXC_PAD_SIZE)) {
+                            // Unroll: max len=128, so max 4 copies total
+                            // Use unconditional stores with overlap - faster than branches
+                            if (len <= 2 * ZXC_PAD_SIZE) {
+                                zxc_copy32(w_ptr + len - ZXC_PAD_SIZE, r_ptr + len - ZXC_PAD_SIZE);
+                            } else if (len <= 3 * ZXC_PAD_SIZE) {
+                                zxc_copy32(w_ptr + ZXC_PAD_SIZE, r_ptr + ZXC_PAD_SIZE);
+                                zxc_copy32(w_ptr + len - ZXC_PAD_SIZE, r_ptr + len - ZXC_PAD_SIZE);
+                            } else {
+                                zxc_copy32(w_ptr + ZXC_PAD_SIZE, r_ptr + ZXC_PAD_SIZE);
+                                zxc_copy32(w_ptr + 2 * ZXC_PAD_SIZE, r_ptr + 2 * ZXC_PAD_SIZE);
+                                zxc_copy32(w_ptr + len - ZXC_PAD_SIZE, r_ptr + len - ZXC_PAD_SIZE);
+                            }
+                        }
+                    } else {
+                        // Near end of source: safe copy (rare cold path)
+                        ZXC_MEMCPY(w_ptr, r_ptr, len);
+                    }
+
+                    w_ptr += len;
+                    r_ptr += len;
+                } else {
+                    // RLE run: fill with single byte
+                    const uint32_t len = (token & ZXC_LIT_LEN_MASK) + 4;
+                    if (UNLIKELY(w_ptr + len > w_end || r_ptr >= r_end))
+                        return ZXC_ERROR_CORRUPT_DATA;
+                    ZXC_MEMSET(w_ptr, *r_ptr++, len);
+                    w_ptr += len;
+                }
+            }
+            if (UNLIKELY(w_ptr != w_end)) return ZXC_ERROR_CORRUPT_DATA;
+            l_ptr = rle_buf;
+            l_end = rle_buf + required_size;
+        } else {
+            l_ptr = p_curr;
+            l_end = p_curr;
+        }
+    } else if (gh.enc_lit == ZXC_SECTION_ENCODING_RAW) {
+        l_ptr = p_curr;
+        l_end = p_curr + lit_stream_size;
+    } else {
+        return ZXC_ERROR_CORRUPT_DATA;
+    }
+
+    p_curr += lit_stream_size;
+
+    // --- Stream Pointers & Validation ---
+    const size_t sz_tokens = (size_t)(desc[1].sizes & ZXC_SECTION_SIZE_MASK);
+    const size_t sz_offsets = (size_t)(desc[2].sizes & ZXC_SECTION_SIZE_MASK);
+    const size_t sz_extras = (size_t)(desc[3].sizes & ZXC_SECTION_SIZE_MASK);
+
+    // Validate stream sizes match sequence count (early rejection of malformed data)
+    const uint64_t expected_off_size =
+        (gh.enc_off == 1) ? (uint64_t)gh.n_sequences : (uint64_t)gh.n_sequences * 2;
+
+    const uint8_t* t_ptr = p_curr;
+    const uint8_t* o_ptr = t_ptr + sz_tokens;
+    const uint8_t* e_ptr = o_ptr + sz_offsets;
+    const uint8_t* const e_end = e_ptr + sz_extras;  // For vbyte overflow detection
+
+    // Validate streams don't overflow source buffer +
+    // Validate stream sizes match sequence count (early rejection of malformed data)
+    if (UNLIKELY((e_end != src + src_size) || sz_tokens < gh.n_sequences ||
+                 (uint64_t)sz_offsets < expected_off_size))
+        return ZXC_ERROR_CORRUPT_DATA;
+
+    uint8_t* d_ptr = dst;
+    const uint8_t* const d_end = dst + dst_capacity;
+    // Destination safe margin for 4x loop: max output without varint extension.
+    // ll_max = 14, ml_max = 14 + 5 = 19, per-seq = 33, 4x = 132.
+    // Add ZXC_PAD_SIZE (32) for the wild zxc_copy32 overshoot + 4 safety = 168.
+    const uint8_t* const d_end_safe = d_end - (132 + ZXC_PAD_SIZE + 4);
+
+    // Literal stream safe threshold for 4x-unrolled loops.
+    // Without varint extension, max ll per sequence = ZXC_TOKEN_LL_MASK - 1 = 14.
+    // For 4 sequences: 4 * 14 = 56. With this margin, l_ptr checks are only needed
+    // on the cold varint path, keeping the hot path free of l_ptr overhead.
+    const size_t glo_sz_lit = (size_t)(l_end - l_ptr);
+    const size_t glo_margin_4x = 4 * (ZXC_TOKEN_LL_MASK - 1);  // 56
+    const size_t glo_margin_1x = ZXC_TOKEN_LL_MASK - 1;        // 14
+    const uint8_t* const l_end_safe_4x =
+        (glo_sz_lit > glo_margin_4x) ? l_end - glo_margin_4x : l_ptr;
+    const uint8_t* const l_end_safe_1x =
+        (glo_sz_lit > glo_margin_1x) ? l_end - glo_margin_1x : l_ptr;
+
+    uint32_t n_seq = gh.n_sequences;
+
+    // Track bytes written for offset validation
+    // For 1-byte offsets (enc_off==1): validate until 256 bytes written (max 8-bit offset)
+    // For 2-byte offsets (enc_off==0): validate until 65536 bytes written (max 16-bit offset)
+    // After threshold, all offsets are guaranteed valid (can't exceed written bytes)
+    size_t written = 0;
+
     // --- SAFE Loop: offset validation until threshold (4x unroll) ---
     // For 1-byte offsets: bounds check until 256 bytes written
     // For 2-byte offsets: bounds check until 65536 bytes written
     const size_t bounds_threshold = (gh.enc_off == 1) ? (1U << 8) : (1U << 16);
 
-    while (n_seq >= 4 && d_ptr < d_end_safe && l_ptr < l_end_safe_4x &&
-           written < bounds_threshold) {
-        uint32_t tokens = zxc_le32(t_ptr);
-        t_ptr += 4;
+    if (safe) {
+        /* SAFE variant: save per-batch state so overflow can rollback. */
+        while (n_seq >= 4 && d_ptr < d_end_safe && l_ptr < l_end_safe_4x &&
+               written < bounds_threshold) {
+            const uint8_t* const t_save = t_ptr;
+            const uint8_t* const o_save = o_ptr;
+            const uint8_t* const e_save = e_ptr;
+            uint8_t* const d_save = d_ptr;
+            const uint8_t* const l_save = l_ptr;
+            const size_t w_save = written;
+            uint32_t tokens = zxc_le32(t_ptr);
+            t_ptr += 4;
 
-        uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS, off3 = ZXC_LZ_OFFSET_BIAS,
-                 off4 = ZXC_LZ_OFFSET_BIAS;
-        if (gh.enc_off == 1) {
-            // Read 4 x 1-byte offsets
-            uint32_t offsets = zxc_le32(o_ptr);
-            o_ptr += 4;
-            off1 += offsets & 0xFF;
-            off2 += (offsets >> 8) & 0xFF;
-            off3 += (offsets >> 16) & 0xFF;
-            off4 += (offsets >> 24) & 0xFF;
-        } else {
-            // Read 4 x 2-byte offsets
-            uint64_t offsets = zxc_le64(o_ptr);
-            o_ptr += 8;
-            off1 += (uint32_t)(offsets & 0xFFFF);
-            off2 += (uint32_t)((offsets >> 16) & 0xFFFF);
-            off3 += (uint32_t)((offsets >> 32) & 0xFFFF);
-            off4 += (uint32_t)((offsets >> 48) & 0xFFFF);
-        }
+            uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS,
+                     off3 = ZXC_LZ_OFFSET_BIAS, off4 = ZXC_LZ_OFFSET_BIAS;
+            if (gh.enc_off == 1) {
+                uint32_t offsets = zxc_le32(o_ptr);
+                o_ptr += 4;
+                off1 += offsets & 0xFF;
+                off2 += (offsets >> 8) & 0xFF;
+                off3 += (offsets >> 16) & 0xFF;
+                off4 += (offsets >> 24) & 0xFF;
+            } else {
+                uint64_t offsets = zxc_le64(o_ptr);
+                o_ptr += 8;
+                off1 += (uint32_t)(offsets & 0xFFFF);
+                off2 += (uint32_t)((offsets >> 16) & 0xFFFF);
+                off3 += (uint32_t)((offsets >> 32) & 0xFFFF);
+                off4 += (uint32_t)((offsets >> 48) & 0xFFFF);
+            }
 
-        uint32_t ll1 = (tokens & 0x0F0) >> 4;
-        uint32_t ml1 = (tokens & 0x00F);
-        if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
-            ll1 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
-            ml1 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        ml1 += ZXC_LZ_MIN_MATCH_LEN;
-        DECODE_SEQ_SAFE(ll1, ml1, off1);
+            uint32_t ll1 = (tokens & 0x0F0) >> 4;
+            uint32_t ml1 = (tokens & 0x00F);
+            if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
+                ll1 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                    goto rollback_safe_4x;
+            }
+            if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
+                ml1 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                    goto rollback_safe_4x;
+            }
+            ml1 += ZXC_LZ_MIN_MATCH_LEN;
+            DECODE_SEQ_SAFE(ll1, ml1, off1);
 
-        uint32_t ll2 = (tokens & 0x0F000) >> 12;
-        uint32_t ml2 = (tokens & 0x00F00) >> 8;
-        if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
-            ll2 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
-            ml2 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        ml2 += ZXC_LZ_MIN_MATCH_LEN;
-        DECODE_SEQ_SAFE(ll2, ml2, off2);
+            uint32_t ll2 = (tokens & 0x0F000) >> 12;
+            uint32_t ml2 = (tokens & 0x00F00) >> 8;
+            if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
+                ll2 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                    goto rollback_safe_4x;
+            }
+            if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
+                ml2 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                    goto rollback_safe_4x;
+            }
+            ml2 += ZXC_LZ_MIN_MATCH_LEN;
+            DECODE_SEQ_SAFE(ll2, ml2, off2);
 
-        uint32_t ll3 = (tokens & 0x0F00000) >> 20;
-        uint32_t ml3 = (tokens & 0x00F0000) >> 16;
-        if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
-            ll3 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
-            ml3 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        ml3 += ZXC_LZ_MIN_MATCH_LEN;
-        DECODE_SEQ_SAFE(ll3, ml3, off3);
+            uint32_t ll3 = (tokens & 0x0F00000) >> 20;
+            uint32_t ml3 = (tokens & 0x00F0000) >> 16;
+            if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
+                ll3 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                    goto rollback_safe_4x;
+            }
+            if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
+                ml3 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                    goto rollback_safe_4x;
+            }
+            ml3 += ZXC_LZ_MIN_MATCH_LEN;
+            DECODE_SEQ_SAFE(ll3, ml3, off3);
 
-        uint32_t ll4 = (tokens >> 28);
-        uint32_t ml4 = (tokens >> 24) & 0x0F;
-        if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
-            ll4 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
-            ml4 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        ml4 += ZXC_LZ_MIN_MATCH_LEN;
-        DECODE_SEQ_SAFE(ll4, ml4, off4);
+            uint32_t ll4 = (tokens >> 28);
+            uint32_t ml4 = (tokens >> 24) & 0x0F;
+            if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
+                ll4 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                    goto rollback_safe_4x;
+            }
+            if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
+                ml4 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                    goto rollback_safe_4x;
+            }
+            ml4 += ZXC_LZ_MIN_MATCH_LEN;
+            DECODE_SEQ_SAFE(ll4, ml4, off4);
 
-        n_seq -= 4;
+            n_seq -= 4;
+            continue;
+
+        rollback_safe_4x:
+            t_ptr = t_save;
+            o_ptr = o_save;
+            e_ptr = e_save;
+            d_ptr = d_save;
+            l_ptr = l_save;
+            written = w_save;
+            break;
+        }
+    } else {
+        while (n_seq >= 4 && d_ptr < d_end_safe && l_ptr < l_end_safe_4x &&
+               written < bounds_threshold) {
+            uint32_t tokens = zxc_le32(t_ptr);
+            t_ptr += 4;
+
+            uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS,
+                     off3 = ZXC_LZ_OFFSET_BIAS, off4 = ZXC_LZ_OFFSET_BIAS;
+            if (gh.enc_off == 1) {
+                // Read 4 x 1-byte offsets
+                uint32_t offsets = zxc_le32(o_ptr);
+                o_ptr += 4;
+                off1 += offsets & 0xFF;
+                off2 += (offsets >> 8) & 0xFF;
+                off3 += (offsets >> 16) & 0xFF;
+                off4 += (offsets >> 24) & 0xFF;
+            } else {
+                // Read 4 x 2-byte offsets
+                uint64_t offsets = zxc_le64(o_ptr);
+                o_ptr += 8;
+                off1 += (uint32_t)(offsets & 0xFFFF);
+                off2 += (uint32_t)((offsets >> 16) & 0xFFFF);
+                off3 += (uint32_t)((offsets >> 32) & 0xFFFF);
+                off4 += (uint32_t)((offsets >> 48) & 0xFFFF);
+            }
+
+            uint32_t ll1 = (tokens & 0x0F0) >> 4;
+            uint32_t ml1 = (tokens & 0x00F);
+            if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
+                ll1 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
+                ml1 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            ml1 += ZXC_LZ_MIN_MATCH_LEN;
+            DECODE_SEQ_SAFE(ll1, ml1, off1);
+
+            uint32_t ll2 = (tokens & 0x0F000) >> 12;
+            uint32_t ml2 = (tokens & 0x00F00) >> 8;
+            if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
+                ll2 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
+                ml2 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            ml2 += ZXC_LZ_MIN_MATCH_LEN;
+            DECODE_SEQ_SAFE(ll2, ml2, off2);
+
+            uint32_t ll3 = (tokens & 0x0F00000) >> 20;
+            uint32_t ml3 = (tokens & 0x00F0000) >> 16;
+            if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
+                ll3 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
+                ml3 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            ml3 += ZXC_LZ_MIN_MATCH_LEN;
+            DECODE_SEQ_SAFE(ll3, ml3, off3);
+
+            uint32_t ll4 = (tokens >> 28);
+            uint32_t ml4 = (tokens >> 24) & 0x0F;
+            if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
+                ll4 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
+                ml4 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            ml4 += ZXC_LZ_MIN_MATCH_LEN;
+            DECODE_SEQ_SAFE(ll4, ml4, off4);
+
+            n_seq -= 4;
+        }
     }
 
     // --- FAST Loop: After threshold, no offset validation needed (4x unroll) ---
-    while (n_seq >= 4 && d_ptr < d_end_safe && l_ptr < l_end_safe_4x) {
-        uint32_t tokens = zxc_le32(t_ptr);
-        t_ptr += 4;
+    if (safe) {
+        while (n_seq >= 4 && d_ptr < d_end_safe && l_ptr < l_end_safe_4x) {
+            const uint8_t* const t_save = t_ptr;
+            const uint8_t* const o_save = o_ptr;
+            const uint8_t* const e_save = e_ptr;
+            uint8_t* const d_save = d_ptr;
+            const uint8_t* const l_save = l_ptr;
+            uint32_t tokens = zxc_le32(t_ptr);
+            t_ptr += 4;
 
-        uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS, off3 = ZXC_LZ_OFFSET_BIAS,
-                 off4 = ZXC_LZ_OFFSET_BIAS;
-        if (gh.enc_off == 1) {
-            // Read 4 x 1-byte offsets
-            uint32_t offsets = zxc_le32(o_ptr);
-            o_ptr += 4;
-            off1 += offsets & 0xFF;
-            off2 += (offsets >> 8) & 0xFF;
-            off3 += (offsets >> 16) & 0xFF;
-            off4 += (offsets >> 24) & 0xFF;
-        } else {
-            // Read 4 x 2-byte offsets
-            uint64_t offsets = zxc_le64(o_ptr);
-            o_ptr += 8;
-            off1 += (uint32_t)(offsets & 0xFFFF);
-            off2 += (uint32_t)((offsets >> 16) & 0xFFFF);
-            off3 += (uint32_t)((offsets >> 32) & 0xFFFF);
-            off4 += (uint32_t)((offsets >> 48) & 0xFFFF);
-        }
+            uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS,
+                     off3 = ZXC_LZ_OFFSET_BIAS, off4 = ZXC_LZ_OFFSET_BIAS;
+            if (gh.enc_off == 1) {
+                uint32_t offsets = zxc_le32(o_ptr);
+                o_ptr += 4;
+                off1 += offsets & 0xFF;
+                off2 += (offsets >> 8) & 0xFF;
+                off3 += (offsets >> 16) & 0xFF;
+                off4 += (offsets >> 24) & 0xFF;
+            } else {
+                uint64_t offsets = zxc_le64(o_ptr);
+                o_ptr += 8;
+                off1 += (uint32_t)(offsets & 0xFFFF);
+                off2 += (uint32_t)((offsets >> 16) & 0xFFFF);
+                off3 += (uint32_t)((offsets >> 32) & 0xFFFF);
+                off4 += (uint32_t)((offsets >> 48) & 0xFFFF);
+            }
 
-        uint32_t ll1 = (tokens & 0x0F0) >> 4;
-        uint32_t ml1 = (tokens & 0x00F);
-        if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
-            ll1 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
-            ml1 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        ml1 += ZXC_LZ_MIN_MATCH_LEN;
-        DECODE_SEQ_FAST(ll1, ml1, off1);
+            uint32_t ll1 = (tokens & 0x0F0) >> 4;
+            uint32_t ml1 = (tokens & 0x00F);
+            if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
+                ll1 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                    goto rollback_fast_4x;
+            }
+            if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
+                ml1 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                    goto rollback_fast_4x;
+            }
+            ml1 += ZXC_LZ_MIN_MATCH_LEN;
+            DECODE_SEQ_FAST(ll1, ml1, off1);
 
-        uint32_t ll2 = (tokens & 0x0F000) >> 12;
-        uint32_t ml2 = (tokens & 0x00F00) >> 8;
-        if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
-            ll2 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
-            ml2 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        ml2 += ZXC_LZ_MIN_MATCH_LEN;
-        DECODE_SEQ_FAST(ll2, ml2, off2);
+            uint32_t ll2 = (tokens & 0x0F000) >> 12;
+            uint32_t ml2 = (tokens & 0x00F00) >> 8;
+            if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
+                ll2 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                    goto rollback_fast_4x;
+            }
+            if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
+                ml2 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                    goto rollback_fast_4x;
+            }
+            ml2 += ZXC_LZ_MIN_MATCH_LEN;
+            DECODE_SEQ_FAST(ll2, ml2, off2);
 
-        uint32_t ll3 = (tokens & 0x0F00000) >> 20;
-        uint32_t ml3 = (tokens & 0x00F0000) >> 16;
-        if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
-            ll3 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
-            ml3 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        ml3 += ZXC_LZ_MIN_MATCH_LEN;
-        DECODE_SEQ_FAST(ll3, ml3, off3);
+            uint32_t ll3 = (tokens & 0x0F00000) >> 20;
+            uint32_t ml3 = (tokens & 0x00F0000) >> 16;
+            if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
+                ll3 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                    goto rollback_fast_4x;
+            }
+            if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
+                ml3 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                    goto rollback_fast_4x;
+            }
+            ml3 += ZXC_LZ_MIN_MATCH_LEN;
+            DECODE_SEQ_FAST(ll3, ml3, off3);
 
-        uint32_t ll4 = (tokens >> 28);
-        uint32_t ml4 = (tokens >> 24) & 0x0F;
-        if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
-            ll4 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
-            ml4 += zxc_read_varint(&e_ptr, e_end);
-            if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        ml4 += ZXC_LZ_MIN_MATCH_LEN;
-        DECODE_SEQ_FAST(ll4, ml4, off4);
+            uint32_t ll4 = (tokens >> 28);
+            uint32_t ml4 = (tokens >> 24) & 0x0F;
+            if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
+                ll4 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                    goto rollback_fast_4x;
+            }
+            if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
+                ml4 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                    goto rollback_fast_4x;
+            }
+            ml4 += ZXC_LZ_MIN_MATCH_LEN;
+            DECODE_SEQ_FAST(ll4, ml4, off4);
 
-        n_seq -= 4;
+            n_seq -= 4;
+            continue;
+
+        rollback_fast_4x:
+            t_ptr = t_save;
+            o_ptr = o_save;
+            e_ptr = e_save;
+            d_ptr = d_save;
+            l_ptr = l_save;
+            break;
+        }
+    } else {
+        while (n_seq >= 4 && d_ptr < d_end_safe && l_ptr < l_end_safe_4x) {
+            uint32_t tokens = zxc_le32(t_ptr);
+            t_ptr += 4;
+
+            uint32_t off1 = ZXC_LZ_OFFSET_BIAS, off2 = ZXC_LZ_OFFSET_BIAS,
+                     off3 = ZXC_LZ_OFFSET_BIAS, off4 = ZXC_LZ_OFFSET_BIAS;
+            if (gh.enc_off == 1) {
+                // Read 4 x 1-byte offsets
+                uint32_t offsets = zxc_le32(o_ptr);
+                o_ptr += 4;
+                off1 += offsets & 0xFF;
+                off2 += (offsets >> 8) & 0xFF;
+                off3 += (offsets >> 16) & 0xFF;
+                off4 += (offsets >> 24) & 0xFF;
+            } else {
+                // Read 4 x 2-byte offsets
+                uint64_t offsets = zxc_le64(o_ptr);
+                o_ptr += 8;
+                off1 += (uint32_t)(offsets & 0xFFFF);
+                off2 += (uint32_t)((offsets >> 16) & 0xFFFF);
+                off3 += (uint32_t)((offsets >> 32) & 0xFFFF);
+                off4 += (uint32_t)((offsets >> 48) & 0xFFFF);
+            }
+
+            uint32_t ll1 = (tokens & 0x0F0) >> 4;
+            uint32_t ml1 = (tokens & 0x00F);
+            if (UNLIKELY(ll1 == ZXC_TOKEN_LL_MASK)) {
+                ll1 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            if (UNLIKELY(ml1 == ZXC_TOKEN_ML_MASK)) {
+                ml1 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            ml1 += ZXC_LZ_MIN_MATCH_LEN;
+            DECODE_SEQ_FAST(ll1, ml1, off1);
+
+            uint32_t ll2 = (tokens & 0x0F000) >> 12;
+            uint32_t ml2 = (tokens & 0x00F00) >> 8;
+            if (UNLIKELY(ll2 == ZXC_TOKEN_LL_MASK)) {
+                ll2 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            if (UNLIKELY(ml2 == ZXC_TOKEN_ML_MASK)) {
+                ml2 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            ml2 += ZXC_LZ_MIN_MATCH_LEN;
+            DECODE_SEQ_FAST(ll2, ml2, off2);
+
+            uint32_t ll3 = (tokens & 0x0F00000) >> 20;
+            uint32_t ml3 = (tokens & 0x00F0000) >> 16;
+            if (UNLIKELY(ll3 == ZXC_TOKEN_LL_MASK)) {
+                ll3 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            if (UNLIKELY(ml3 == ZXC_TOKEN_ML_MASK)) {
+                ml3 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            ml3 += ZXC_LZ_MIN_MATCH_LEN;
+            DECODE_SEQ_FAST(ll3, ml3, off3);
+
+            uint32_t ll4 = (tokens >> 28);
+            uint32_t ml4 = (tokens >> 24) & 0x0F;
+            if (UNLIKELY(ll4 == ZXC_TOKEN_LL_MASK)) {
+                ll4 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            if (UNLIKELY(ml4 == ZXC_TOKEN_ML_MASK)) {
+                ml4 += zxc_read_varint(&e_ptr, e_end);
+                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_LZ_MIN_MATCH_LEN + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            ml4 += ZXC_LZ_MIN_MATCH_LEN;
+            DECODE_SEQ_FAST(ll4, ml4, off4);
+
+            n_seq -= 4;
+        }
     }
-
-#undef DECODE_SEQ_SAFE
-#undef DECODE_SEQ_FAST
-#undef DECODE_COPY_LITERALS
-#undef DECODE_COPY_MATCH
 
     // Validate vbyte reads didn't overflow
     if (UNLIKELY(e_ptr > e_end)) return ZXC_ERROR_CORRUPT_DATA;
@@ -1084,9 +1337,17 @@ static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
  * @return int Returns the number of bytes written on success, or a negative zxc_error_t code on
  * failure.
  */
-static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
-                                const size_t src_size, uint8_t* RESTRICT dst,
-                                const size_t dst_capacity) {
+/**
+ * @brief Unified GHI decoder body shared by the fast and safe variants.
+ *
+ * @p safe must be a compile-time constant (0 or 1). The two 4x-unrolled loops
+ * are duplicated verbatim inside @c if(safe)/else branches so that each
+ * variant keeps its own single-assignment @c const save pointers.
+ */
+static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(zxc_cctx_t* RESTRICT ctx,
+                                                       const uint8_t* RESTRICT src,
+                                                       const size_t src_size, uint8_t* RESTRICT dst,
+                                                       const size_t dst_capacity, const int safe) {
     (void)ctx;
     zxc_gnr_header_t gh;
     zxc_section_desc_t desc[ZXC_GHI_SECTIONS];
@@ -1111,7 +1372,8 @@ static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
 
     // Validate streams don't overflow source buffer +
     // Validate sequence stream size matches sequence count
-    if (UNLIKELY((extras_end != src + src_size) || (sz_seqs < (size_t)gh.n_sequences * 4)))
+    if (UNLIKELY((extras_end != src + src_size) ||
+                 ((uint64_t)sz_seqs < (uint64_t)gh.n_sequences * 4)))
         return ZXC_ERROR_CORRUPT_DATA;
 
     uint8_t* d_ptr = dst;
@@ -1119,7 +1381,7 @@ static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
     const uint8_t* const d_end_safe = d_end - (ZXC_PAD_SIZE * 4);  // 128
     // Safety margin for 4x unrolled loop: 4 * (ZXC_SEQ_LL_MASK LL +
     // ZXC_SEQ_ML_MASK+ZXC_LZ_MIN_MATCH_LEN ML) + ZXC_PAD_SIZE Pad = 4 x (255 + 255 + 5) + 32 = 2092
-    const uint8_t* const d_end_fast = d_end - (ZXC_PAD_SIZE * 66);  // 2112
+    const uint8_t* const d_end_fast = d_end - ZXC_DECOMPRESS_TAIL_PAD;  // 2112
 
     // Literal stream safe thresholds for GHI loops.
     // Without varint extension, max ll per sequence = ZXC_SEQ_LL_MASK - 1 = 254.
@@ -1138,166 +1400,171 @@ static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
     // After threshold, all offsets are guaranteed valid (can't exceed written bytes)
     size_t written = 0;
 
-    // --- Factored sub-macros for literal copy + match copy ---
-    // Used by DECODE_SEQ_SAFE and DECODE_SEQ_FAST to avoid duplication.
-
-#define DECODE_COPY_LITERALS(ll)              \
-    do {                                      \
-        const uint8_t* src_lit = l_ptr;       \
-        uint8_t* dst_lit = d_ptr;             \
-        zxc_copy32(dst_lit, src_lit);         \
-        if (UNLIKELY(ll > ZXC_PAD_SIZE)) {    \
-            dst_lit += ZXC_PAD_SIZE;          \
-            src_lit += ZXC_PAD_SIZE;          \
-            size_t rem = ll - ZXC_PAD_SIZE;   \
-            while (rem > ZXC_PAD_SIZE) {      \
-                zxc_copy32(dst_lit, src_lit); \
-                dst_lit += ZXC_PAD_SIZE;      \
-                src_lit += ZXC_PAD_SIZE;      \
-                rem -= ZXC_PAD_SIZE;          \
-            }                                 \
-            zxc_copy32(dst_lit, src_lit);     \
-        }                                     \
-        l_ptr += ll;                          \
-        d_ptr += ll;                          \
-    } while (0)
-
-#define DECODE_COPY_MATCH(ml, off)                                   \
-    do {                                                             \
-        const uint8_t* match_src = d_ptr - off;                      \
-        if (LIKELY(off >= ZXC_PAD_SIZE)) {                           \
-            zxc_copy32(d_ptr, match_src);                            \
-            if (UNLIKELY(ml > ZXC_PAD_SIZE)) {                       \
-                uint8_t* out = d_ptr + ZXC_PAD_SIZE;                 \
-                const uint8_t* ref = match_src + ZXC_PAD_SIZE;       \
-                size_t rem = ml - ZXC_PAD_SIZE;                      \
-                while (rem > ZXC_PAD_SIZE) {                         \
-                    zxc_copy32(out, ref);                            \
-                    out += ZXC_PAD_SIZE;                             \
-                    ref += ZXC_PAD_SIZE;                             \
-                    rem -= ZXC_PAD_SIZE;                             \
-                }                                                    \
-                zxc_copy32(out, ref);                                \
-            }                                                        \
-            d_ptr += ml;                                             \
-        } else if (off >= (ZXC_PAD_SIZE / 2)) {                      \
-            zxc_copy16(d_ptr, match_src);                            \
-            if (UNLIKELY(ml > (ZXC_PAD_SIZE / 2))) {                 \
-                uint8_t* out = d_ptr + (ZXC_PAD_SIZE / 2);           \
-                const uint8_t* ref = match_src + (ZXC_PAD_SIZE / 2); \
-                size_t rem = ml - (ZXC_PAD_SIZE / 2);                \
-                while (rem > (ZXC_PAD_SIZE / 2)) {                   \
-                    zxc_copy16(out, ref);                            \
-                    out += (ZXC_PAD_SIZE / 2);                       \
-                    ref += (ZXC_PAD_SIZE / 2);                       \
-                    rem -= (ZXC_PAD_SIZE / 2);                       \
-                }                                                    \
-                zxc_copy16(out, ref);                                \
-            }                                                        \
-            d_ptr += ml;                                             \
-        } else if (off == 1) {                                       \
-            ZXC_MEMSET(d_ptr, match_src[0], ml);                     \
-            d_ptr += ml;                                             \
-        } else {                                                     \
-            size_t copied = 0;                                       \
-            while (copied < ml) {                                    \
-                zxc_copy_overlap16(d_ptr + copied, off);             \
-                copied += (ZXC_PAD_SIZE / 2);                        \
-            }                                                        \
-            d_ptr += ml;                                             \
-        }                                                            \
-    } while (0)
-
-#define DECODE_SEQ_SAFE(ll, ml, off)                              \
-    do {                                                          \
-        DECODE_COPY_LITERALS(ll);                                 \
-        written += ll;                                            \
-        if (UNLIKELY(off > written)) return ZXC_ERROR_BAD_OFFSET; \
-        DECODE_COPY_MATCH(ml, off);                               \
-        written += ml;                                            \
-    } while (0)
-
-#define DECODE_SEQ_FAST(ll, ml, off) \
-    do {                             \
-        DECODE_COPY_LITERALS(ll);    \
-        DECODE_COPY_MATCH(ml, off);  \
-    } while (0)
-
     // --- SAFE Loop: offset validation until threshold (4x unroll) ---
     // Since offset is 16-bit, threshold is 65536.
     // For 1-byte offsets (enc_off==1): validate until 256 bytes written
     // For 2-byte offsets (enc_off==0): validate until 65536 bytes written
     const size_t bounds_threshold = (gh.enc_off == 1) ? (1U << 8) : (1U << 16);
 
-    while (n_seq >= 4 && d_ptr < d_end_safe && l_ptr < l_end_safe_4x &&
-           written < bounds_threshold) {
-        uint32_t s1 = zxc_le32(seq_ptr);
-        uint32_t s2 = zxc_le32(seq_ptr + 4);
-        uint32_t s3 = zxc_le32(seq_ptr + 8);
-        uint32_t s4 = zxc_le32(seq_ptr + 12);
-        seq_ptr += 16;
+    if (safe) {
+        /* SAFE variant: save per-batch state so an OVERFLOW can rollback and
+         * hand over to the 1x loop / Safe Path. Wild writes already committed
+         * are deterministically overwritten when the 1x loop replays. */
+        while (n_seq >= 4 && d_ptr < d_end_fast && l_ptr < l_end_safe_4x &&
+               written < bounds_threshold) {
+            const uint8_t* const t_save = seq_ptr;
+            const uint8_t* const e_save = extras_ptr;
+            uint8_t* const d_save = d_ptr;
+            const uint8_t* const l_save = l_ptr;
+            const size_t w_save = written;
+            uint32_t s1 = zxc_le32(seq_ptr);
+            uint32_t s2 = zxc_le32(seq_ptr + 4);
+            uint32_t s3 = zxc_le32(seq_ptr + 8);
+            uint32_t s4 = zxc_le32(seq_ptr + 12);
+            seq_ptr += 16;
 
-        uint32_t ll1 = (uint32_t)(s1 >> 24);
-        if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
-            ll1 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
-        uint32_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
-        if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
-            ml1 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        }
-        uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-        DECODE_SEQ_SAFE(ll1, ml1, off1);
+            uint32_t ll1 = (uint32_t)(s1 >> 24);
+            if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
+                ll1 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                    goto rollback_safe_4x;
+            }
+            uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
+            uint32_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
+                ml1 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_PAD_SIZE > d_end)) goto rollback_safe_4x;
+            }
+            uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            DECODE_SEQ_SAFE(ll1, ml1, off1);
 
-        uint32_t ll2 = (uint32_t)(s2 >> 24);
-        if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
-            ll2 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
-        uint32_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
-        if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
-            ml2 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        }
-        uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-        DECODE_SEQ_SAFE(ll2, ml2, off2);
+            uint32_t ll2 = (uint32_t)(s2 >> 24);
+            if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
+                ll2 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                    goto rollback_safe_4x;
+            }
+            uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
+            uint32_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
+                ml2 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_PAD_SIZE > d_end)) goto rollback_safe_4x;
+            }
+            uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            DECODE_SEQ_SAFE(ll2, ml2, off2);
 
-        uint32_t ll3 = (uint32_t)(s3 >> 24);
-        if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
-            ll3 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
-        uint32_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
-        if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
-            ml3 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        }
-        uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-        DECODE_SEQ_SAFE(ll3, ml3, off3);
+            uint32_t ll3 = (uint32_t)(s3 >> 24);
+            if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
+                ll3 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                    goto rollback_safe_4x;
+            }
+            uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
+            uint32_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
+                ml3 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_PAD_SIZE > d_end)) goto rollback_safe_4x;
+            }
+            uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            DECODE_SEQ_SAFE(ll3, ml3, off3);
 
-        uint32_t ll4 = (uint32_t)(s4 >> 24);
-        if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
-            ll4 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
-        uint32_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
-        if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
-            ml4 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        }
-        uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-        DECODE_SEQ_SAFE(ll4, ml4, off4);
+            uint32_t ll4 = (uint32_t)(s4 >> 24);
+            if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
+                ll4 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                    goto rollback_safe_4x;
+            }
+            uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
+            uint32_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
+                ml4 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) goto rollback_safe_4x;
+            }
+            uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            DECODE_SEQ_SAFE(ll4, ml4, off4);
 
-        n_seq -= 4;
+            n_seq -= 4;
+            continue;
+
+        rollback_safe_4x:
+            seq_ptr = t_save;
+            extras_ptr = e_save;
+            d_ptr = d_save;
+            l_ptr = l_save;
+            written = w_save;
+            break;
+        }
+    } else {
+        while (n_seq >= 4 && d_ptr < d_end_safe && l_ptr < l_end_safe_4x &&
+               written < bounds_threshold) {
+            uint32_t s1 = zxc_le32(seq_ptr);
+            uint32_t s2 = zxc_le32(seq_ptr + 4);
+            uint32_t s3 = zxc_le32(seq_ptr + 8);
+            uint32_t s4 = zxc_le32(seq_ptr + 12);
+            seq_ptr += 16;
+
+            uint32_t ll1 = (uint32_t)(s1 >> 24);
+            if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
+                ll1 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
+            uint32_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
+                ml1 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
+            }
+            uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            DECODE_SEQ_SAFE(ll1, ml1, off1);
+
+            uint32_t ll2 = (uint32_t)(s2 >> 24);
+            if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
+                ll2 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
+            uint32_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
+                ml2 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
+            }
+            uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            DECODE_SEQ_SAFE(ll2, ml2, off2);
+
+            uint32_t ll3 = (uint32_t)(s3 >> 24);
+            if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
+                ll3 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
+            uint32_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
+                ml3 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
+            }
+            uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            DECODE_SEQ_SAFE(ll3, ml3, off3);
+
+            uint32_t ll4 = (uint32_t)(s4 >> 24);
+            if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
+                ll4 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
+            uint32_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
+                ml4 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
+            }
+            uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            DECODE_SEQ_SAFE(ll4, ml4, off4);
+
+            n_seq -= 4;
+        }
     }
 
     // --- SAFE Loop tail: remaining sequences with offset validation (1x) ---
@@ -1342,83 +1609,165 @@ static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
     }
 
     // --- FAST Loop: After threshold, check large margin to avoid individual bounds checks ---
-    while (n_seq >= 4 && d_ptr < d_end_fast && l_ptr < l_end_safe_4x) {
-        uint32_t s1 = zxc_le32(seq_ptr);
-        uint32_t s2 = zxc_le32(seq_ptr + 4);
-        uint32_t s3 = zxc_le32(seq_ptr + 8);
-        uint32_t s4 = zxc_le32(seq_ptr + 12);
-        seq_ptr += 16;
+    if (safe) {
+        while (n_seq >= 4 && d_ptr < d_end_fast && l_ptr < l_end_safe_4x) {
+            const uint8_t* const t_save = seq_ptr;
+            const uint8_t* const e_save = extras_ptr;
+            uint8_t* const d_save = d_ptr;
+            const uint8_t* const l_save = l_ptr;
+            uint32_t s1 = zxc_le32(seq_ptr);
+            uint32_t s2 = zxc_le32(seq_ptr + 4);
+            uint32_t s3 = zxc_le32(seq_ptr + 8);
+            uint32_t s4 = zxc_le32(seq_ptr + 12);
+            seq_ptr += 16;
 
-        // Prefetch ahead in literal and extras streams to hide memory latency
-        ZXC_PREFETCH_READ(l_ptr + ZXC_CACHE_LINE_SIZE);
+            // Prefetch ahead in literal and extras streams to hide memory latency
+            ZXC_PREFETCH_READ(l_ptr + ZXC_CACHE_LINE_SIZE);
 
-        uint32_t ll1 = (uint32_t)(s1 >> 24);
-        if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
-            ll1 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
-        uint32_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
-        if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
-            ml1 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        }
-        uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-        DECODE_SEQ_FAST(ll1, ml1, off1);
+            uint32_t ll1 = (uint32_t)(s1 >> 24);
+            if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
+                ll1 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                    goto rollback_fast_4x;
+            }
+            uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
+            uint32_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
+                ml1 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_PAD_SIZE > d_end)) goto rollback_fast_4x;
+            }
+            uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            DECODE_SEQ_FAST(ll1, ml1, off1);
 
-        uint32_t ll2 = (uint32_t)(s2 >> 24);
-        if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
-            ll2 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
-        uint32_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
-        if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
-            ml2 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        }
-        uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-        DECODE_SEQ_FAST(ll2, ml2, off2);
+            uint32_t ll2 = (uint32_t)(s2 >> 24);
+            if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
+                ll2 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                    goto rollback_fast_4x;
+            }
+            uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
+            uint32_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
+                ml2 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_PAD_SIZE > d_end)) goto rollback_fast_4x;
+            }
+            uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            DECODE_SEQ_FAST(ll2, ml2, off2);
 
-        uint32_t ll3 = (uint32_t)(s3 >> 24);
-        if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
-            ll3 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
-        uint32_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
-        if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
-            ml3 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        }
-        uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-        DECODE_SEQ_FAST(ll3, ml3, off3);
+            uint32_t ll3 = (uint32_t)(s3 >> 24);
+            if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
+                ll3 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                    goto rollback_fast_4x;
+            }
+            uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
+            uint32_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
+                ml3 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_PAD_SIZE > d_end)) goto rollback_fast_4x;
+            }
+            uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            DECODE_SEQ_FAST(ll3, ml3, off3);
 
-        uint32_t ll4 = (uint32_t)(s4 >> 24);
-        if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
-            ll4 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
-                return ZXC_ERROR_OVERFLOW;
-        }
-        uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
-        uint32_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
-        if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
-            ml4 += zxc_read_varint(&extras_ptr, extras_end);
-            if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
-        }
-        uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
-        DECODE_SEQ_FAST(ll4, ml4, off4);
+            uint32_t ll4 = (uint32_t)(s4 >> 24);
+            if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
+                ll4 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                    goto rollback_fast_4x;
+            }
+            uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
+            uint32_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
+                ml4 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) goto rollback_fast_4x;
+            }
+            uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            DECODE_SEQ_FAST(ll4, ml4, off4);
 
-        n_seq -= 4;
+            n_seq -= 4;
+            continue;
+
+        rollback_fast_4x:
+            seq_ptr = t_save;
+            extras_ptr = e_save;
+            d_ptr = d_save;
+            l_ptr = l_save;
+            break;
+        }
+    } else {
+        while (n_seq >= 4 && d_ptr < d_end_fast && l_ptr < l_end_safe_4x) {
+            uint32_t s1 = zxc_le32(seq_ptr);
+            uint32_t s2 = zxc_le32(seq_ptr + 4);
+            uint32_t s3 = zxc_le32(seq_ptr + 8);
+            uint32_t s4 = zxc_le32(seq_ptr + 12);
+            seq_ptr += 16;
+
+            // Prefetch ahead in literal and extras streams to hide memory latency
+            ZXC_PREFETCH_READ(l_ptr + ZXC_CACHE_LINE_SIZE);
+
+            uint32_t ll1 = (uint32_t)(s1 >> 24);
+            if (UNLIKELY(ll1 == ZXC_SEQ_LL_MASK)) {
+                ll1 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(l_ptr + ll1 > l_end || d_ptr + ll1 + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            uint32_t m1b = (uint32_t)((s1 >> 16) & 0xFF);
+            uint32_t ml1 = m1b + ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(m1b == ZXC_SEQ_ML_MASK)) {
+                ml1 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(d_ptr + ll1 + ml1 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
+            }
+            uint32_t off1 = (uint32_t)(s1 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            DECODE_SEQ_FAST(ll1, ml1, off1);
+
+            uint32_t ll2 = (uint32_t)(s2 >> 24);
+            if (UNLIKELY(ll2 == ZXC_SEQ_LL_MASK)) {
+                ll2 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(l_ptr + ll2 > l_end || d_ptr + ll2 + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            uint32_t m2b = (uint32_t)((s2 >> 16) & 0xFF);
+            uint32_t ml2 = m2b + ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(m2b == ZXC_SEQ_ML_MASK)) {
+                ml2 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(d_ptr + ll2 + ml2 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
+            }
+            uint32_t off2 = (uint32_t)(s2 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            DECODE_SEQ_FAST(ll2, ml2, off2);
+
+            uint32_t ll3 = (uint32_t)(s3 >> 24);
+            if (UNLIKELY(ll3 == ZXC_SEQ_LL_MASK)) {
+                ll3 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(l_ptr + ll3 > l_end || d_ptr + ll3 + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            uint32_t m3b = (uint32_t)((s3 >> 16) & 0xFF);
+            uint32_t ml3 = m3b + ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(m3b == ZXC_SEQ_ML_MASK)) {
+                ml3 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(d_ptr + ll3 + ml3 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
+            }
+            uint32_t off3 = (uint32_t)(s3 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            DECODE_SEQ_FAST(ll3, ml3, off3);
+
+            uint32_t ll4 = (uint32_t)(s4 >> 24);
+            if (UNLIKELY(ll4 == ZXC_SEQ_LL_MASK)) {
+                ll4 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(l_ptr + ll4 > l_end || d_ptr + ll4 + ZXC_PAD_SIZE > d_end))
+                    return ZXC_ERROR_OVERFLOW;
+            }
+            uint32_t m4b = (uint32_t)((s4 >> 16) & 0xFF);
+            uint32_t ml4 = m4b + ZXC_LZ_MIN_MATCH_LEN;
+            if (UNLIKELY(m4b == ZXC_SEQ_ML_MASK)) {
+                ml4 += zxc_read_varint(&extras_ptr, extras_end);
+                if (UNLIKELY(d_ptr + ll4 + ml4 + ZXC_PAD_SIZE > d_end)) return ZXC_ERROR_OVERFLOW;
+            }
+            uint32_t off4 = (uint32_t)(s4 & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;
+            DECODE_SEQ_FAST(ll4, ml4, off4);
+
+            n_seq -= 4;
+        }
     }
-
-#undef DECODE_SEQ_SAFE
-#undef DECODE_SEQ_FAST
-#undef DECODE_COPY_LITERALS
-#undef DECODE_COPY_MATCH
 
     // --- Remaining 1 sequence (Fast Path) ---
     while (n_seq > 0 && d_ptr < d_end_safe && l_ptr < l_end_safe_1x) {
@@ -1551,6 +1900,35 @@ static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
     return (int)(d_ptr - dst);
 }
 
+static int zxc_decode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
+                                const size_t src_size, uint8_t* RESTRICT dst,
+                                const size_t dst_capacity) {
+    return zxc_decode_block_ghi_impl(ctx, src, src_size, dst, dst_capacity, 0);
+}
+
+static int zxc_decode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
+                                const size_t src_size, uint8_t* RESTRICT dst,
+                                const size_t dst_capacity) {
+    return zxc_decode_block_glo_impl(ctx, src, src_size, dst, dst_capacity, 0);
+}
+
+static int zxc_decode_block_glo_safe(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
+                                     const size_t src_size, uint8_t* RESTRICT dst,
+                                     const size_t dst_capacity) {
+    return zxc_decode_block_glo_impl(ctx, src, src_size, dst, dst_capacity, 1);
+}
+
+static int zxc_decode_block_ghi_safe(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
+                                     const size_t src_size, uint8_t* RESTRICT dst,
+                                     const size_t dst_capacity) {
+    return zxc_decode_block_ghi_impl(ctx, src, src_size, dst, dst_capacity, 1);
+}
+
+#undef DECODE_SEQ_FAST
+#undef DECODE_SEQ_SAFE
+#undef DECODE_COPY_MATCH
+#undef DECODE_COPY_LITERALS
+
 // cppcheck-suppress unusedFunction
 int zxc_decompress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                  const size_t src_sz, uint8_t* RESTRICT dst, const size_t dst_cap) {
@@ -1599,4 +1977,44 @@ int zxc_decompress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRI
     }
 
     return decoded_sz;
+}
+
+// cppcheck-suppress unusedFunction
+int zxc_decompress_chunk_wrapper_safe(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
+                                      const size_t src_sz, uint8_t* RESTRICT dst,
+                                      const size_t dst_cap) {
+    if (UNLIKELY(src_sz < ZXC_BLOCK_HEADER_SIZE)) return ZXC_ERROR_SRC_TOO_SMALL;
+
+    const uint8_t type = src[0];
+    const uint32_t comp_sz = zxc_le32(src + 3);
+    const int has_crc = ctx->checksum_enabled;
+
+    const size_t expected_sz =
+        (size_t)ZXC_BLOCK_HEADER_SIZE + comp_sz + (has_crc ? ZXC_BLOCK_CHECKSUM_SIZE : 0);
+    if (UNLIKELY(src_sz < expected_sz)) return ZXC_ERROR_SRC_TOO_SMALL;
+
+    const uint8_t* data = src + ZXC_BLOCK_HEADER_SIZE;
+
+    if (has_crc) {
+        const uint32_t stored = zxc_le32(data + comp_sz);
+        const uint32_t calc = zxc_checksum(data, comp_sz, ZXC_CHECKSUM_RAPIDHASH);
+        if (UNLIKELY(stored != calc)) return ZXC_ERROR_BAD_CHECKSUM;
+    }
+
+    switch (type) {
+        case ZXC_BLOCK_GLO:
+            return zxc_decode_block_glo_safe(ctx, data, comp_sz, dst, dst_cap);
+        case ZXC_BLOCK_GHI:
+            return zxc_decode_block_ghi_safe(ctx, data, comp_sz, dst, dst_cap);
+        case ZXC_BLOCK_RAW:
+            if (UNLIKELY(comp_sz > dst_cap)) return ZXC_ERROR_DST_TOO_SMALL;
+            ZXC_MEMCPY(dst, data, comp_sz);
+            return (int)comp_sz;
+        case ZXC_BLOCK_NUM:
+            return zxc_decode_block_num(data, comp_sz, dst, dst_cap);
+        case ZXC_BLOCK_EOF:
+            return ZXC_ERROR_CORRUPT_DATA;
+        default:
+            return ZXC_ERROR_BAD_BLOCK_TYPE;
+    }
 }

--- a/lz/zxc/src/lib/zxc_dispatch.c
+++ b/lz/zxc/src/lib/zxc_dispatch.c
@@ -47,6 +47,9 @@
 int zxc_decompress_chunk_wrapper_default(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                          const size_t src_sz, uint8_t* RESTRICT dst,
                                          const size_t dst_cap);
+int zxc_decompress_chunk_wrapper_safe_default(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
+                                              const size_t src_sz, uint8_t* RESTRICT dst,
+                                              const size_t dst_cap);
 
 #ifndef ZXC_ONLY_DEFAULT
 #if defined(__x86_64__) || defined(_M_X64)
@@ -56,10 +59,19 @@ int zxc_decompress_chunk_wrapper_avx2(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
 int zxc_decompress_chunk_wrapper_avx512(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                         const size_t src_sz, uint8_t* RESTRICT dst,
                                         const size_t dst_cap);
+int zxc_decompress_chunk_wrapper_safe_avx2(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
+                                           const size_t src_sz, uint8_t* RESTRICT dst,
+                                           const size_t dst_cap);
+int zxc_decompress_chunk_wrapper_safe_avx512(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
+                                             const size_t src_sz, uint8_t* RESTRICT dst,
+                                             const size_t dst_cap);
 #elif defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)
 int zxc_decompress_chunk_wrapper_neon(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                       const size_t src_sz, uint8_t* RESTRICT dst,
                                       const size_t dst_cap);
+int zxc_decompress_chunk_wrapper_safe_neon(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
+                                           const size_t src_sz, uint8_t* RESTRICT dst,
+                                           const size_t dst_cap);
 #endif
 #endif
 
@@ -67,6 +79,18 @@ int zxc_decompress_chunk_wrapper_neon(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
 int zxc_compress_chunk_wrapper_default(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                        const size_t src_sz, uint8_t* RESTRICT dst,
                                        const size_t dst_cap);
+
+// Huffman Prototypes (variant TUs of zxc_huffman.c). The compressor and
+// decompressor variants resolve their Huffman calls to the matching suffixed
+// symbol at compile time (zero dispatch overhead in the hot path); the thin
+// wrappers below expose the un-suffixed names for tests and external callers.
+int zxc_huf_build_code_lengths_default(const uint32_t* RESTRICT freq, uint8_t* RESTRICT code_len,
+                                       void* RESTRICT scratch);
+int zxc_huf_encode_section_default(const uint8_t* RESTRICT literals, const size_t n_literals,
+                                   const uint8_t* RESTRICT code_len, uint8_t* RESTRICT dst,
+                                   const size_t dst_cap);
+int zxc_huf_decode_section_default(const uint8_t* RESTRICT payload, const size_t payload_size,
+                                   uint8_t* RESTRICT dst, const size_t n_literals);
 
 #if defined(__x86_64__) || defined(_M_X64)
 int zxc_compress_chunk_wrapper_avx2(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
@@ -106,6 +130,7 @@ typedef enum {
  *
  * @return The highest @ref zxc_cpu_feature_t level supported.
  */
+// LCOV_EXCL_START
 static zxc_cpu_feature_t zxc_detect_cpu_features(void) {
 #ifdef ZXC_ONLY_DEFAULT
     return ZXC_CPU_GENERIC;
@@ -171,6 +196,7 @@ static zxc_cpu_feature_t zxc_detect_cpu_features(void) {
     return features;
 #endif
 }
+// LCOV_EXCL_STOP
 
 /*
  * ============================================================================
@@ -188,6 +214,8 @@ typedef int (*zxc_compress_func_t)(zxc_cctx_t* RESTRICT, const uint8_t* RESTRICT
 
 /** @brief Lazily-resolved pointer to the best decompression variant. */
 static ZXC_ATOMIC zxc_decompress_func_t zxc_decompress_ptr = (zxc_decompress_func_t)0;
+/** @brief Lazily-resolved pointer to the best safe-decompression variant. */
+static ZXC_ATOMIC zxc_decompress_func_t zxc_decompress_safe_ptr = (zxc_decompress_func_t)0;
 /** @brief Lazily-resolved pointer to the best compression variant. */
 static ZXC_ATOMIC zxc_compress_func_t zxc_compress_ptr = (zxc_compress_func_t)0;
 
@@ -197,6 +225,7 @@ static ZXC_ATOMIC zxc_compress_func_t zxc_compress_ptr = (zxc_compress_func_t)0;
  * Detects CPU features, selects the best implementation, stores the
  * pointer atomically, then tail-calls into it.
  */
+// LCOV_EXCL_START
 static int zxc_decompress_dispatch_init(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                         const size_t src_sz, uint8_t* RESTRICT dst,
                                         const size_t dst_cap) {
@@ -233,6 +262,53 @@ static int zxc_decompress_dispatch_init(zxc_cctx_t* RESTRICT ctx, const uint8_t*
 #endif
     return zxc_decompress_ptr_local(ctx, src, src_sz, dst, dst_cap);
 }
+// LCOV_EXCL_STOP
+
+/**
+ * @brief First-call initialiser for the safe-decompression dispatcher.
+ *
+ * Mirrors @ref zxc_decompress_dispatch_init but selects the `_safe_*`
+ * decoder variants used by @ref zxc_decompress_block_safe.
+ */
+// LCOV_EXCL_START
+static int zxc_decompress_safe_dispatch_init(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
+                                             const size_t src_sz, uint8_t* RESTRICT dst,
+                                             const size_t dst_cap) {
+    const zxc_cpu_feature_t cpu = zxc_detect_cpu_features();
+    zxc_decompress_func_t zxc_decompress_safe_ptr_local = NULL;
+
+#ifndef ZXC_ONLY_DEFAULT
+#if defined(__x86_64__) || defined(_M_X64)
+    if (cpu == ZXC_CPU_AVX512)
+        zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_avx512;
+    else if (cpu == ZXC_CPU_AVX2)
+        zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_avx2;
+    else
+        zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_default;
+#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)
+    // cppcheck-suppress knownConditionTrueFalse
+    if (cpu == ZXC_CPU_NEON)
+        zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_neon;
+    else
+        zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_default;
+#else
+    (void)cpu;
+    zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_default;
+#endif
+#else
+    (void)cpu;
+    zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_default;
+#endif
+
+#if ZXC_USE_C11_ATOMICS
+    atomic_store_explicit(&zxc_decompress_safe_ptr, zxc_decompress_safe_ptr_local,
+                          memory_order_release);
+#else
+    zxc_decompress_safe_ptr = zxc_decompress_safe_ptr_local;
+#endif
+    return zxc_decompress_safe_ptr_local(ctx, src, src_sz, dst, dst_cap);
+}
+// LCOV_EXCL_STOP
 
 /**
  * @brief First-call initialiser for the compression dispatcher.
@@ -240,6 +316,7 @@ static int zxc_decompress_dispatch_init(zxc_cctx_t* RESTRICT ctx, const uint8_t*
  * Detects CPU features, selects the best implementation, stores the
  * pointer atomically, then tail-calls into it.
  */
+// LCOV_EXCL_START
 static int zxc_compress_dispatch_init(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                       const size_t src_sz, uint8_t* RESTRICT dst,
                                       const size_t dst_cap) {
@@ -276,6 +353,7 @@ static int zxc_compress_dispatch_init(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
 #endif
     return zxc_compress_ptr_local(ctx, src, src_sz, dst, dst_cap);
 }
+// LCOV_EXCL_STOP
 
 /**
  * @brief Public decompression dispatcher (calls lazily-resolved implementation).
@@ -300,6 +378,23 @@ int zxc_decompress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRI
 }
 
 /**
+ * @brief Internal safe-decompression dispatcher (strict dst_capacity == uncompressed_size).
+ */
+static int zxc_decompress_chunk_wrapper_safe_public(zxc_cctx_t* RESTRICT ctx,
+                                                    const uint8_t* RESTRICT src,
+                                                    const size_t src_sz, uint8_t* RESTRICT dst,
+                                                    const size_t dst_cap) {
+#if ZXC_USE_C11_ATOMICS
+    const zxc_decompress_func_t func =
+        atomic_load_explicit(&zxc_decompress_safe_ptr, memory_order_acquire);
+#else
+    const zxc_decompress_func_t func = zxc_decompress_safe_ptr;
+#endif
+    if (UNLIKELY(!func)) return zxc_decompress_safe_dispatch_init(ctx, src, src_sz, dst, dst_cap);
+    return func(ctx, src, src_sz, dst, dst_cap);
+}
+
+/**
  * @brief Public compression dispatcher (calls lazily-resolved implementation).
  *
  * @param[in,out] ctx    Compression context.
@@ -318,6 +413,36 @@ int zxc_compress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT
 #endif
     if (UNLIKELY(!func)) return zxc_compress_dispatch_init(ctx, src, src_sz, dst, dst_cap);
     return func(ctx, src, src_sz, dst, dst_cap);
+}
+
+/*
+ * ============================================================================
+ * HUFFMAN TRAMPOLINES
+ * ============================================================================
+ * The Huffman codec is built per-variant (default / avx2 / avx512 / neon)
+ * alongside zxc_compress.c and zxc_decompress.c, so the LZ77 stages and the
+ * Huffman stage in a given variant share the same ISA flags (e.g. -mbmi2 on
+ * the AVX2/AVX512 variants). The compress/decompress variant TUs resolve
+ * their Huffman calls to the matching suffixed symbol at compile time, so
+ * the production hot path has zero dispatch overhead.
+ *
+ * These thin wrappers exist only for tests and external callers that link
+ * against the un-suffixed names. They forward to the default (scalar) variant.
+ */
+int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT code_len,
+                               void* RESTRICT scratch) {
+    return zxc_huf_build_code_lengths_default(freq, code_len, scratch);
+}
+
+int zxc_huf_encode_section(const uint8_t* RESTRICT literals, const size_t n_literals,
+                           const uint8_t* RESTRICT code_len, uint8_t* RESTRICT dst,
+                           const size_t dst_cap) {
+    return zxc_huf_encode_section_default(literals, n_literals, code_len, dst, dst_cap);
+}
+
+int zxc_huf_decode_section(const uint8_t* RESTRICT payload, const size_t payload_size,
+                           uint8_t* RESTRICT dst, const size_t n_literals) {
+    return zxc_huf_decode_section_default(payload, payload_size, dst, n_literals);
 }
 
 /*
@@ -576,13 +701,12 @@ int64_t zxc_decompress(const void* RESTRICT src, const size_t src_size, void* RE
 
         int res;
         const size_t rem_cap = (size_t)(op_end - op);
-        if (LIKELY(rem_cap >= runtime_chunk_size + 2 * ZXC_PAD_SIZE)) {
+        if (LIKELY(rem_cap >= work_sz)) {
             // Fast path: decode directly into dst. Cap dst_cap to chunk_size + PAD
-            res = zxc_decompress_chunk_wrapper(&ctx, ip, rem_src, op,
-                                               runtime_chunk_size + ZXC_PAD_SIZE);
+            res = zxc_decompress_chunk_wrapper(&ctx, ip, rem_src, op, work_sz);
         } else {
             // Safe path: decode into bounce buffer, then copy exact result.
-            res = zxc_decompress_chunk_wrapper(&ctx, ip, rem_src, ctx.work_buf, runtime_chunk_size);
+            res = zxc_decompress_chunk_wrapper(&ctx, ip, rem_src, ctx.work_buf, ctx.work_buf_cap);
             if (LIKELY(res > 0)) {
                 // LCOV_EXCL_START
                 if (UNLIKELY((size_t)res > rem_cap)) {
@@ -681,7 +805,7 @@ zxc_cctx* zxc_create_cctx(const zxc_compress_opts_t* opts) {
 }
 
 void zxc_free_cctx(zxc_cctx* cctx) {
-    if (!cctx) return;
+    if (UNLIKELY(!cctx)) return;
     if (cctx->initialized) zxc_cctx_free(&cctx->inner);
     free(cctx);
 }
@@ -704,10 +828,12 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return ZXC_ERROR_BAD_BLOCK_SIZE;
 
     /* Re-init only when block_size changed (it drives buffer sizes). */
-    if (!cctx->initialized || cctx->last_block_size != block_size) {
+    if (UNLIKELY(!cctx->initialized || cctx->last_block_size != block_size)) {
         if (cctx->initialized) {
+            // LCOV_EXCL_START
             zxc_cctx_free(&cctx->inner);
             cctx->initialized = 0;
+            // LCOV_EXCL_STOP
         }
         // LCOV_EXCL_START
         if (UNLIKELY(zxc_cctx_init(&cctx->inner, block_size, 1, level, checksum_enabled) != ZXC_OK))
@@ -786,7 +912,7 @@ zxc_dctx* zxc_create_dctx(void) {
 }
 
 void zxc_free_dctx(zxc_dctx* dctx) {
-    if (!dctx) return;
+    if (UNLIKELY(!dctx)) return;
     if (dctx->initialized) zxc_cctx_free(&dctx->inner);
     free(dctx);
 }
@@ -794,8 +920,8 @@ void zxc_free_dctx(zxc_dctx* dctx) {
 int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size_t src_size,
                             void* RESTRICT dst, const size_t dst_capacity,
                             const zxc_decompress_opts_t* opts) {
-    if (UNLIKELY(!dctx)) return ZXC_ERROR_NULL_INPUT;
-    if (UNLIKELY(!src || !dst || src_size < ZXC_FILE_HEADER_SIZE)) return ZXC_ERROR_NULL_INPUT;
+    if (UNLIKELY(!dctx || !src || !dst || src_size < ZXC_FILE_HEADER_SIZE))
+        return ZXC_ERROR_NULL_INPUT;
 
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
 
@@ -806,16 +932,19 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
     const uint8_t* const op_end = op + dst_capacity;
     size_t runtime_chunk_size = 0;
     int file_has_checksums = 0;
+    uint32_t global_hash = 0;
 
     if (UNLIKELY(zxc_read_file_header(ip, src_size, &runtime_chunk_size, &file_has_checksums) !=
                  ZXC_OK))
         return ZXC_ERROR_BAD_HEADER;
 
     /* Re-init only when block size changed. */
-    if (!dctx->initialized || dctx->last_block_size != runtime_chunk_size) {
+    if (UNLIKELY(!dctx->initialized || dctx->last_block_size != runtime_chunk_size)) {
         if (dctx->initialized) {
+            // LCOV_EXCL_START
             zxc_cctx_free(&dctx->inner);
             dctx->initialized = 0;
+            // LCOV_EXCL_STOP
         }
         // LCOV_EXCL_START
         if (UNLIKELY(zxc_cctx_init(&dctx->inner, runtime_chunk_size, 0, 0,
@@ -833,14 +962,12 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
 
     /* Ensure scratch buffer is large enough. */
     const size_t work_sz = runtime_chunk_size + ZXC_PAD_SIZE;
-    if (ctx->work_buf_cap < work_sz) {
+    if (UNLIKELY(ctx->work_buf_cap < work_sz)) {
         free(ctx->work_buf);
         ctx->work_buf = (uint8_t*)malloc(work_sz);
         if (UNLIKELY(!ctx->work_buf)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
         ctx->work_buf_cap = work_sz;
     }
-
-    uint32_t global_hash = 0;
 
     while (ip < ip_end) {
         const size_t rem_src = (size_t)(ip_end - ip);
@@ -865,12 +992,12 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
 
         const size_t rem_cap = (size_t)(op_end - op);
         int res;
-        if (LIKELY(rem_cap >= runtime_chunk_size + ZXC_PAD_SIZE)) {
+        if (LIKELY(rem_cap >= work_sz)) {
             // Fast path: decode directly into dst (enough padding for wild copies).
             res = zxc_decompress_chunk_wrapper(ctx, ip, rem_src, op, rem_cap);
         } else {
             // Safe path: decode into bounce buffer, then copy exact result.
-            res = zxc_decompress_chunk_wrapper(ctx, ip, rem_src, ctx->work_buf, runtime_chunk_size);
+            res = zxc_decompress_chunk_wrapper(ctx, ip, rem_src, ctx->work_buf, ctx->work_buf_cap);
             if (LIKELY(res > 0)) {
                 if (UNLIKELY((size_t)res > rem_cap))
                     return ZXC_ERROR_DST_TOO_SMALL;  // LCOV_EXCL_LINE
@@ -907,17 +1034,22 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
     /* For block API, block_size == src_size (the caller compresses one block at a time). */
     const size_t block_size =
         (opts && opts->block_size > 0) ? opts->block_size : cctx->stored_block_size;
-    const size_t effective_block_size = (block_size > 0) ? block_size : src_size;
+    const size_t min_bs = zxc_block_size_ceil(src_size);
+
+    /* Always ensure internal buffers can hold src_size. */
+    const size_t effective_block_size = (block_size > min_bs) ? block_size : min_bs;
 
     cctx->stored_level = level;
     cctx->stored_block_size = effective_block_size;
     cctx->stored_checksum = checksum_enabled;
 
     /* Re-init only when block_size changed. */
-    if (!cctx->initialized || cctx->last_block_size != effective_block_size) {
+    if (UNLIKELY(!cctx->initialized || cctx->last_block_size != effective_block_size)) {
         if (cctx->initialized) {
+            // LCOV_EXCL_START
             zxc_cctx_free(&cctx->inner);
             cctx->initialized = 0;
+            // LCOV_EXCL_STOP
         }
         // LCOV_EXCL_START
         if (UNLIKELY(zxc_cctx_init(&cctx->inner, effective_block_size, 1, level,
@@ -940,17 +1072,14 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
 int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const size_t src_size,
                              void* RESTRICT dst, const size_t dst_capacity,
                              const zxc_decompress_opts_t* opts) {
-    if (UNLIKELY(!dctx || !src || !dst || src_size < ZXC_BLOCK_HEADER_SIZE))
+    if (UNLIKELY(!dctx || !src || !dst || src_size < ZXC_BLOCK_HEADER_SIZE || dst_capacity == 0))
         return ZXC_ERROR_NULL_INPUT;
 
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
 
-    /*
-     * Derive the block_size from dst_capacity (callers know the original size).
-     * Re-init only when needed.
-     */
-    const size_t block_size = dst_capacity;
-    if (!dctx->initialized || dctx->last_block_size != block_size) {
+    /* Derive the block_size from dst_capacity (callers know the original size). */
+    const size_t block_size = zxc_block_size_ceil(dst_capacity);
+    if (UNLIKELY(!dctx->initialized || dctx->last_block_size != block_size)) {
         if (dctx->initialized) {
             zxc_cctx_free(&dctx->inner);
             dctx->initialized = 0;
@@ -977,18 +1106,62 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
     }
 
     int res;
-    if (LIKELY(dst_capacity >= block_size + ZXC_PAD_SIZE)) {
+    if (LIKELY(dst_capacity >= work_sz)) {
         res = zxc_decompress_chunk_wrapper(ctx, (const uint8_t*)src, src_size, (uint8_t*)dst,
                                            dst_capacity);
     } else {
         /* Bounce through work_buf when output can't absorb wild copies. */
         res = zxc_decompress_chunk_wrapper(ctx, (const uint8_t*)src, src_size, ctx->work_buf,
-                                           block_size);
+                                           ctx->work_buf_cap);
         if (LIKELY(res > 0)) {
             if (UNLIKELY((size_t)res > dst_capacity)) return ZXC_ERROR_DST_TOO_SMALL;
             ZXC_MEMCPY(dst, ctx->work_buf, (size_t)res);
         }
     }
+    if (UNLIKELY(res < 0)) return res;
+    return (int64_t)res;
+}
+
+/**
+ * @brief Safe-variant block decompressor: accepts dst_capacity == uncompressed_size.
+ *
+ * Router: NUM/RAW blocks (which never wild-write past dst_capacity) are
+ * forwarded to the existing fast path. GLO/GHI blocks use the strict safe
+ * decoder, avoiding the bounce buffer and the +ZXC_DECOMPRESS_TAIL_PAD
+ * requirement of @ref zxc_decompress_block.
+ */
+int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* RESTRICT src, const size_t src_size,
+                                  void* RESTRICT dst, const size_t dst_capacity,
+                                  const zxc_decompress_opts_t* opts) {
+    if (UNLIKELY(!dctx || !src || !dst || src_size < ZXC_BLOCK_HEADER_SIZE || dst_capacity == 0))
+        return ZXC_ERROR_NULL_INPUT;
+
+    const uint8_t type = ((const uint8_t*)src)[0];
+    /* NUM/RAW never wild-write past dst_capacity: route to the existing fast API. */
+    if (type == ZXC_BLOCK_NUM || type == ZXC_BLOCK_RAW) {
+        return zxc_decompress_block(dctx, src, src_size, dst, dst_capacity, opts);
+    }
+
+    /* GLO/GHI: use the strict-tail decoder (no bounce buffer required). */
+    const int checksum_enabled = opts ? opts->checksum_enabled : 0;
+    const size_t block_size = zxc_block_size_ceil(dst_capacity);
+    if (UNLIKELY(!dctx->initialized || dctx->last_block_size != block_size)) {
+        if (dctx->initialized) {
+            zxc_cctx_free(&dctx->inner);
+            dctx->initialized = 0;
+        }
+        // LCOV_EXCL_START
+        if (UNLIKELY(zxc_cctx_init(&dctx->inner, block_size, 0, 0, checksum_enabled) != ZXC_OK))
+            return ZXC_ERROR_MEMORY;
+        // LCOV_EXCL_STOP
+        dctx->last_block_size = block_size;
+        dctx->initialized = 1;
+    } else {
+        dctx->inner.checksum_enabled = checksum_enabled;
+    }
+
+    const int res = zxc_decompress_chunk_wrapper_safe_public(&dctx->inner, (const uint8_t*)src,
+                                                             src_size, (uint8_t*)dst, dst_capacity);
     if (UNLIKELY(res < 0)) return res;
     return (int64_t)res;
 }

--- a/lz/zxc/src/lib/zxc_driver.c
+++ b/lz/zxc/src/lib/zxc_driver.c
@@ -441,23 +441,23 @@ static void* zxc_async_writer(void* arg) {
         while (job->status != JOB_STATUS_PROCESSED && !ctx->io_error)
             pthread_cond_wait(&ctx->cond_writer, &ctx->lock);
 
-        if (job->result_sz == (size_t)-1) {
-            pthread_mutex_unlock(&ctx->lock);
-            break;
-        }
+        const size_t result_sz = job->result_sz;
+        const size_t in_sz = job->in_sz;
         pthread_mutex_unlock(&ctx->lock);
 
-        if (args->f && job->result_sz > 0) {
-            if (fwrite(job->out_buf, 1, job->result_sz, args->f) != job->result_sz) {
+        if (result_sz == (size_t)-1) break;
+
+        if (args->f && result_sz > 0) {
+            if (fwrite(job->out_buf, 1, result_sz, args->f) != result_sz) {
                 pthread_mutex_lock(&ctx->lock);
                 ctx->io_error = 1;
                 pthread_cond_signal(&ctx->cond_reader);
                 pthread_mutex_unlock(&ctx->lock);
             } else if (ctx->checksum_enabled && ctx->compression_mode == 1) {
                 // Update Global Hash (Rotation + XOR)
-                if (LIKELY(job->result_sz >= ZXC_GLOBAL_CHECKSUM_SIZE)) {
+                if (LIKELY(result_sz >= ZXC_GLOBAL_CHECKSUM_SIZE)) {
                     uint32_t block_hash =
-                        zxc_le32(job->out_buf + job->result_sz - ZXC_GLOBAL_CHECKSUM_SIZE);
+                        zxc_le32(job->out_buf + result_sz - ZXC_GLOBAL_CHECKSUM_SIZE);
                     args->global_hash = zxc_hash_combine_rotate(args->global_hash, block_hash);
                 }
             }
@@ -469,7 +469,7 @@ static void* zxc_async_writer(void* arg) {
             pthread_mutex_unlock(&ctx->lock);
             break;
         }
-        args->total_bytes += (int64_t)job->result_sz;
+        args->total_bytes += (int64_t)result_sz;
 
         /* Seekable: record compressed block size */
         if (args->seek_comp && ctx->compression_mode == 1) {
@@ -479,8 +479,8 @@ static void* zxc_async_writer(void* arg) {
                     (uint32_t*)realloc(args->seek_comp, args->seek_cap * sizeof(uint32_t));
                 // LCOV_EXCL_START
                 if (UNLIKELY(!nc)) {
-                    ctx->io_error = 1;
                     pthread_mutex_lock(&ctx->lock);
+                    ctx->io_error = 1;
                     job->status = JOB_STATUS_FREE;
                     pthread_cond_signal(&ctx->cond_reader);
                     pthread_mutex_unlock(&ctx->lock);
@@ -489,13 +489,13 @@ static void* zxc_async_writer(void* arg) {
                 // LCOV_EXCL_STOP
                 args->seek_comp = nc;
             }
-            args->seek_comp[args->seek_count++] = (uint32_t)job->result_sz;
+            args->seek_comp[args->seek_count++] = (uint32_t)result_sz;
         }
 
         // Update progress callback
         if (ctx->progress_cb) {
             // LCOV_EXCL_START
-            args->bytes_processed += ctx->compression_mode == 1 ? job->in_sz : job->result_sz;
+            args->bytes_processed += ctx->compression_mode == 1 ? in_sz : result_sz;
             ctx->progress_cb(args->bytes_processed, ctx->total_input_bytes,
                              ctx->progress_user_data);
             // LCOV_EXCL_STOP
@@ -809,7 +809,7 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     pthread_mutex_lock(&ctx.lock);
     while (end_job->status != JOB_STATUS_FREE && !ctx.io_error)
         pthread_cond_wait(&ctx.cond_reader, &ctx.lock);
-    end_job->result_sz = -1;
+    end_job->result_sz = (size_t)-1;
     end_job->status = JOB_STATUS_PROCESSED;
     pthread_cond_broadcast(&ctx.cond_writer);
     pthread_mutex_unlock(&ctx.lock);

--- a/lz/zxc/src/lib/zxc_huffman.c
+++ b/lz/zxc/src/lib/zxc_huffman.c
@@ -1,0 +1,813 @@
+/*
+ * ZXC - High-performance lossless compression
+ *
+ * Copyright (c) 2025-2026 Bertrand Lebonnois and contributors.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+/**
+ * @file zxc_huffman.c
+ * @brief Canonical, length-limited (ZXC_HUF_MAX_CODE_LEN) Huffman codec for the GLO literal
+ *
+ * Canonical, length-limited (ZXC_HUF_MAX_CODE_LEN) Huffman codec for the GLO literal
+ * stream at compression level >= 6. Codes are emitted LSB-first; the
+ * decoder uses a 2048-entry multi-symbol lookup table (11-bit lookup,
+ * 1 or 2 symbols per lookup depending on the cumulative code length)
+ * and a 4-way interleaved hot loop. Public declarations live in
+ * zxc_internal.h; the rest is private to this translation unit.
+ */
+
+/*
+ * Function Multi-Versioning Support
+ * If ZXC_FUNCTION_SUFFIX is defined (e.g. _avx2, _neon), rename the public
+ * entry points so each variant TU produces its own copy under a unique symbol
+ * (e.g. zxc_huf_decode_section_avx2). The runtime dispatcher in
+ * zxc_compress.c / zxc_decompress.c routes to the matching variant.
+ *
+ * The defines sit before zxc_internal.h so the header's prototypes are
+ * rewritten with the same suffix as the definitions below.
+ */
+#ifdef ZXC_FUNCTION_SUFFIX
+#define ZXC_CAT_IMPL(x, y) x##y
+#define ZXC_CAT(x, y) ZXC_CAT_IMPL(x, y)
+#define zxc_huf_build_code_lengths ZXC_CAT(zxc_huf_build_code_lengths, ZXC_FUNCTION_SUFFIX)
+#define zxc_huf_encode_section ZXC_CAT(zxc_huf_encode_section, ZXC_FUNCTION_SUFFIX)
+#define zxc_huf_decode_section ZXC_CAT(zxc_huf_decode_section, ZXC_FUNCTION_SUFFIX)
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../include/zxc_error.h"
+#include "zxc_internal.h"
+
+/* 2048-entry multi-symbol decoder lookup table entry. Bit layout:
+ *   bits  0..7   sym1       - first decoded symbol
+ *   bits  8..15  sym2       - second decoded symbol (junk if n_extra == 0)
+ *   bits 16..19  len1       - bit length of sym1's code (1..8)
+ *   bits 20..23  len_total  - total bits consumed (1..11)
+ *   bit  24      n_extra    - 0 if 1 symbol, 1 if 2 symbols decoded
+ *
+ * Single-symbol path (tail) reads sym1 + len1; multi-symbol path (hot
+ * batched loop) reads sym1, sym2 (always written, possibly overwritten
+ * next iter), len_total, n_extra. */
+typedef struct {
+    uint32_t entry;
+} zxc_huf_dec_entry_t;
+
+#define ZXC_HUF_ENTRY(sym1, sym2, len1, len_total, n_extra)                  \
+    ((uint32_t)(sym1) | ((uint32_t)(sym2) << 8) | ((uint32_t)(len1) << 16) | \
+     ((uint32_t)(len_total) << 20) | ((uint32_t)(n_extra) << 24))
+
+/* ===========================================================================
+ * Length-limited Huffman: boundary package-merge
+ * ===========================================================================
+ *
+ * Builds optimal length-limited Huffman code lengths (max length
+ * ZXC_HUF_MAX_CODE_LEN) on 256-symbol alphabets. Package-merge is run for
+ * ZXC_HUF_MAX_CODE_LEN levels; each level holds up to 2N items (leaves +
+ * paired packages). Selection of the cheapest 2N - 2 items at level
+ * ZXC_HUF_MAX_CODE_LEN gives the appearance count of each leaf, which is
+ * its code length.
+ */
+
+typedef zxc_huf_pm_item_t pm_item_t;
+
+typedef struct {
+    uint32_t w;
+    int16_t sym;
+} pm_leaf_t;
+
+typedef zxc_huf_pm_frame_t frame_t;
+
+/**
+ * @brief qsort comparator for `pm_leaf_t` arrays.
+ *
+ * Orders leaves by ascending weight, breaking ties by ascending symbol value
+ * so the resulting code-length assignment is deterministic across runs.
+ *
+ * @param[in] a Pointer to a `pm_leaf_t` (cast from `const void*`).
+ * @param[in] b Pointer to a `pm_leaf_t` (cast from `const void*`).
+ * @return Negative / zero / positive per the `qsort` convention.
+ */
+static int pm_leaf_cmp(const void* a, const void* b) {
+    const pm_leaf_t* const la = (const pm_leaf_t*)a;
+    const pm_leaf_t* const lb = (const pm_leaf_t*)b;
+    if (la->w < lb->w) return -1;
+    if (la->w > lb->w) return 1;
+    return la->sym - lb->sym;
+}
+
+/**
+ * @brief Build length-limited canonical Huffman code lengths.
+ *
+ * Runs the boundary package-merge algorithm capped at `ZXC_HUF_MAX_CODE_LEN`.
+ * Symbols with `freq[i] == 0` get `code_len[i] == 0`; every other symbol
+ * receives a length in `[1, ZXC_HUF_MAX_CODE_LEN]`. The single-present-symbol
+ * case is handled as a degenerate code of length 1.
+ *
+ * @param[in]  freq     Frequency table indexed by symbol (0..255).
+ * @param[out] code_len Output code-length array, written in full.
+ * @param[in]  scratch  Optional scratch of `ZXC_HUF_BUILD_SCRATCH_SIZE` bytes
+ *                      (carved into items / counts / stack regions). If
+ *                      `NULL`, the function allocates its own working memory
+ *                      for the duration of the call.
+ * @return `ZXC_OK` on success, `ZXC_ERROR_MEMORY` or `ZXC_ERROR_CORRUPT_DATA`
+ *         on failure.
+ */
+int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT code_len,
+                               void* RESTRICT scratch) {
+    ZXC_MEMSET(code_len, 0, ZXC_HUF_NUM_SYMBOLS);
+
+    pm_leaf_t leaves[ZXC_HUF_NUM_SYMBOLS];
+    int n = 0;
+    for (int i = 0; i < ZXC_HUF_NUM_SYMBOLS; i++) {
+        if (freq[i] > 0) {
+            leaves[n].w = freq[i];
+            leaves[n].sym = (int16_t)i;
+            n++;
+        }
+    }
+    if (UNLIKELY(n == 0)) return ZXC_ERROR_CORRUPT_DATA;
+    if (n == 1) {
+        code_len[leaves[0].sym] = 1;
+        return ZXC_OK;
+    }
+
+    qsort(leaves, (size_t)n, sizeof(pm_leaf_t), pm_leaf_cmp);
+
+    /* n <= 256 <= 2^ZXC_HUF_MAX_CODE_LEN, so length-limit is always feasible. */
+    const int max_per_level = 2 * n;
+
+    /* Working buffers: either carve from caller-provided scratch (sized for
+     * the worst-case alphabet) or fall back to per-call malloc/free. */
+    pm_item_t* items;
+    int* counts;
+    frame_t* stack;
+    pm_item_t* owned_items = NULL;
+    int* owned_counts = NULL;
+    frame_t* owned_stack = NULL;
+    if (scratch) {
+        uint8_t* p = (uint8_t*)scratch;
+        items = (pm_item_t*)p;
+        p += (size_t)ZXC_HUF_MAX_CODE_LEN * (size_t)ZXC_HUF_PM_LEVEL_BOUND * sizeof(pm_item_t);
+        p = (uint8_t*)(((uintptr_t)p + 7u) & ~(uintptr_t)7u);
+        counts = (int*)p;
+        ZXC_MEMSET(counts, 0, (size_t)ZXC_HUF_MAX_CODE_LEN * sizeof(int));
+        p += (size_t)ZXC_HUF_MAX_CODE_LEN * sizeof(int);
+        p = (uint8_t*)(((uintptr_t)p + 7u) & ~(uintptr_t)7u);
+        stack = (frame_t*)p;
+    } else {
+        owned_items = (pm_item_t*)malloc((size_t)ZXC_HUF_MAX_CODE_LEN * (size_t)max_per_level *
+                                         sizeof(pm_item_t));
+        owned_counts = (int*)calloc((size_t)ZXC_HUF_MAX_CODE_LEN, sizeof(int));
+        owned_stack = (frame_t*)malloc((size_t)ZXC_HUF_MAX_CODE_LEN * (size_t)max_per_level *
+                                       sizeof(frame_t));
+        if (UNLIKELY(!owned_items || !owned_counts || !owned_stack)) {
+            free(owned_items);
+            free(owned_counts);
+            free(owned_stack);
+            return ZXC_ERROR_MEMORY;
+        }
+        items = owned_items;
+        counts = owned_counts;
+        stack = owned_stack;
+    }
+#define ITEM(k, i) items[(size_t)(k) * (size_t)max_per_level + (size_t)(i)]
+
+    /* Level 0 (logical level 1): the leaves themselves, already sorted. */
+    for (int i = 0; i < n; i++) {
+        ITEM(0, i).weight = leaves[i].w;
+        ITEM(0, i).left = -1;
+        ITEM(0, i).right = -1;
+        ITEM(0, i).sym = leaves[i].sym;
+    }
+    counts[0] = n;
+
+    /* Levels 1..ZXC_HUF_MAX_CODE_LEN-1: merge sorted leaves with sorted packages from the previous
+     * level. */
+    for (int k = 1; k < ZXC_HUF_MAX_CODE_LEN; k++) {
+        const int prev = counts[k - 1];
+        const int packs = prev / 2;
+        int li = 0, pi = 0, n_lvl = 0;
+        while (li < n || pi < packs) {
+            const uint32_t wl = (li < n) ? leaves[li].w : UINT32_MAX;
+            const uint32_t wp =
+                (pi < packs)
+                    ? (uint32_t)(ITEM(k - 1, 2 * pi).weight + ITEM(k - 1, 2 * pi + 1).weight)
+                    : UINT32_MAX;
+            if (wl <= wp && li < n) {
+                ITEM(k, n_lvl).weight = wl;
+                ITEM(k, n_lvl).left = -1;
+                ITEM(k, n_lvl).right = -1;
+                ITEM(k, n_lvl).sym = leaves[li].sym;
+                li++;
+            } else {
+                ITEM(k, n_lvl).weight = wp;
+                ITEM(k, n_lvl).left = (int16_t)(2 * pi);
+                ITEM(k, n_lvl).right = (int16_t)(2 * pi + 1);
+                ITEM(k, n_lvl).sym = -1;
+                pi++;
+            }
+            n_lvl++;
+        }
+        counts[k] = n_lvl;
+    }
+
+    /* Step 3: take first 2n-2 items at level ZXC_HUF_MAX_CODE_LEN-1; trace back, counting leaf
+     * appearances. */
+    int n_take = 2 * n - 2;
+    if (n_take > counts[ZXC_HUF_MAX_CODE_LEN - 1]) n_take = counts[ZXC_HUF_MAX_CODE_LEN - 1];
+
+    /* Worst case stack depth: (ZXC_HUF_MAX_CODE_LEN * n_take) frames; bounded by
+     * ZXC_HUF_MAX_CODE_LEN * 2n. `stack` was set up earlier from scratch (or
+     * the local malloc fallback). */
+    int sp = 0;
+    for (int i = 0; i < n_take; i++) {
+        stack[sp].lvl = (int8_t)(ZXC_HUF_MAX_CODE_LEN - 1);
+        stack[sp].idx = (int16_t)i;
+        sp++;
+    }
+    while (sp > 0) {
+        frame_t f = stack[--sp];
+        const pm_item_t* it = &ITEM(f.lvl, f.idx);
+        if (it->sym >= 0) {
+            code_len[it->sym]++;
+        } else {
+            stack[sp].lvl = (int8_t)(f.lvl - 1);
+            stack[sp].idx = it->left;
+            sp++;
+            stack[sp].lvl = (int8_t)(f.lvl - 1);
+            stack[sp].idx = it->right;
+            sp++;
+        }
+    }
+
+    if (owned_items) {
+        free(owned_items);
+        free(owned_counts);
+        free(owned_stack);
+    }
+#undef ITEM
+    return ZXC_OK;
+}
+
+/* ===========================================================================
+ * Canonical code construction (LSB-first by bit-reversing canonical MSB codes)
+ * =========================================================================*/
+
+/**
+ * @brief Reverse the low @p n bits of @p v.
+ *
+ * Used to convert MSB-first canonical Huffman codes (the natural form
+ * produced by the canonical-code construction) into LSB-first codes that
+ * can be packed into the bit writer with a single shift-or.
+ *
+ * @param[in] v Value whose low @p n bits will be reversed.
+ * @param[in] n Number of significant bits in @p v (1..32).
+ * @return The bit-reversed value, with bits above position @p n set to 0.
+ */
+static uint32_t reverse_bits(uint32_t v, const int n) {
+    uint32_t r = 0;
+    for (int i = 0; i < n; i++) {
+        r = (r << 1) | (v & 1u);
+        v >>= 1;
+    }
+    return r;
+}
+
+/**
+ * @brief Build the canonical LSB-first Huffman codes for a length table.
+ *
+ * Generates MSB-first canonical codes following RFC 1951 3.2.2, then
+ * bit-reverses each so the encoder can emit them with a plain
+ * `accum |= code << bits` step. Absent symbols (length 0) receive code 0.
+ *
+ * @param[in]  code_len Per-symbol code lengths.
+ * @param[out] codes    Per-symbol LSB-first canonical codes.
+ */
+static void build_canonical_codes(const uint8_t* RESTRICT code_len, uint32_t* RESTRICT codes) {
+    uint32_t bl_count[ZXC_HUF_MAX_CODE_LEN + 1] = {0};
+    for (int i = 0; i < ZXC_HUF_NUM_SYMBOLS; i++) {
+        bl_count[code_len[i]]++;
+    }
+    bl_count[0] = 0;
+
+    uint32_t next_code[ZXC_HUF_MAX_CODE_LEN + 2] = {0};
+    uint32_t code = 0;
+    for (int k = 1; k <= ZXC_HUF_MAX_CODE_LEN + 1; k++) {
+        code = (code + bl_count[k - 1]) << 1;
+        next_code[k] = code;
+    }
+
+    for (int i = 0; i < ZXC_HUF_NUM_SYMBOLS; i++) {
+        const int l = code_len[i];
+        if (l == 0) {
+            codes[i] = 0;
+        } else {
+            const uint32_t msb_code = next_code[l]++;
+            codes[i] = reverse_bits(msb_code, l);
+        }
+    }
+}
+
+/* ===========================================================================
+ * 128-byte length header: 256 x 4-bit lengths, low nibble first.
+ * =========================================================================*/
+
+/**
+ * @brief Pack 256 4-bit code lengths into the 128-byte section header.
+ *
+ * The packing is little-endian within each byte: low nibble holds
+ * `code_len[2*i]`, high nibble holds `code_len[2*i + 1]`. The function
+ * silently truncates any length > 15; callers must enforce the cap of
+ * `ZXC_HUF_MAX_CODE_LEN` (<= 15) before calling.
+ *
+ * @param[in]  code_len Per-symbol code lengths (length `ZXC_HUF_NUM_SYMBOLS`).
+ * @param[out] out      Output header buffer of `ZXC_HUF_LENGTHS_HEADER_SIZE` bytes.
+ */
+static void pack_lengths_header(const uint8_t* RESTRICT code_len, uint8_t* RESTRICT out) {
+    for (int i = 0; i < ZXC_HUF_NUM_SYMBOLS; i += 2) {
+        const uint8_t lo = code_len[i] & 0x0F;
+        const uint8_t hi = code_len[i + 1] & 0x0F;
+        out[i >> 1] = (uint8_t)(lo | (hi << 4));
+    }
+}
+
+/**
+ * @brief Decode the 128-byte length header back into 256 code lengths.
+ *
+ * Inverts ::pack_lengths_header and validates the two structural invariants:
+ * no length exceeds `ZXC_HUF_MAX_CODE_LEN`, and at least one symbol is
+ * present.
+ *
+ * @param[in]  in       Input header buffer of `ZXC_HUF_LENGTHS_HEADER_SIZE` bytes.
+ * @param[out] code_len Output code-length array of length `ZXC_HUF_NUM_SYMBOLS`.
+ * @return `ZXC_OK` on success, `ZXC_ERROR_CORRUPT_DATA` if a length is too
+ *         large or the table is empty.
+ */
+static int unpack_lengths_header(const uint8_t* RESTRICT in, uint8_t* RESTRICT code_len) {
+    int max_len = 0;
+    int n_present = 0;
+    for (int i = 0; i < ZXC_HUF_NUM_SYMBOLS; i += 2) {
+        const uint8_t b = in[i >> 1];
+        const uint8_t lo = b & 0x0F;
+        const uint8_t hi = (uint8_t)(b >> 4);
+        code_len[i] = lo;
+        code_len[i + 1] = hi;
+        if (lo > max_len) max_len = lo;
+        if (hi > max_len) max_len = hi;
+        if (lo) n_present++;
+        if (hi) n_present++;
+    }
+    if (UNLIKELY(max_len > ZXC_HUF_MAX_CODE_LEN)) return ZXC_ERROR_CORRUPT_DATA;
+    if (UNLIKELY(n_present == 0)) return ZXC_ERROR_CORRUPT_DATA;
+    return ZXC_OK;
+}
+
+/* ===========================================================================
+ * Bit writer (LSB-first)
+ * =========================================================================*/
+
+typedef struct {
+    uint8_t* ptr;
+    uint8_t* end;
+    uint64_t accum;
+    int bits;
+    int err;
+} bit_writer_t;
+
+/**
+ * @brief Initialise an LSB-first bit writer over a caller-owned buffer.
+ *
+ * @param[out] bw  Writer to initialise.
+ * @param[out] dst Output buffer (writer takes no ownership).
+ * @param[in]  cap Capacity of @p dst in bytes.
+ */
+static ZXC_ALWAYS_INLINE void bw_init(bit_writer_t* RESTRICT bw, uint8_t* RESTRICT dst,
+                                      const size_t cap) {
+    bw->ptr = dst;
+    bw->end = dst + cap;
+    bw->accum = 0;
+    bw->bits = 0;
+    bw->err = 0;
+}
+
+/**
+ * @brief Append the low @p len bits of @p code to the writer's bitstream.
+ *
+ * Bits are consumed from the LSB end. When the internal accumulator has
+ * accumulated 8 or more bits, full bytes are flushed to the output buffer.
+ * If the buffer is exhausted mid-flush the writer's `err` flag is set;
+ * subsequent ::bw_finish reports `ZXC_ERROR_DST_TOO_SMALL`.
+ *
+ * @param[in,out] bw   Writer state.
+ * @param[in]     code Code bits to emit (the low @p len bits matter).
+ * @param[in]     len  Number of bits to emit (1..ZXC_HUF_MAX_CODE_LEN).
+ */
+static ZXC_ALWAYS_INLINE void bw_put(bit_writer_t* RESTRICT bw, const uint32_t code,
+                                     const int len) {
+    bw->accum |= ((uint64_t)code) << bw->bits;
+    bw->bits += len;
+    if (LIKELY((size_t)(bw->end - bw->ptr) >= sizeof(uint64_t))) {
+        zxc_store_le64(bw->ptr, bw->accum);
+    } else {
+        if (UNLIKELY(bw->ptr >= bw->end)) {
+            bw->err = 1;
+            bw->bits = 0;
+            return;
+        }
+        *bw->ptr = (uint8_t)bw->accum;
+    }
+    const int n = bw->bits >> 3; /* 0 or 1 full byte to flush */
+    bw->ptr += n;
+    bw->accum >>= n << 3;
+    bw->bits &= 7;
+}
+
+/**
+ * @brief Flush any partial trailing byte and finalise the bit writer.
+ *
+ * Writes the (zero-padded) trailing byte if the accumulator holds any bits.
+ *
+ * @param[in,out] bw Writer state.
+ * @return `ZXC_OK` on success, `ZXC_ERROR_DST_TOO_SMALL` if the buffer was
+ *         exhausted at any point.
+ */
+static ZXC_ALWAYS_INLINE int bw_finish(bit_writer_t* RESTRICT bw) {
+    if (bw->bits > 0) {
+        if (UNLIKELY(bw->ptr >= bw->end)) return ZXC_ERROR_DST_TOO_SMALL;
+        *bw->ptr++ = (uint8_t)bw->accum;
+        bw->accum = 0;
+        bw->bits = 0;
+    }
+    return UNLIKELY(bw->err) ? ZXC_ERROR_DST_TOO_SMALL : ZXC_OK;
+}
+
+/* ===========================================================================
+ * Encoder
+ * =========================================================================*/
+
+/**
+ * @copydoc zxc_huf_encode_section
+ */
+int zxc_huf_encode_section(const uint8_t* RESTRICT literals, const size_t n_literals,
+                           const uint8_t* RESTRICT code_len, uint8_t* RESTRICT dst,
+                           const size_t dst_cap) {
+    if (UNLIKELY(n_literals == 0)) return ZXC_ERROR_CORRUPT_DATA;
+    if (UNLIKELY(dst_cap < ZXC_HUF_HEADER_SIZE)) return ZXC_ERROR_DST_TOO_SMALL;
+
+    /* 1. Pack the 128-byte length header. */
+    pack_lengths_header(code_len, dst);
+
+    /* 2. Build canonical codes (LSB-first via bit-reversal). */
+    uint32_t codes[ZXC_HUF_NUM_SYMBOLS];
+    build_canonical_codes(code_len, codes);
+
+    /* 3. Reserve 6 bytes for sub-stream sizes; encode 4 sub-streams after them. */
+    uint8_t* const sizes_hdr = dst + ZXC_HUF_LENGTHS_HEADER_SIZE;
+    uint8_t* const stream_base = sizes_hdr + ZXC_HUF_STREAM_SIZES_HEADER_SIZE;
+    const uint8_t* const stream_end = dst + dst_cap;
+
+    const size_t Q = (n_literals + ZXC_HUF_NUM_STREAMS - 1) / ZXC_HUF_NUM_STREAMS;
+
+    bit_writer_t bw;
+    uint8_t* p = stream_base;
+    size_t s_sizes[ZXC_HUF_NUM_STREAMS];
+
+    for (int s = 0; s < ZXC_HUF_NUM_STREAMS; s++) {
+        const size_t start = (size_t)s * Q;
+        size_t stop = start + Q;
+        if (stop > n_literals) stop = n_literals;
+
+        uint8_t* const stream_start = p;
+        bw_init(&bw, p, (size_t)(stream_end - p));
+        for (size_t i = start; i < stop; i++) {
+            const uint8_t sym = literals[i];
+            const int len = code_len[sym];
+            if (UNLIKELY(len == 0)) return ZXC_ERROR_CORRUPT_DATA; /* symbol absent from table */
+            bw_put(&bw, codes[sym], len);
+        }
+        const int rc = bw_finish(&bw);
+        if (UNLIKELY(rc != ZXC_OK)) return rc;
+        s_sizes[s] = (size_t)(bw.ptr - stream_start);
+        p = bw.ptr;
+    }
+
+    /* 4. Persist the 3 explicit sub-stream sizes (s4 is implied). */
+    for (int s = 0; s < ZXC_HUF_NUM_STREAMS - 1; s++) {
+        if (UNLIKELY(s_sizes[s] > 0xFFFFu)) return ZXC_ERROR_DST_TOO_SMALL;
+        zxc_store_le16(sizes_hdr + 2 * s, (uint16_t)s_sizes[s]);
+    }
+
+    return (int)(p - dst);
+}
+
+/* ===========================================================================
+ * Decoder table builder + 4-way interleaved decoder
+ * =========================================================================*/
+
+/**
+ * @brief Build the 2048-entry multi-symbol decoder lookup table.
+ *
+ * Strategy: build a temporary 256-entry single-symbol (8-bit) table, then
+ * use it to populate the 2048-entry (11-bit) multi-symbol table. For each
+ * 11-bit prefix p:
+ *   1. (sym1, len1) = ss[p & 0xFF]   -- always valid, 1 <= len1 <= 8.
+ *   2. rem = 11 - len1 E [3, 10] bits remain after consuming the first code.
+ *   3. (sym2_cand, len2_cand) = ss[(p >> len1) & 0xFF]. If len2_cand <= rem,
+ *      both codes fit in 11 bits -> encode 2-symbol entry. Otherwise the
+ *      second code's bit window extends past the lookup width -> keep only
+ *      the first symbol and let the next iteration handle the rest.
+ *
+ * Validates Kraft equality (or the single-present-symbol degenerate case).
+ *
+ * @param[in]  code_len Per-symbol code lengths from the section header.
+ * @param[out] table    Destination 2048-entry lookup table (caller-aligned).
+ * @return `ZXC_OK` on success, `ZXC_ERROR_CORRUPT_DATA` on validation failure.
+ */
+static int build_decode_table(const uint8_t* RESTRICT code_len,
+                              zxc_huf_dec_entry_t* RESTRICT table) {
+    uint32_t bl_count[ZXC_HUF_MAX_CODE_LEN + 1] = {0};
+    int n_present = 0;
+    for (int i = 0; i < ZXC_HUF_NUM_SYMBOLS; i++) {
+        const uint8_t l = code_len[i];
+        if (UNLIKELY(l > ZXC_HUF_MAX_CODE_LEN)) return ZXC_ERROR_CORRUPT_DATA;
+        bl_count[l]++;
+        if (l) n_present++;
+    }
+    if (UNLIKELY(n_present == 0)) return ZXC_ERROR_CORRUPT_DATA;
+    bl_count[0] = 0;
+
+    /* Validate Kraft equality on the ZXC_HUF_MAX_CODE_LEN axis. */
+    {
+        uint64_t kraft = 0;
+        for (int k = 1; k <= ZXC_HUF_MAX_CODE_LEN; k++) {
+            kraft += (uint64_t)bl_count[k] << (ZXC_HUF_MAX_CODE_LEN - k);
+        }
+        /* Degenerate: single symbol with length 1 (Kraft sum =
+         * 2^(ZXC_HUF_MAX_CODE_LEN-1)). Otherwise: full Kraft equality
+         * on the ZXC_HUF_MAX_CODE_LEN axis. */
+        const int kraft_ok = (n_present == 1) ? (bl_count[1] == 1)
+                                              : (kraft == ((uint64_t)1 << ZXC_HUF_MAX_CODE_LEN));
+        if (UNLIKELY(!kraft_ok)) return ZXC_ERROR_CORRUPT_DATA;
+    }
+
+    uint32_t next_code[ZXC_HUF_MAX_CODE_LEN + 2] = {0};
+    {
+        uint32_t code = 0;
+        for (int k = 1; k <= ZXC_HUF_MAX_CODE_LEN + 1; k++) {
+            code = (code + bl_count[k - 1]) << 1;
+            next_code[k] = code;
+        }
+    }
+
+    /* Single-symbol intermediate (ZXC_HUF_MAX_CODE_LEN-bit lookup). Layout:
+     * low byte = sym, high byte = len. Filled by replicating each canonical
+     * code across all ZXC_HUF_MAX_CODE_LEN-bit windows that share its low
+     * `len` bits. */
+#define ZXC_HUF_SS_SIZE (1u << ZXC_HUF_MAX_CODE_LEN)
+#define ZXC_HUF_SS_MASK ((uint32_t)(ZXC_HUF_SS_SIZE - 1))
+    uint16_t ss[ZXC_HUF_SS_SIZE] = {0};
+
+    for (int sym = 0; sym < ZXC_HUF_NUM_SYMBOLS; sym++) {
+        const int l = code_len[sym];
+        if (l == 0) continue;
+        const uint32_t msb_code = next_code[l]++;
+        const uint32_t lsb_code = reverse_bits(msb_code, l);
+        const uint16_t entry = (uint16_t)((unsigned)l << 8 | (unsigned)sym);
+        const uint32_t step = (uint32_t)1 << l;
+        for (uint32_t fill = lsb_code; fill < ZXC_HUF_SS_SIZE; fill += step) {
+            ss[fill] = entry;
+        }
+    }
+
+    /* Single-symbol degenerate (Kraft sum = 2^(ZXC_HUF_MAX_CODE_LEN-1)): replicate the one
+     * valid entry across every slot. */
+    if (UNLIKELY(n_present == 1)) {
+        uint16_t valid = 0;
+        for (uint32_t i = 0; i < ZXC_HUF_SS_SIZE; i++) {
+            if (ss[i] != 0) {
+                valid = ss[i];
+                break;
+            }
+        }
+        for (uint32_t i = 0; i < ZXC_HUF_SS_SIZE; i++) {
+            if (ss[i] == 0) ss[i] = valid;
+        }
+    }
+
+    /* Build the multi-symbol table. */
+    for (uint32_t p = 0; p < ZXC_HUF_TABLE_SIZE; p++) {
+        const uint16_t e1 = ss[p & ZXC_HUF_SS_MASK];
+        const uint8_t sym1 = (uint8_t)e1;
+        const int len1 = e1 >> 8;
+        const int rem = ZXC_HUF_LOOKUP_BITS - len1;
+
+        uint8_t sym2 = 0;
+        int len_total = len1;
+        int n_extra = 0;
+
+        const uint16_t e2 = ss[(p >> len1) & ZXC_HUF_SS_MASK];
+        const int len2 = e2 >> 8;
+        if (len2 <= rem) {
+            sym2 = (uint8_t)e2;
+            len_total = len1 + len2;
+            n_extra = 1;
+        }
+
+        table[p].entry = ZXC_HUF_ENTRY(sym1, sym2, len1, len_total, n_extra);
+    }
+#undef ZXC_HUF_SS_SIZE
+#undef ZXC_HUF_SS_MASK
+
+    return ZXC_OK;
+}
+
+/**
+ * @copydoc zxc_huf_decode_section
+ */
+int zxc_huf_decode_section(const uint8_t* RESTRICT payload, const size_t payload_size,
+                           uint8_t* RESTRICT dst, const size_t n_literals) {
+    if (UNLIKELY(payload_size < ZXC_HUF_HEADER_SIZE || n_literals == 0))
+        return ZXC_ERROR_CORRUPT_DATA;
+
+    /* 1. Parse length header. */
+    uint8_t code_len[ZXC_HUF_NUM_SYMBOLS];
+    {
+        const int rc = unpack_lengths_header(payload, code_len);
+        if (UNLIKELY(rc != ZXC_OK)) return rc;
+    }
+
+    /* 2. Build the 2048-entry multi-symbol decode table. Cache-line
+     * aligned: the LUT spans 128 lines (8 KB / 64 B) and is hammered every
+     * symbol, landing it on a 64-byte boundary avoids any cross-line
+     * load split on the per-iteration entry fetch. */
+    ZXC_ALIGN(ZXC_CACHE_LINE_SIZE) zxc_huf_dec_entry_t table[ZXC_HUF_TABLE_SIZE];
+    {
+        const int rc = build_decode_table(code_len, table);
+        if (UNLIKELY(rc != ZXC_OK)) return rc;
+    }
+
+    /* 3. Parse sub-stream sizes. */
+    const uint8_t* const sizes_hdr = payload + ZXC_HUF_LENGTHS_HEADER_SIZE;
+    const uint16_t s1 = zxc_le16(sizes_hdr + 0);
+    const uint16_t s2 = zxc_le16(sizes_hdr + 2);
+    const uint16_t s3 = zxc_le16(sizes_hdr + 4);
+
+    const size_t streams_total = payload_size - ZXC_HUF_HEADER_SIZE;
+    const size_t s123 = (size_t)s1 + (size_t)s2 + (size_t)s3;
+    if (UNLIKELY(s123 > streams_total)) return ZXC_ERROR_CORRUPT_DATA;
+    const size_t s4 = streams_total - s123;
+
+    const uint8_t* const stream_base = payload + ZXC_HUF_HEADER_SIZE;
+    const size_t off[ZXC_HUF_NUM_STREAMS] = {0, s1, (size_t)s1 + s2, s123};
+    const size_t sz[ZXC_HUF_NUM_STREAMS] = {s1, s2, s3, s4};
+
+    /* 4. Initialise 4 bit readers. */
+    zxc_bit_reader_t br[ZXC_HUF_NUM_STREAMS];
+    for (int s = 0; s < ZXC_HUF_NUM_STREAMS; s++) {
+        zxc_br_init(&br[s], stream_base + off[s], sz[s]);
+    }
+
+    /* 5. 4-way interleaved multi-symbol decode. Each sub-stream owns a
+     * contiguous slice of dst: stream s covers literal indices
+     * [s*Q, min((s+1)*Q, N)). With Q = ceil(N/4) the first 3 streams have
+     * exactly Q symbols and stream 3 has `N - 3Q` symbols. */
+    const size_t Q = (n_literals + ZXC_HUF_NUM_STREAMS - 1) / ZXC_HUF_NUM_STREAMS;
+    size_t s_count[ZXC_HUF_NUM_STREAMS];
+    uint8_t* s_dst[ZXC_HUF_NUM_STREAMS];
+    for (int s = 0; s < ZXC_HUF_NUM_STREAMS; s++) {
+        size_t start = (size_t)s * Q;
+        size_t stop = start + Q;
+        if (start > n_literals) start = n_literals;
+        if (stop > n_literals) stop = n_literals;
+        s_count[s] = stop - start;
+        s_dst[s] = dst + start;
+    }
+
+    /* Batched multi-symbol decode. Each ZXC_HUF_BATCH iterations consume
+     * <= ZXC_HUF_BATCH_BITS bits per stream, fitting under the 57-bit cap
+     * an 8-byte refill can guarantee.
+     *
+     * Each iter speculatively writes 2 bytes per stream and advances by 1
+     * or 2. If only 1 symbol was decoded, the spec byte is overwritten by
+     * the next iter, except at end-of-stream where it would corrupt the
+     * adjacent stream. The batched loop therefore requires
+     * ZXC_HUF_SAFE_MARGIN bytes of headroom per stream. */
+
+    uint8_t* d0 = s_dst[0];
+    uint8_t* d1 = s_dst[1];
+    uint8_t* d2 = s_dst[2];
+    uint8_t* d3 = s_dst[3];
+
+    const uint8_t* const dend0 = s_dst[0] + s_count[0];
+    const uint8_t* const dend1 = s_dst[1] + s_count[1];
+    const uint8_t* const dend2 = s_dst[2] + s_count[2];
+    const uint8_t* const dend3 = s_dst[3] + s_count[3];
+
+    /* Hoist all four bit-reader hot fields into locals. They live in
+     * registers for the full duration of the batched loop. */
+    uint64_t a0 = br[0].accum, a1 = br[1].accum, a2 = br[2].accum, a3 = br[3].accum;
+    int bb0 = br[0].bits, bb1 = br[1].bits, bb2 = br[2].bits, bb3 = br[3].bits;
+    const uint8_t *p0 = br[0].ptr, *p1 = br[1].ptr, *p2 = br[2].ptr, *p3 = br[3].ptr;
+    const uint8_t* const e0 = br[0].end;
+    const uint8_t* const e1 = br[1].end;
+    const uint8_t* const e2 = br[2].end;
+    const uint8_t* const e3 = br[3].end;
+
+    /* Refill the bit accumulator with up to (ZXC_HUF_ACCUM_BITS - nbits) more
+     * bits read from src. Fast path reads 8 bytes at once (LE u64 load); slow
+     * path reads byte-by-byte while at least one byte of free room remains. */
+#define REFILL(accum, nbits, src, src_end)                                                   \
+    do {                                                                                     \
+        if (LIKELY((nbits) < ZXC_HUF_BATCH_BITS && (src) + sizeof(uint64_t) <= (src_end))) { \
+            (accum) |= zxc_le64(src) << (nbits);                                             \
+            const int _n = (ZXC_HUF_ACCUM_BITS - (nbits)) / CHAR_BIT;                        \
+            (src) += _n;                                                                     \
+            (nbits) += _n * CHAR_BIT;                                                        \
+        } else {                                                                             \
+            while ((nbits) <= ZXC_HUF_ACCUM_BITS - CHAR_BIT && (src) < (src_end)) {          \
+                (accum) |= ((uint64_t)*(src)++) << (nbits);                                  \
+                (nbits) += CHAR_BIT;                                                         \
+            }                                                                                \
+        }                                                                                    \
+    } while (0)
+
+    /* Decode one 11-bit window per stream. Always writes 2 bytes per stream
+     * (sym1 + spec sym2); advances d_s by 1 + n_extra; advances accum by
+     * len_total. Per-stream length accumulators sl0..sl3 collect consumed
+     * bits across the batch and are folded into bb_s once at end of batch. */
+#define DECODE_ONE()                                             \
+    do {                                                         \
+        const uint32_t _e0 = table[a0 & ZXC_HUF_TBL_MASK].entry; \
+        const uint32_t _e1 = table[a1 & ZXC_HUF_TBL_MASK].entry; \
+        const uint32_t _e2 = table[a2 & ZXC_HUF_TBL_MASK].entry; \
+        const uint32_t _e3 = table[a3 & ZXC_HUF_TBL_MASK].entry; \
+        zxc_store_le16(d0, (uint16_t)_e0);                       \
+        zxc_store_le16(d1, (uint16_t)_e1);                       \
+        zxc_store_le16(d2, (uint16_t)_e2);                       \
+        zxc_store_le16(d3, (uint16_t)_e3);                       \
+        const int _t0 = (int)((_e0 >> 20) & 0xF);                \
+        const int _t1 = (int)((_e1 >> 20) & 0xF);                \
+        const int _t2 = (int)((_e2 >> 20) & 0xF);                \
+        const int _t3 = (int)((_e3 >> 20) & 0xF);                \
+        d0 += 1 + (int)((_e0 >> 24) & 1);                        \
+        d1 += 1 + (int)((_e1 >> 24) & 1);                        \
+        d2 += 1 + (int)((_e2 >> 24) & 1);                        \
+        d3 += 1 + (int)((_e3 >> 24) & 1);                        \
+        a0 >>= _t0;                                              \
+        a1 >>= _t1;                                              \
+        a2 >>= _t2;                                              \
+        a3 >>= _t3;                                              \
+        sl0 += _t0;                                              \
+        sl1 += _t1;                                              \
+        sl2 += _t2;                                              \
+        sl3 += _t3;                                              \
+    } while (0)
+
+    while ((size_t)(dend0 - d0) >= ZXC_HUF_SAFE_MARGIN &&
+           (size_t)(dend1 - d1) >= ZXC_HUF_SAFE_MARGIN &&
+           (size_t)(dend2 - d2) >= ZXC_HUF_SAFE_MARGIN &&
+           (size_t)(dend3 - d3) >= ZXC_HUF_SAFE_MARGIN) {
+        REFILL(a0, bb0, p0, e0);
+        REFILL(a1, bb1, p1, e1);
+        REFILL(a2, bb2, p2, e2);
+        REFILL(a3, bb3, p3, e3);
+
+        int sl0 = 0, sl1 = 0, sl2 = 0, sl3 = 0;
+        DECODE_ONE();
+        DECODE_ONE();
+        DECODE_ONE();
+        DECODE_ONE();
+        DECODE_ONE();
+        bb0 -= sl0;
+        bb1 -= sl1;
+        bb2 -= sl2;
+        bb3 -= sl3;
+    }
+
+    /* Per-stream scalar tail (<= ZXC_HUF_SAFE_MARGIN - 1 = 9 symbols per
+     * stream). Single-symbol decode using the same 2048-entry table,
+     * we read sym1 + len1 only and advance by 1 byte, no spec write. */
+#define TAIL_ONE(accum, nbits, src, src_end, dst)                    \
+    do {                                                             \
+        REFILL(accum, nbits, src, src_end);                          \
+        const uint32_t _e = table[(accum) & ZXC_HUF_TBL_MASK].entry; \
+        *(dst)++ = (uint8_t)_e;                                      \
+        const int _l1 = (int)((_e >> 16) & 0xF);                     \
+        (accum) >>= _l1;                                             \
+        (nbits) -= _l1;                                              \
+    } while (0)
+
+    while (d0 < dend0) TAIL_ONE(a0, bb0, p0, e0, d0);
+    while (d1 < dend1) TAIL_ONE(a1, bb1, p1, e1, d1);
+    while (d2 < dend2) TAIL_ONE(a2, bb2, p2, e2, d2);
+    while (d3 < dend3) TAIL_ONE(a3, bb3, p3, e3, d3);
+
+#undef TAIL_ONE
+#undef DECODE_ONE
+#undef REFILL
+    return ZXC_OK;
+}

--- a/lz/zxc/src/lib/zxc_internal.h
+++ b/lz/zxc/src/lib/zxc_internal.h
@@ -293,12 +293,24 @@ extern "C" {
 #define ZXC_MAX_THREADS 512
 /** @brief Safety padding appended to buffers to tolerate overruns. */
 #define ZXC_PAD_SIZE 32
+/**
+ * @brief Tail padding required on the decompression destination buffer.
+ *
+ * The decoder's fast path uses speculative wild-copy writes and gates
+ * fast-loop entry on @c d_end - ZXC_DECOMPRESS_TAIL_PAD. Sizing
+ * @c dst_capacity to @c uncompressed_size + ZXC_DECOMPRESS_TAIL_PAD
+ * guarantees the fast path is reachable and that tail bounds checks
+ * never spuriously reject the last literals of a valid block.
+ *
+ * @see zxc_decompress_block_bound()
+ */
+#define ZXC_DECOMPRESS_TAIL_PAD (ZXC_PAD_SIZE * 66)
 /** @brief Assumed CPU cache line size for alignment. */
 #define ZXC_CACHE_LINE_SIZE 64
 /** @brief Bitmask for cache-line alignment checks. */
 #define ZXC_ALIGNMENT_MASK (ZXC_CACHE_LINE_SIZE - 1)
-/** @brief Allocation-safe max vbyte length (sufficient for < 2 MB blocks). */
-#define ZXC_VBYTE_ALLOC_LEN 3
+/** @brief Round @p x up to the next cache-line boundary. */
+#define ZXC_ALIGN_CL(x) (((x) + ZXC_ALIGNMENT_MASK) & ~(size_t)ZXC_ALIGNMENT_MASK)
 
 /** @brief File header size: Magic(4)+Version(1)+Chunk(1)+Flags(1)+Reserved(7)+CRC(2). */
 #define ZXC_FILE_HEADER_SIZE 16
@@ -419,12 +431,32 @@ extern "C" {
 #define ZXC_LZ_HASH_SIZE (1U << ZXC_LZ_HASH_BITS)
 /** @brief Sliding window size (64 KB). */
 #define ZXC_LZ_WINDOW_SIZE (1U << 16)
+/** @brief Mask for ring-buffer indexing into chain_table (power-of-two window). */
+#define ZXC_LZ_WINDOW_MASK (ZXC_LZ_WINDOW_SIZE - 1U)
 /** @brief Minimum match length for an LZ77 match. */
 #define ZXC_LZ_MIN_MATCH_LEN 5
 /** @brief Base bias added to encoded offsets (stored = actual - bias). */
 #define ZXC_LZ_OFFSET_BIAS 1
 /** @brief Maximum allowed offset distance. */
 #define ZXC_LZ_MAX_DIST (ZXC_LZ_WINDOW_SIZE - 1)
+/** @} */
+
+/** @name Optimal Parser Tuning (level >= 6)
+ *  @brief Static prices and complexity guards used by the level-6 optimal
+ *         LZ77 parser DP.
+ *  @{ */
+/** @brief Static price (bits) of a match token before varint extras: 1 byte
+ *         token + 2 byte offset. */
+#define ZXC_OPT_MATCH_COST_BASE ((uint32_t)(3U * CHAR_BIT))
+/** @brief Threshold above which `find_best_match` is skipped at intra-match
+ *         positions, keeping the parser O(N) on highly repetitive data. */
+#define ZXC_OPT_LONG_MATCH_SKIP ((size_t)256)
+/** @brief Minimum literal count for the sample-based Huffman cost estimator
+ *         used by the optimal parser. Below this, the strided sample is too
+ *         small for the resulting code-lengths to be statistically reliable,
+ *         so the estimator falls back to RAW cost (8 bits/byte). */
+#define ZXC_OPT_LIT_SAMPLE_MIN 1024
+
 /** @} */
 
 /** @name Hash Prime Constants
@@ -436,13 +468,110 @@ extern "C" {
 #define ZXC_HASH_PRIME2 0xD2D84A61D2D84A61ULL
 /** @} */
 
+/** @name Huffman Codec Constants
+ *  @brief Length-limited canonical Huffman codec for the GLO literal stream
+ *         (active at compression level >= 6).
+ *
+ *  On-disk section payload layout:
+ *  - @c ZXC_HUF_LENGTHS_HEADER_SIZE bytes: @c ZXC_HUF_NUM_SYMBOLS code lengths
+ *    packed two per byte (4 bits each).
+ *  - @c ZXC_HUF_STREAM_SIZES_HEADER_SIZE bytes: the first
+ *    `ZXC_HUF_NUM_STREAMS - 1` sub-stream sizes as little-endian @c uint16_t;
+ *    the last sub-stream size is derived from the enclosing section length.
+ *  - Payload: @c ZXC_HUF_NUM_STREAMS concatenated LSB-first bit-streams,
+ *    each covering an equal share of the literal indices (the last absorbs
+ *    the remainder).
+ *
+ *  The decoder uses a single lookup table of @c ZXC_HUF_TABLE_SIZE entries
+ *  (width @c ZXC_HUF_LOOKUP_BITS) that yields 1 or 2 symbols per lookup,
+ *  feeding a `ZXC_HUF_NUM_STREAMS`-way interleaved hot loop.
+ *  @{ */
+/** @brief Maximum code length, in bits. Capped well below the package-merge
+ *         algorithmic ceiling (14) to keep the decoder LUT small. */
+#define ZXC_HUF_MAX_CODE_LEN 8
+/** @brief Decoder LUT width: each lookup consumes this many bits and yields
+ *         1 or 2 symbols. */
+#define ZXC_HUF_LOOKUP_BITS 11
+/** @brief Number of entries in the multi-symbol decoder lookup table. */
+#define ZXC_HUF_TABLE_SIZE (1U << ZXC_HUF_LOOKUP_BITS)
+/** @brief Alphabet size: one entry per possible byte value. */
+#define ZXC_HUF_NUM_SYMBOLS 256
+/** @brief Interleaved bit-stream count for parallel decoding. */
+#define ZXC_HUF_NUM_STREAMS 4
+/** @brief Packed 4-bit code-lengths header size: two lengths per byte. */
+#define ZXC_HUF_LENGTHS_HEADER_SIZE (ZXC_HUF_NUM_SYMBOLS / 2)
+/** @brief Sub-stream sizes header: `(ZXC_HUF_NUM_STREAMS - 1)` little-endian
+ *         @c uint16_t values; the last sub-stream size is derived from the
+ *         enclosing section length. */
+#define ZXC_HUF_STREAM_SIZES_HEADER_SIZE ((int)((ZXC_HUF_NUM_STREAMS - 1) * sizeof(uint16_t)))
+/** @brief Total Huffman header size: lengths + sub-stream sizes. */
+#define ZXC_HUF_HEADER_SIZE (ZXC_HUF_LENGTHS_HEADER_SIZE + ZXC_HUF_STREAM_SIZES_HEADER_SIZE)
+/** @brief Absolute floor below which Huffman cannot beat RAW even with
+ *         zero-entropy literals after the 3 % savings margin. Above this
+ *         floor, the precise size accounting at the call site decides per
+ *         block, so the threshold is corpus-agnostic.
+ *
+ *         Derivation: the call site requires `huf_total < baseline * 31/32`
+ *         (3 % margin = `baseline >> 5`). At zero-entropy literals the
+ *         payload vanishes and `huf_total = HEADER`, giving
+ *         `N > HEADER x 32/31`. The `+30` is the standard ceiling-division
+ *         offset (`b - 1` with `b = 31`). Constants:
+ *           - 32 = inverse of the 3 % margin (`1/32`)
+ *           - 31 = `32 - 1`, the fraction kept after the margin
+ *           - 30 = `31 - 1`, ceiling-division rounding offset */
+#define ZXC_HUF_MIN_LITERALS ((ZXC_HUF_HEADER_SIZE * 32 + 30) / 31)
+/** @brief Width of the decoder bit accumulator, in bits
+ *         (`sizeof(uint64_t) * CHAR_BIT`). */
+#define ZXC_HUF_ACCUM_BITS 64
+/** @brief Decoder batch size: lookups per stream between two refills. */
+#define ZXC_HUF_BATCH 5
+/** @brief Worst-case bits consumed per stream per batch. Must stay <= 57 so
+ *         that an 8-byte refill always brings the bit accumulator back to
+ *         >= 56 bits before the next batch. */
+#define ZXC_HUF_BATCH_BITS (ZXC_HUF_BATCH * ZXC_HUF_LOOKUP_BITS)
+/** @brief Mask for indexing into the multi-symbol decoder lookup table. */
+#define ZXC_HUF_TBL_MASK ((uint64_t)(ZXC_HUF_TABLE_SIZE - 1))
+/** @brief Per-stream output headroom required to enter the batched fast loop:
+ *         each iteration speculatively writes 2 bytes per stream and runs
+ *         @c ZXC_HUF_BATCH iterations before re-checking the bound. */
+#define ZXC_HUF_SAFE_MARGIN ((size_t)(2 * ZXC_HUF_BATCH))
+
+/* Boundary package-merge work item. Each level holds at most
+ * `2 * ZXC_HUF_NUM_SYMBOLS` of these; exposed so callers can size
+ * pre-allocated scratch via ::ZXC_HUF_BUILD_SCRATCH_SIZE. */
+typedef struct {
+    uint32_t weight;
+    int16_t left, right;
+    int16_t sym;
+} zxc_huf_pm_item_t;
+
+/* Trace-back stack frame for the package-merge code-length recovery. */
+typedef struct {
+    int8_t lvl;
+    int16_t idx;
+} zxc_huf_pm_frame_t;
+
+/** @brief Per-level item bound: at most leaves + paired packages from the
+ *         previous level. */
+#define ZXC_HUF_PM_LEVEL_BOUND (2 * ZXC_HUF_NUM_SYMBOLS)
+
+/** @brief Worst-case scratch size (bytes) for ::zxc_huf_build_code_lengths.
+ *         Carved by the function into items / counts / stack regions; sized
+ *         for the worst-case alphabet (n = `ZXC_HUF_NUM_SYMBOLS`). Includes
+ *         a small alignment slack between regions. */
+#define ZXC_HUF_BUILD_SCRATCH_SIZE                                                               \
+    ((size_t)ZXC_HUF_MAX_CODE_LEN * (size_t)ZXC_HUF_PM_LEVEL_BOUND * sizeof(zxc_huf_pm_item_t) + \
+     8U + (size_t)ZXC_HUF_MAX_CODE_LEN * sizeof(int) + 8U +                                      \
+     (size_t)ZXC_HUF_MAX_CODE_LEN * (size_t)ZXC_HUF_PM_LEVEL_BOUND * sizeof(zxc_huf_pm_frame_t))
+/** @} */
+
 /** @name Block Size Helpers
  *  @brief Runtime helpers for variable block sizes.
  *  @{ */
 
 /**
  * @brief Integer log-base-2 for a 32-bit value.
- * @param v Must be a power of two (undefined for zero).
+ * @param v Must be a power of two (returns 0 for zero).
  * @return Floor of log2(v).
  */
 static ZXC_ALWAYS_INLINE uint32_t zxc_log2_u32(const uint32_t v) {
@@ -455,8 +584,26 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_log2_u32(const uint32_t v) {
 }
 
 /**
+ * @brief Branchless bit_ceil: smallest power of two >= v, clamped to ZXC_BLOCK_SIZE_MIN.
+ * @param[in] v Input size (must be > 0).
+ */
+static ZXC_ALWAYS_INLINE size_t zxc_block_size_ceil(const size_t v) {
+    uint64_t x = (uint64_t)v - 1;
+    x |= x >> 1;
+    x |= x >> 2;
+    x |= x >> 4;
+    x |= x >> 8;
+    x |= x >> 16;
+    x |= x >> 32;
+    x++;
+    const size_t bs = (size_t)x;
+    return (bs < ZXC_BLOCK_SIZE_MIN) ? ZXC_BLOCK_SIZE_MIN : bs;
+}
+
+/**
  * @brief Validates a block size.
  * Must be a power of two in [ZXC_BLOCK_SIZE_MIN, ZXC_BLOCK_SIZE_MAX].
+ * @param[in] bs Block size to validate.
  * @return 1 if valid, 0 otherwise.
  */
 static ZXC_ALWAYS_INLINE int zxc_validate_block_size(const size_t bs) {
@@ -521,17 +668,18 @@ typedef struct {
  * @return zxc_lz77_params_t The LZ77 parameters structure corresponding to the specified level.
  */
 static ZXC_ALWAYS_INLINE zxc_lz77_params_t zxc_get_lz77_params(const int level) {
-    if (level >= 5) return (zxc_lz77_params_t){64, 256, 1, 16, 128, 1, 8};
+    if (level >= ZXC_LEVEL_DENSITY) return (zxc_lz77_params_t){64, 256, 0, 0, 0, 1, 8};
     // search_depth, sufficient_len, use_lazy, lazy_attempts, lazy_len_threshold, step_base,
     // step_shift
-    static const zxc_lz77_params_t table[5] = {
-        {3, 16, 0, 0, 0, 4, 4},    // fallback
-        {3, 16, 0, 0, 0, 4, 4},    // level 1
-        {3, 18, 0, 0, 0, 3, 6},    // level 2
-        {3, 16, 1, 4, 128, 1, 4},  // level 3
-        {3, 18, 1, 4, 128, 1, 5}   // level 4
+    static const zxc_lz77_params_t table[6] = {
+        {3, 16, 0, 0, 0, 4, 4},      // fallback
+        {3, 16, 0, 0, 0, 4, 4},      // level 1
+        {3, 18, 0, 0, 0, 3, 6},      // level 2
+        {3, 16, 1, 4, 128, 1, 4},    // level 3
+        {3, 18, 1, 4, 128, 1, 5},    // level 4
+        {64, 256, 1, 16, 128, 1, 8}  // level 5
     };
-    return table[level < 1 ? 1 : level];
+    return table[level < ZXC_LEVEL_FASTEST ? ZXC_LEVEL_FASTEST : level];
 }
 
 /**
@@ -570,8 +718,15 @@ typedef enum {
  * or offsets) are stored within a block.
  * - `ZXC_SECTION_ENCODING_RAW`: Data is stored uncompressed.
  * - `ZXC_SECTION_ENCODING_RLE`: Run-Length Encoding.
+ * - `ZXC_SECTION_ENCODING_HUFFMAN`: Canonical Huffman, 4-way interleaved
+ *   sub-streams, max 11-bit codes, LSB-first. Only valid for the literal
+ *   stream (`enc_lit`) of GLO blocks. Produced exclusively at level >= 6.
  */
-typedef enum { ZXC_SECTION_ENCODING_RAW = 0, ZXC_SECTION_ENCODING_RLE = 1 } zxc_section_encoding_t;
+typedef enum {
+    ZXC_SECTION_ENCODING_RAW = 0,
+    ZXC_SECTION_ENCODING_RLE = 1,
+    ZXC_SECTION_ENCODING_HUFFMAN = 2
+} zxc_section_encoding_t;
 
 /**
  * @struct zxc_gnr_header_t
@@ -1266,6 +1421,65 @@ int zxc_write_ghi_header_and_desc(uint8_t* RESTRICT dst, const size_t rem,
 int zxc_read_ghi_header_and_desc(const uint8_t* RESTRICT src, const size_t len,
                                  zxc_gnr_header_t* RESTRICT gh,
                                  zxc_section_desc_t desc[ZXC_GHI_SECTIONS]);
+
+/* ============================================================================
+ * Huffman codec for the GLO literal stream (level >= 6).
+ *
+ * On-disk layout, decoder geometry and tunables: see
+ * @ref ZXC_HUF_MAX_CODE_LEN and the surrounding "Huffman Codec Constants"
+ * group above.
+ * ============================================================================
+ */
+
+/**
+ * @brief Build length-limited canonical Huffman code lengths from a frequency table.
+ *
+ * Uses the boundary package-merge algorithm capped at `ZXC_HUF_MAX_CODE_LEN`.
+ * Symbols with `freq[i] == 0` get `code_len[i] == 0`; others receive a value
+ * in `[1, ZXC_HUF_MAX_CODE_LEN]`.
+ *
+ * @param[in]  freq     Frequency table of length `ZXC_HUF_NUM_SYMBOLS`.
+ * @param[out] code_len Output code-length array of length `ZXC_HUF_NUM_SYMBOLS`.
+ * @param[in]  scratch  Optional caller-owned scratch buffer of at least
+ *                      ::ZXC_HUF_BUILD_SCRATCH_SIZE bytes. If `NULL`, the
+ *                      function allocates its own working memory and frees
+ *                      it before returning.
+ * @return `ZXC_OK` on success, negative `zxc_error_t` code on failure.
+ */
+int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT code_len,
+                               void* RESTRICT scratch);
+
+/**
+ * @brief Encode the literal stream into a Huffman section payload.
+ *
+ * Writes the 128-byte length header, the 6-byte sub-stream size table and
+ * the 4 concatenated LSB-first bit-streams.
+ *
+ * @param[in]  literals   Source literal bytes (must not alias `dst`).
+ * @param[in]  n_literals Number of source bytes.
+ * @param[in]  code_len   Per-symbol code lengths produced by
+ *                        ::zxc_huf_build_code_lengths.
+ * @param[out] dst        Destination buffer for the section payload.
+ * @param[in]  dst_cap    Capacity of @p dst in bytes.
+ * @return Total bytes written on success, negative `zxc_error_t` code on failure.
+ */
+int zxc_huf_encode_section(const uint8_t* RESTRICT literals, const size_t n_literals,
+                           const uint8_t* RESTRICT code_len, uint8_t* RESTRICT dst,
+                           const size_t dst_cap);
+
+/**
+ * @brief Decode a Huffman literal section payload of `payload_size` bytes.
+ *
+ * Writes exactly `n_literals` decoded bytes into @p dst.
+ *
+ * @param[in]  payload      Section payload (header + 4 sub-streams).
+ * @param[in]  payload_size Total payload length in bytes.
+ * @param[out] dst          Destination buffer (must not alias @p payload).
+ * @param[in]  n_literals   Expected number of decoded bytes.
+ * @return `ZXC_OK` on success, negative `zxc_error_t` code on failure.
+ */
+int zxc_huf_decode_section(const uint8_t* RESTRICT payload, const size_t payload_size,
+                           uint8_t* RESTRICT dst, const size_t n_literals);
 
 /**
  * @brief Internal wrapper function to decompress a single chunk of data.

--- a/lz/zxc/src/lib/zxc_pstream.c
+++ b/lz/zxc/src/lib/zxc_pstream.c
@@ -1,0 +1,1138 @@
+/*
+ * ZXC - High-performance lossless compression
+ *
+ * Copyright (c) 2025-2026 Bertrand Lebonnois and contributors.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file zxc_pstream.c
+ * @brief Push-based, single-threaded streaming driver implementation.
+ *
+ * See zxc_pstream.h for the public contract.  The implementation composes
+ * the public block API (@ref zxc_compress_block / @ref zxc_decompress_block)
+ * with the public sans-IO header helpers (@ref zxc_write_file_header /
+ * footer, @c zxc_read_*); the only internal dependency is on shared
+ * constants and the global-hash combine inline, pulled from zxc_internal.h.
+ *
+ * Both compression and decompression are structured as resumable state
+ * machines driven by caller-provided input/output buffers
+ * (@ref zxc_inbuf_t / @ref zxc_outbuf_t).  Each call advances as much as
+ * possible without blocking and returns a status indicating whether the
+ * caller should drain @p out, supply more @p in, or finalise the stream.
+ */
+
+#include "../../include/zxc_pstream.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../include/zxc_buffer.h"
+#include "../../include/zxc_constants.h"
+#include "../../include/zxc_error.h"
+#include "../../include/zxc_sans_io.h"
+#include "zxc_internal.h"
+
+/* ===================================================================== */
+/*  Compression                                                          */
+/* ===================================================================== */
+
+/**
+ * @enum cstream_state_t
+ * @brief Lifecycle states of the push compression stream.
+ *
+ * The compression state machine alternates between *staging* a chunk of
+ * output bytes into the @c pending buffer and *draining* those bytes into
+ * the caller's @ref zxc_outbuf_t.  Forward progress is therefore always
+ * either consuming from @c in or producing into @c out.
+ *
+ * @var cstream_state_t::CS_INIT
+ *      Initial state; nothing has been emitted yet.
+ * @var cstream_state_t::CS_DRAIN_HEADER
+ *      File header staged in @c pending; draining to @p out, then transitions
+ *      to @c CS_ACCUMULATE.
+ * @var cstream_state_t::CS_ACCUMULATE
+ *      Copying input bytes into the internal block accumulator until it is
+ *      full (or the stream is finalised).
+ * @var cstream_state_t::CS_DRAIN_BLOCK
+ *      A full data block was just compressed; draining it to @p out, then
+ *      back to @c CS_ACCUMULATE.
+ * @var cstream_state_t::CS_DRAIN_LAST
+ *      Draining the final partial block produced inside @ref zxc_cstream_end;
+ *      transitions to @c CS_DRAIN_EOF.
+ * @var cstream_state_t::CS_DRAIN_EOF
+ *      Draining the EOF block; transitions to @c CS_DRAIN_FOOTER.
+ * @var cstream_state_t::CS_DRAIN_FOOTER
+ *      Draining the file footer; transitions to @c CS_DONE.
+ * @var cstream_state_t::CS_DONE
+ *      Finalisation complete; further @c _compress / @c _end calls are
+ *      rejected.
+ * @var cstream_state_t::CS_ERRORED
+ *      Sticky error state; subsequent calls return the latched error code.
+ */
+typedef enum {
+    CS_INIT = 0,
+    CS_DRAIN_HEADER,
+    CS_ACCUMULATE,
+    CS_DRAIN_BLOCK,
+    CS_DRAIN_LAST,
+    CS_DRAIN_EOF,
+    CS_DRAIN_FOOTER,
+    CS_DONE,
+    CS_ERRORED
+} cstream_state_t;
+
+/**
+ * @struct zxc_cstream_s
+ * @brief Internal state of a push compression stream.
+ *
+ * Owns three buffers: a fixed-size input accumulator (@c in_block, sized
+ * to one block), a variable-size output staging area (@c pending, holding
+ * the file header, one compressed block, the EOF block, or the file
+ * footer), and the underlying compression context (@c cctx).
+ *
+ * @var zxc_cstream_s::opts
+ *      Compression options (copied from the caller at creation time).
+ * @var zxc_cstream_s::cctx
+ *      Underlying single-block compression context.
+ * @var zxc_cstream_s::block_size
+ *      Target block size in bytes; cached from @c opts.block_size.
+ * @var zxc_cstream_s::in_block
+ *      Heap buffer of capacity @c block_size used to accumulate one full
+ *      uncompressed block before invoking the block compressor.
+ * @var zxc_cstream_s::in_used
+ *      Number of valid bytes currently held in @c in_block (in
+ *      [0, @c block_size]).
+ * @var zxc_cstream_s::pending
+ *      Heap buffer holding the next chunk of output bytes to emit
+ *      (header, compressed block, EOF marker or footer).
+ * @var zxc_cstream_s::pending_cap
+ *      Allocated capacity of @c pending.
+ * @var zxc_cstream_s::pending_len
+ *      Total valid bytes currently staged in @c pending.
+ * @var zxc_cstream_s::pending_pos
+ *      Bytes already copied from @c pending to the caller's output buffer.
+ *      Drain is complete when @c pending_pos == @c pending_len.
+ * @var zxc_cstream_s::total_in
+ *      Running count of uncompressed bytes consumed; written into the file
+ *      footer.
+ * @var zxc_cstream_s::global_hash
+ *      Rolling per-block-trailer hash; written into the file footer when
+ *      checksums are enabled.
+ * @var zxc_cstream_s::state
+ *      Current state machine position (see @ref cstream_state_t).
+ * @var zxc_cstream_s::error_code
+ *      Sticky error code; valid only when @c state is @c CS_ERRORED.
+ */
+struct zxc_cstream_s {
+    zxc_compress_opts_t opts;
+    zxc_cctx* cctx;
+    size_t block_size;
+
+    uint8_t* in_block;
+    size_t in_used;
+
+    uint8_t* pending;
+    size_t pending_cap;
+    size_t pending_len;
+    size_t pending_pos;
+
+    uint64_t total_in;
+    uint32_t global_hash;
+
+    cstream_state_t state;
+    int error_code;
+};
+
+/**
+ * @brief Latches a sticky error on the compression stream.
+ *
+ * Stores @p code in @c cs->error_code, transitions @c cs->state to
+ * @c CS_ERRORED, and returns @p code.  Once errored, subsequent
+ * @ref zxc_cstream_compress / @ref zxc_cstream_end calls return the same
+ * code without performing further work.
+ *
+ * @param[in,out] cs   Compression stream.
+ * @param[in]     code Negative @ref zxc_error_t value to latch.
+ * @return @p code (always negative).
+ */
+static int cs_set_error(zxc_cstream* cs, const int code) {
+    cs->error_code = code;
+    cs->state = CS_ERRORED;
+    return code;
+}
+
+/**
+ * @brief Compresses one full or partial accumulated block.
+ *
+ * Compresses the contents of @c cs->in_block into @c cs->pending, growing
+ * the latter to @ref zxc_compress_block_bound if needed, and updates
+ * bookkeeping (@c total_in, @c global_hash, @c in_used reset to 0).  When
+ * file-level checksums are enabled, folds the block trailer into the
+ * rolling @c global_hash.
+ *
+ * @pre @c cs->in_used > 0.
+ *
+ * @param[in,out] cs Compression stream.
+ * @return @ref ZXC_OK on success, negative @ref zxc_error_t on failure.
+ */
+static int cs_compress_one_block(zxc_cstream* cs) {
+    const uint64_t bound = zxc_compress_block_bound(cs->in_used);
+    // LCOV_EXCL_START
+    if (UNLIKELY(bound == 0 || bound > SIZE_MAX)) return ZXC_ERROR_OVERFLOW;
+    if (UNLIKELY(bound > cs->pending_cap)) {
+        uint8_t* nb = (uint8_t*)realloc(cs->pending, (size_t)bound);
+        if (UNLIKELY(!nb)) return ZXC_ERROR_MEMORY;
+        cs->pending = nb;
+        cs->pending_cap = (size_t)bound;
+    }
+    // LCOV_EXCL_STOP
+    const int64_t csize = zxc_compress_block(cs->cctx, cs->in_block, cs->in_used, cs->pending,
+                                             cs->pending_cap, &cs->opts);
+    if (UNLIKELY(csize < 0)) return (int)csize;  // LCOV_EXCL_LINE
+
+    cs->pending_len = (size_t)csize;
+    cs->pending_pos = 0;
+    cs->total_in += cs->in_used;
+    cs->in_used = 0;
+
+    /* If checksums are on, the block trailer is the last ZXC_BLOCK_CHECKSUM_SIZE
+     * bytes of pending; fold it into the rolling global hash. */
+    if (cs->opts.checksum_enabled && cs->pending_len >= ZXC_BLOCK_CHECKSUM_SIZE) {
+        const uint32_t bh = zxc_le32(cs->pending + cs->pending_len - ZXC_BLOCK_CHECKSUM_SIZE);
+        cs->global_hash = zxc_hash_combine_rotate(cs->global_hash, bh);
+    }
+    return ZXC_OK;
+}
+
+/**
+ * @brief Drains staged output bytes into the caller's output buffer.
+ *
+ * Copies as many bytes as possible from
+ * @c cs->pending[pending_pos..pending_len) into
+ * @c out->dst[pos..size), advancing both cursors.
+ *
+ * @param[in,out] cs  Compression stream.
+ * @param[in,out] out Caller output buffer.
+ * @return Non-zero once the @c pending buffer has been fully drained
+ *         (@c pending_pos == @c pending_len), zero otherwise.
+ */
+static int cs_drain_pending(zxc_cstream* cs, zxc_outbuf_t* out) {
+    const size_t avail_out = out->size - out->pos;
+    const size_t avail_pen = cs->pending_len - cs->pending_pos;
+    const size_t n = avail_out < avail_pen ? avail_out : avail_pen;
+    if (n) {
+        ZXC_MEMCPY((uint8_t*)out->dst + out->pos, cs->pending + cs->pending_pos, n);
+        out->pos += n;
+        cs->pending_pos += n;
+    }
+    return cs->pending_pos == cs->pending_len;
+}
+
+/**
+ * @brief Allocates and initialises a push compression stream.
+ *
+ * Copies @p opts into the new context, applying defaults for any zero-valued
+ * field (@c level -> @ref ZXC_LEVEL_DEFAULT, @c block_size ->
+ * @ref ZXC_BLOCK_SIZE_DEFAULT).  Forces single-threaded operation
+ * (@c n_threads = 0), disables progress callbacks and seekable framing
+ * (those modes belong to the @c FILE*-based pipeline).  Pre-sizes the
+ * @c pending buffer so that the file header / footer paths never need a
+ * realloc.
+ *
+ * @param[in] opts Compression options, or @c NULL for full defaults.
+ * @return New stream owned by the caller, or @c NULL on allocation
+ *         failure / invalid option values.
+ */
+zxc_cstream* zxc_cstream_create(const zxc_compress_opts_t* opts) {
+    zxc_cstream* cs = (zxc_cstream*)calloc(1, sizeof(*cs));
+    if (UNLIKELY(!cs)) return NULL;  // LCOV_EXCL_LINE
+
+    if (opts) cs->opts = *opts;
+    if (cs->opts.level == 0) cs->opts.level = ZXC_LEVEL_DEFAULT;
+    if (cs->opts.block_size == 0) cs->opts.block_size = ZXC_BLOCK_SIZE_DEFAULT;
+    /* n_threads is ignored on this single-threaded path. */
+    cs->opts.n_threads = 0;
+    cs->opts.progress_cb = NULL;
+    cs->opts.user_data = NULL;
+    cs->opts.seekable = 0;
+    cs->block_size = cs->opts.block_size;
+
+    cs->cctx = zxc_create_cctx(&cs->opts);
+    // LCOV_EXCL_START
+    if (UNLIKELY(!cs->cctx)) {
+        free(cs);
+        return NULL;
+    }
+    cs->in_block = (uint8_t*)malloc(cs->block_size);
+    if (UNLIKELY(!cs->in_block)) {
+        zxc_free_cctx(cs->cctx);
+        free(cs);
+        return NULL;
+    }
+    // LCOV_EXCL_STOP
+    /* Pre-size pending so the file header path never needs realloc. */
+    cs->pending_cap =
+        ZXC_FILE_HEADER_SIZE > ZXC_FILE_FOOTER_SIZE ? ZXC_FILE_HEADER_SIZE : ZXC_FILE_FOOTER_SIZE;
+    cs->pending = (uint8_t*)malloc(cs->pending_cap);
+    // LCOV_EXCL_START
+    if (UNLIKELY(!cs->pending)) {
+        free(cs->in_block);
+        zxc_free_cctx(cs->cctx);
+        free(cs);
+        return NULL;
+    }
+    // LCOV_EXCL_STOP
+    cs->state = CS_INIT;
+    return cs;
+}
+
+/**
+ * @brief Stages the 16-byte file header into the @c pending buffer.
+ *
+ * @param[in,out] cs Compression stream.
+ * @return @ref ZXC_OK on success, negative @ref zxc_error_t on failure.
+ */
+static int cs_stage_file_header(zxc_cstream* cs) {
+    const int w = zxc_write_file_header(cs->pending, cs->pending_cap, cs->block_size,
+                                        cs->opts.checksum_enabled);
+    if (UNLIKELY(w < 0)) return w;  // LCOV_EXCL_LINE
+    cs->pending_len = (size_t)w;
+    cs->pending_pos = 0;
+    return ZXC_OK;
+}
+
+/**
+ * @brief Stages the 8-byte EOF block into the @c pending buffer.
+ *
+ * The EOF block is a regular block header with @c block_type set to
+ * @ref ZXC_BLOCK_EOF and @c comp_size = 0; it carries no payload.
+ *
+ * @param[in,out] cs Compression stream.
+ * @return @ref ZXC_OK on success, negative @ref zxc_error_t on failure.
+ */
+static int cs_stage_eof(zxc_cstream* cs) {
+    // LCOV_EXCL_START
+    if (UNLIKELY(ZXC_BLOCK_HEADER_SIZE > cs->pending_cap)) {
+        uint8_t* nb = (uint8_t*)realloc(cs->pending, ZXC_BLOCK_HEADER_SIZE);
+        if (UNLIKELY(!nb)) return ZXC_ERROR_MEMORY;
+        cs->pending = nb;
+        cs->pending_cap = ZXC_BLOCK_HEADER_SIZE;
+    }
+    // LCOV_EXCL_STOP
+    const zxc_block_header_t eof = {
+        .block_type = (uint8_t)ZXC_BLOCK_EOF,
+        .block_flags = 0,
+        .reserved = 0,
+        .header_crc = 0,
+        .comp_size = 0,
+    };
+    const int w = zxc_write_block_header(cs->pending, cs->pending_cap, &eof);
+    if (UNLIKELY(w < 0)) return w;  // LCOV_EXCL_LINE
+    cs->pending_len = (size_t)w;
+    cs->pending_pos = 0;
+    return ZXC_OK;
+}
+
+/**
+ * @brief Stages the 12-byte file footer into the @c pending buffer.
+ *
+ * The footer carries the total uncompressed input size and (when checksums
+ * are enabled) the global rolling hash accumulated across all data blocks.
+ *
+ * @param[in,out] cs Compression stream.
+ * @return @ref ZXC_OK on success, negative @ref zxc_error_t on failure.
+ */
+static int cs_stage_footer(zxc_cstream* cs) {
+    // LCOV_EXCL_START
+    if (UNLIKELY(ZXC_FILE_FOOTER_SIZE > cs->pending_cap)) {
+        uint8_t* nb = (uint8_t*)realloc(cs->pending, ZXC_FILE_FOOTER_SIZE);
+        if (UNLIKELY(!nb)) return ZXC_ERROR_MEMORY;
+        cs->pending = nb;
+        cs->pending_cap = ZXC_FILE_FOOTER_SIZE;
+    }
+    // LCOV_EXCL_STOP
+    const int w = zxc_write_file_footer(cs->pending, cs->pending_cap, cs->total_in, cs->global_hash,
+                                        cs->opts.checksum_enabled);
+    if (UNLIKELY(w < 0)) return w;  // LCOV_EXCL_LINE
+    cs->pending_len = (size_t)w;
+    cs->pending_pos = 0;
+    return ZXC_OK;
+}
+
+/**
+ * @brief Releases a compression stream and all internal buffers.
+ *
+ * Safe to call with @c NULL.
+ *
+ * @param[in,out] cs Stream returned by @ref zxc_cstream_create.
+ */
+void zxc_cstream_free(zxc_cstream* cs) {
+    if (!cs) return;
+    free(cs->pending);
+    free(cs->in_block);
+    zxc_free_cctx(cs->cctx);
+    free(cs);
+}
+
+/**
+ * @brief Returns the suggested input chunk size (configured block size).
+ *
+ * @param[in] cs Compression stream.
+ * @return Block size in bytes, or 0 if @p cs is @c NULL.
+ */
+size_t zxc_cstream_in_size(const zxc_cstream* cs) { return cs ? cs->block_size : 0; }
+
+/**
+ * @brief Returns the suggested output chunk size.
+ *
+ * Sized to hold one full compressed block plus framing overhead, i.e.
+ * @ref zxc_compress_block_bound applied to the configured block size.
+ * Falls back to @c block_size when the bound overflows @c size_t.
+ *
+ * @param[in] cs Compression stream.
+ * @return Suggested output buffer capacity in bytes, or 0 if @p cs is @c NULL.
+ */
+size_t zxc_cstream_out_size(const zxc_cstream* cs) {
+    if (!cs) return 0;
+    const uint64_t b = zxc_compress_block_bound(cs->block_size);
+    return (b == 0 || b > SIZE_MAX) ? cs->block_size : (size_t)b;
+}
+
+/**
+ * @brief Push-side entry point: feeds input and drains compressed output.
+ *
+ * Drives the @ref cstream_state_t machine: emits the file header on the
+ * first call, then accumulates input until a block is full, compresses it,
+ * and drains the result into @p out.  Each call makes as much progress as
+ * either buffer allows; the function is fully reentrant.  See the public
+ * contract in @ref zxc_cstream_compress for full semantics.
+ *
+ * The terminal states (@c CS_DRAIN_LAST, @c CS_DRAIN_EOF, @c CS_DRAIN_FOOTER,
+ * @c CS_DONE, @c CS_ERRORED) are owned by @ref zxc_cstream_end; reaching
+ * them here yields @ref ZXC_ERROR_NULL_INPUT.
+ *
+ * @param[in,out] cs  Compression stream.
+ * @param[in,out] out Caller output buffer.
+ * @param[in,out] in  Caller input buffer.
+ * @return @c 0 if @p in fully consumed and nothing pending,
+ *         @c >0 number of bytes still pending (drain @p out then call again),
+ *         @c <0 a @ref zxc_error_t code.
+ */
+int64_t zxc_cstream_compress(zxc_cstream* cs, zxc_outbuf_t* out, zxc_inbuf_t* in) {
+    if (UNLIKELY(!cs || !out || !in || in->pos > in->size || out->pos > out->size ||
+                 (in->size > in->pos && !in->src) || (out->size > out->pos && !out->dst) ||
+                 cs->state == CS_DONE)) {
+        return ZXC_ERROR_NULL_INPUT;
+    }
+    if (UNLIKELY(cs->state == CS_ERRORED)) return cs->error_code;
+
+    for (;;) {
+        switch (cs->state) {
+            case CS_INIT: {
+                const int rc = cs_stage_file_header(cs);
+                if (UNLIKELY(rc < 0)) return cs_set_error(cs, rc);  // LCOV_EXCL_LINE
+                cs->state = CS_DRAIN_HEADER;
+                break;
+            }
+
+            case CS_DRAIN_HEADER: {
+                if (!cs_drain_pending(cs, out)) return (int64_t)(cs->pending_len - cs->pending_pos);
+                cs->state = CS_ACCUMULATE;
+                break;
+            }
+
+            case CS_DRAIN_BLOCK: {
+                if (!cs_drain_pending(cs, out)) return (int64_t)(cs->pending_len - cs->pending_pos);
+                cs->state = CS_ACCUMULATE;
+                break;
+            }
+
+            case CS_ACCUMULATE: {
+                const size_t avail_in = in->size - in->pos;
+                const size_t room = cs->block_size - cs->in_used;
+                const size_t n = avail_in < room ? avail_in : room;
+                if (n) {
+                    ZXC_MEMCPY(cs->in_block + cs->in_used, (const uint8_t*)in->src + in->pos, n);
+                    in->pos += n;
+                    cs->in_used += n;
+                }
+
+                if (cs->in_used == cs->block_size) {
+                    const int rc = cs_compress_one_block(cs);
+                    if (UNLIKELY(rc < 0)) return cs_set_error(cs, rc);  // LCOV_EXCL_LINE
+                    cs->state = CS_DRAIN_BLOCK;
+                    break;
+                }
+                /* Block not yet full either in is empty or we made no progress. */
+                return 0;
+            }
+
+            case CS_DRAIN_LAST:
+            case CS_DRAIN_EOF:
+            case CS_DRAIN_FOOTER:
+            case CS_DONE:
+            case CS_ERRORED:
+                /* These states are owned by _end(). */
+                return ZXC_ERROR_NULL_INPUT;
+        }
+    }
+}
+
+/**
+ * @brief Finalises the stream: residual block (if any), EOF, and footer.
+ *
+ * Continues the same state machine as @ref zxc_cstream_compress through the
+ * terminal states (@c CS_DRAIN_LAST -> @c CS_DRAIN_EOF -> @c CS_DRAIN_FOOTER
+ * -> @c CS_DONE).  Reentrant: when @p out fills mid-drain, returns the
+ * number of bytes still pending and resumes from where it left off on the
+ * next call.  See the public contract in @ref zxc_cstream_end.
+ *
+ * @param[in,out] cs  Compression stream.
+ * @param[in,out] out Caller output buffer.
+ * @return @c 0 once finalisation is complete (stream is now in DONE state),
+ *         @c >0 number of bytes still pending (drain and call again),
+ *         @c <0 a @ref zxc_error_t code.
+ */
+int64_t zxc_cstream_end(zxc_cstream* cs, zxc_outbuf_t* out) {
+    if (UNLIKELY(!cs || !out || cs->state == CS_DONE)) return ZXC_ERROR_NULL_INPUT;
+    if (UNLIKELY(cs->state == CS_ERRORED)) return cs->error_code;
+
+    for (;;) {
+        switch (cs->state) {
+            case CS_INIT: {
+                /* _end before any input, still need to emit file header. */
+                const int rc = cs_stage_file_header(cs);
+                if (UNLIKELY(rc < 0)) return cs_set_error(cs, rc);  // LCOV_EXCL_LINE
+                cs->state = CS_DRAIN_HEADER;
+                break;
+            }
+
+            case CS_DRAIN_HEADER: {
+                if (!cs_drain_pending(cs, out)) return (int64_t)(cs->pending_len - cs->pending_pos);
+                cs->state = CS_ACCUMULATE;
+                break;
+            }
+
+            case CS_DRAIN_BLOCK: {
+                /* This drain came from a full block compressed during _compress. */
+                if (!cs_drain_pending(cs, out)) return (int64_t)(cs->pending_len - cs->pending_pos);
+                cs->state = CS_ACCUMULATE;
+                break;
+            }
+
+            case CS_ACCUMULATE: {
+                /* Compress the residual partial block (if any), then EOF + footer. */
+                if (cs->in_used > 0) {
+                    const int rc = cs_compress_one_block(cs);
+                    if (UNLIKELY(rc < 0)) return cs_set_error(cs, rc);  // LCOV_EXCL_LINE
+                    cs->state = CS_DRAIN_LAST;
+                    break;
+                }
+                /* No residual data: go straight to EOF. */
+                {
+                    const int rc = cs_stage_eof(cs);
+                    if (UNLIKELY(rc < 0)) return cs_set_error(cs, rc);  // LCOV_EXCL_LINE
+                    cs->state = CS_DRAIN_EOF;
+                    break;
+                }
+            }
+
+            case CS_DRAIN_LAST: {
+                if (!cs_drain_pending(cs, out)) return (int64_t)(cs->pending_len - cs->pending_pos);
+                /* After last data block -> EOF. */
+                const int rc = cs_stage_eof(cs);
+                if (UNLIKELY(rc < 0)) return cs_set_error(cs, rc);  // LCOV_EXCL_LINE
+                cs->state = CS_DRAIN_EOF;
+                break;
+            }
+
+            case CS_DRAIN_EOF: {
+                if (!cs_drain_pending(cs, out)) return (int64_t)(cs->pending_len - cs->pending_pos);
+                const int rc = cs_stage_footer(cs);
+                if (UNLIKELY(rc < 0)) return cs_set_error(cs, rc);  // LCOV_EXCL_LINE
+                cs->state = CS_DRAIN_FOOTER;
+                break;
+            }
+
+            case CS_DRAIN_FOOTER: {
+                if (!cs_drain_pending(cs, out)) return (int64_t)(cs->pending_len - cs->pending_pos);
+                cs->state = CS_DONE;
+                return 0;
+            }
+
+            case CS_DONE:
+            case CS_ERRORED:
+                return cs->state == CS_ERRORED ? cs->error_code : 0;
+        }
+    }
+}
+
+/* ===================================================================== */
+/*  Decompression                                                        */
+/* ===================================================================== */
+
+/**
+ * @enum dstream_state_t
+ * @brief Lifecycle states of the push decompression stream.
+ *
+ * The decompressor implements a frame-aware parser: file header -> N
+ * (data block header + payload [+ optional checksum]) -> EOF block ->
+ * optional SEK index block -> file footer.  The states alternate between
+ * *pulling* fixed- or variable-sized chunks from the caller's input, and
+ * *emitting* the corresponding decoded output.
+ *
+ * @var dstream_state_t::DS_NEED_FILE_HEADER
+ *      Pulling the 16-byte file header into @c scratch.
+ * @var dstream_state_t::DS_NEED_BLOCK_HEADER
+ *      Pulling an 8-byte block header into @c scratch.
+ * @var dstream_state_t::DS_NEED_BLOCK_PAYLOAD
+ *      Pulling a data block payload (and optional checksum) into @c payload.
+ * @var dstream_state_t::DS_DECODE_BLOCK
+ *      Calling the underlying block decoder on the accumulated payload.
+ * @var dstream_state_t::DS_EMIT_DECODED
+ *      Draining decoded bytes from @c decoded into @p out.
+ * @var dstream_state_t::DS_PEEK_TAIL
+ *      Just past the EOF block: read 8 bytes and peek to disambiguate
+ *      between an optional SEK index block and the file footer.
+ * @var dstream_state_t::DS_DRAIN_SEK_PAYLOAD
+ *      The peeked 8 bytes were a SEK header; skipping its payload bytes.
+ * @var dstream_state_t::DS_NEED_FOOTER_FULL
+ *      Pulling the full 12-byte file footer (used after a SEK block).
+ * @var dstream_state_t::DS_NEED_FOOTER_REST
+ *      The 8 peeked bytes were the head of the footer; pulling the
+ *      remaining 4 bytes.
+ * @var dstream_state_t::DS_VALIDATE_FOOTER
+ *      Validating @c total_out and the optional global hash.
+ * @var dstream_state_t::DS_DONE
+ *      Stream fully consumed and validated.
+ * @var dstream_state_t::DS_ERRORED
+ *      Sticky error state; subsequent calls return the latched code.
+ */
+typedef enum {
+    DS_NEED_FILE_HEADER = 0,
+    DS_NEED_BLOCK_HEADER,
+    DS_NEED_BLOCK_PAYLOAD,
+    DS_DECODE_BLOCK,
+    DS_EMIT_DECODED,
+    DS_PEEK_TAIL,
+    DS_DRAIN_SEK_PAYLOAD,
+    DS_NEED_FOOTER_FULL,
+    DS_NEED_FOOTER_REST,
+    DS_VALIDATE_FOOTER,
+    DS_DONE,
+    DS_ERRORED
+} dstream_state_t;
+
+/**
+ * @struct zxc_dstream_s
+ * @brief Internal state of a push decompression stream.
+ *
+ * Owns three accumulator regions: a fixed-size on-stack-style @c scratch
+ * buffer for headers/footers/peeks, a heap @c payload buffer for variable
+ * block payloads, and a heap @c decoded buffer that holds one decompressed
+ * block before it is emitted to the caller.
+ *
+ * @var zxc_dstream_s::opts
+ *      Decompression options (copied at creation time).
+ * @var zxc_dstream_s::inner
+ *      Underlying single-block decompression context.
+ * @var zxc_dstream_s::inner_initialized
+ *      Non-zero once @c inner has been initialised; gates the matching
+ *      @ref zxc_cctx_free call at teardown.
+ * @var zxc_dstream_s::block_size
+ *      Block size declared by the file header; 0 until the header is parsed.
+ * @var zxc_dstream_s::file_has_checksum
+ *      File-level checksum flag declared by the file header.
+ * @var zxc_dstream_s::scratch
+ *      Generic accumulator for fixed-size frames; sized for the largest
+ *      (file header = 16 bytes).
+ * @var zxc_dstream_s::scratch_used
+ *      Number of bytes currently held in @c scratch.
+ * @var zxc_dstream_s::scratch_need
+ *      Target number of bytes for the current accumulation phase.
+ * @var zxc_dstream_s::payload
+ *      Heap buffer holding one block: header + compressed payload + optional
+ *      checksum.
+ * @var zxc_dstream_s::payload_cap
+ *      Allocated capacity of @c payload.
+ * @var zxc_dstream_s::payload_used
+ *      Number of valid bytes currently in @c payload.
+ * @var zxc_dstream_s::payload_need
+ *      Target byte count for the current payload phase
+ *      (= header size + comp_size + checksum size).
+ * @var zxc_dstream_s::decoded
+ *      Heap buffer holding the decoded output of one block (sized for the
+ *      wild-copy fast path: @c block_size + @ref ZXC_PAD_SIZE).
+ * @var zxc_dstream_s::decoded_cap
+ *      Allocated capacity of @c decoded.
+ * @var zxc_dstream_s::decoded_size
+ *      Real number of decoded bytes in @c decoded after the last decode.
+ * @var zxc_dstream_s::decoded_pos
+ *      Bytes already emitted from @c decoded; drain complete when
+ *      @c decoded_pos == @c decoded_size.
+ * @var zxc_dstream_s::cur_bh
+ *      Parsed block header for the block currently being processed.
+ * @var zxc_dstream_s::sek_remaining
+ *      Bytes left to skip from a SEK block payload (only used in
+ *      @c DS_DRAIN_SEK_PAYLOAD).
+ * @var zxc_dstream_s::total_out
+ *      Cumulative decompressed output size; cross-checked against the
+ *      file footer.
+ * @var zxc_dstream_s::global_hash
+ *      Rolling per-block-trailer hash; cross-checked against the file
+ *      footer when checksums are enabled.
+ * @var zxc_dstream_s::state
+ *      Current state machine position (see @ref dstream_state_t).
+ * @var zxc_dstream_s::error_code
+ *      Sticky error code; valid only when @c state is @c DS_ERRORED.
+ */
+struct zxc_dstream_s {
+    zxc_decompress_opts_t opts;
+    zxc_cctx_t inner;
+    int inner_initialized;
+    size_t block_size;
+    int file_has_checksum;
+
+    uint8_t scratch[32];
+    size_t scratch_used;
+    size_t scratch_need;
+
+    uint8_t* payload;
+    size_t payload_cap;
+    size_t payload_used;
+    size_t payload_need;
+
+    uint8_t* decoded;
+    size_t decoded_cap;
+    size_t decoded_size;
+    size_t decoded_pos;
+
+    zxc_block_header_t cur_bh;
+    size_t sek_remaining;
+
+    uint64_t total_out;
+    uint32_t global_hash;
+
+    dstream_state_t state;
+    int error_code;
+};
+
+/**
+ * @brief Latches a sticky error on the decompression stream.
+ *
+ * Stores @p code in @c ds->error_code, transitions @c ds->state to
+ * @c DS_ERRORED, and returns @p code.  Once errored, subsequent
+ * @ref zxc_dstream_decompress calls return the same code without
+ * performing further work.
+ *
+ * @param[in,out] ds   Decompression stream.
+ * @param[in]     code Negative @ref zxc_error_t value to latch.
+ * @return @p code (always negative).
+ */
+static int ds_set_error(zxc_dstream* ds, const int code) {
+    ds->error_code = code;
+    ds->state = DS_ERRORED;
+    return code;
+}
+
+/**
+ * @brief Pulls up to @c (scratch_need - scratch_used) bytes from @p in.
+ *
+ * Used to accumulate fixed-size frames (file header, block header, footer,
+ * EOF tail peek) into the inline @c scratch buffer.
+ *
+ * @param[in,out] ds Decompression stream.
+ * @param[in,out] in Caller input buffer; @c pos is advanced.
+ * @return @c 1 once @c scratch holds exactly @c scratch_need bytes,
+ *         @c 0 otherwise (need more input).
+ */
+static int ds_pull_scratch(zxc_dstream* ds, zxc_inbuf_t* in) {
+    const size_t want = ds->scratch_need - ds->scratch_used;
+    const size_t avail = in->size - in->pos;
+    const size_t n = want < avail ? want : avail;
+    if (n) {
+        ZXC_MEMCPY(ds->scratch + ds->scratch_used, (const uint8_t*)in->src + in->pos, n);
+        in->pos += n;
+        ds->scratch_used += n;
+    }
+    return ds->scratch_used == ds->scratch_need;
+}
+
+/**
+ * @brief Same as @ref ds_pull_scratch but pulls into the heap @c payload buffer.
+ *
+ * Used to accumulate the variable-size compressed block payload
+ * (header + comp_size [+ checksum]).
+ *
+ * @param[in,out] ds Decompression stream.
+ * @param[in,out] in Caller input buffer; @c pos is advanced.
+ * @return @c 1 once @c payload holds exactly @c payload_need bytes,
+ *         @c 0 otherwise (need more input).
+ */
+static int ds_pull_payload(zxc_dstream* ds, zxc_inbuf_t* in) {
+    const size_t want = ds->payload_need - ds->payload_used;
+    const size_t avail = in->size - in->pos;
+    const size_t n = want < avail ? want : avail;
+    if (n) {
+        ZXC_MEMCPY(ds->payload + ds->payload_used, (const uint8_t*)in->src + in->pos, n);
+        in->pos += n;
+        ds->payload_used += n;
+    }
+    return ds->payload_used == ds->payload_need;
+}
+
+/**
+ * @brief Allocates and initialises a push decompression stream.
+ *
+ * Copies @p opts into the new context.  The internal multi-threading,
+ * progress-callback, and seekable knobs are forced off (those modes belong
+ * to the @c FILE*-based pipeline).  @c block_size, @c file_has_checksum,
+ * and the @c payload / @c decoded buffers are filled in lazily once the
+ * file header is parsed.
+ *
+ * @param[in] opts Decompression options, or @c NULL for full defaults.
+ * @return New stream owned by the caller, or @c NULL on allocation failure.
+ */
+zxc_dstream* zxc_dstream_create(const zxc_decompress_opts_t* opts) {
+    zxc_dstream* ds = (zxc_dstream*)calloc(1, sizeof(*ds));
+    if (UNLIKELY(!ds)) return NULL;  // LCOV_EXCL_LINE
+    if (opts) ds->opts = *opts;
+    ds->opts.n_threads = 0;
+    ds->opts.progress_cb = NULL;
+    ds->opts.user_data = NULL;
+    ds->state = DS_NEED_FILE_HEADER;
+    ds->scratch_need = ZXC_FILE_HEADER_SIZE;
+    return ds;
+}
+
+/**
+ * @brief Releases a decompression stream and all internal buffers.
+ *
+ * Safe to call with @c NULL.
+ *
+ * @param[in,out] ds Stream returned by @ref zxc_dstream_create.
+ */
+void zxc_dstream_free(zxc_dstream* ds) {
+    if (!ds) return;
+    free(ds->payload);
+    free(ds->decoded);
+    if (ds->inner_initialized) zxc_cctx_free(&ds->inner);
+    free(ds);
+}
+
+/**
+ * @brief Returns 1 iff the stream has reached @c DS_DONE.
+ *
+ * @param[in] ds Decompression stream.
+ * @return @c 1 if DONE, @c 0 otherwise (including errored).
+ */
+int zxc_dstream_finished(const zxc_dstream* ds) { return (ds && ds->state == DS_DONE) ? 1 : 0; }
+
+/**
+ * @brief Returns the suggested input chunk size for the decompressor.
+ *
+ * Before the file header is parsed the call returns
+ * @ref ZXC_BLOCK_SIZE_DEFAULT; afterwards it returns the maximal compressed
+ * block size derived from the negotiated @c block_size.
+ *
+ * @param[in] ds Decompression stream.
+ * @return Suggested input buffer capacity in bytes, or 0 if @p ds is @c NULL.
+ */
+size_t zxc_dstream_in_size(const zxc_dstream* ds) {
+    if (!ds) return 0;
+    if (ds->block_size == 0) return ZXC_BLOCK_SIZE_DEFAULT;
+    const uint64_t b = zxc_compress_block_bound(ds->block_size);
+    return (b == 0 || b > SIZE_MAX) ? ds->block_size : (size_t)b;
+}
+
+/**
+ * @brief Returns the suggested output chunk size for the decompressor.
+ *
+ * Equals the negotiated @c block_size; before the file header is parsed,
+ * returns @ref ZXC_BLOCK_SIZE_DEFAULT.
+ *
+ * @param[in] ds Decompression stream.
+ * @return Suggested output buffer capacity in bytes, or 0 if @p ds is @c NULL.
+ */
+size_t zxc_dstream_out_size(const zxc_dstream* ds) {
+    if (!ds) return 0;
+    return ds->block_size == 0 ? ZXC_BLOCK_SIZE_DEFAULT : ds->block_size;
+}
+
+/**
+ * @brief Drains @c ds->decoded[decoded_pos..decoded_size) into @p out.
+ *
+ * Updates @c ds->total_out by the number of bytes copied and, when
+ * @p produced is non-NULL, accumulates the same count into @c *produced
+ * (used by the outer state machine to compute the per-call return value).
+ *
+ * @param[in,out] ds       Decompression stream.
+ * @param[in,out] out      Caller output buffer.
+ * @param[in,out] produced Optional running count of bytes produced this call.
+ * @return @c 1 once @c decoded is fully drained, @c 0 otherwise.
+ */
+static int ds_drain_decoded(zxc_dstream* ds, zxc_outbuf_t* out, size_t* produced) {
+    const size_t avail_out = out->size - out->pos;
+    const size_t avail_dec = ds->decoded_size - ds->decoded_pos;
+    const size_t n = avail_out < avail_dec ? avail_out : avail_dec;
+    if (n) {
+        ZXC_MEMCPY((uint8_t*)out->dst + out->pos, ds->decoded + ds->decoded_pos, n);
+        out->pos += n;
+        ds->decoded_pos += n;
+        ds->total_out += n;
+        if (produced) *produced += n;
+    }
+    return ds->decoded_pos == ds->decoded_size;
+}
+
+/**
+ * @brief Handles the @c DS_NEED_FILE_HEADER state.
+ *
+ * Pulls the 16-byte file header into @c scratch, parses it via
+ * @ref zxc_read_file_header, and lazily allocates the @c payload and
+ * @c decoded buffers (sized from the negotiated @c block_size).  The
+ * @c decoded buffer is over-allocated by @ref ZXC_PAD_SIZE bytes to absorb
+ * wild-copy overflow from the inner decoder.  Initialises the underlying
+ * decompression context and transitions to @c DS_NEED_BLOCK_HEADER.
+ *
+ * @param[in,out] ds Decompression stream.
+ * @param[in,out] in Caller input buffer.
+ * @return @c 1 if more input is needed, @c 0 to continue the outer loop,
+ *         negative @ref zxc_error_t on validation/allocation failure.
+ */
+static int ds_handle_need_file_header(zxc_dstream* ds, zxc_inbuf_t* in) {
+    if (!ds_pull_scratch(ds, in)) return 1;
+
+    size_t bs = 0;
+    int has_csum = 0;
+    const int rc = zxc_read_file_header(ds->scratch, ds->scratch_used, &bs, &has_csum);
+    if (UNLIKELY(rc != ZXC_OK)) return ds_set_error(ds, rc);  // LCOV_EXCL_LINE
+    ds->block_size = bs;
+    ds->file_has_checksum = has_csum;
+
+    /* Allocate payload + decoded buffers now that block_size is known. */
+    const uint64_t pb = zxc_compress_block_bound(ds->block_size);
+    // LCOV_EXCL_START
+    if (UNLIKELY(pb == 0 || pb > SIZE_MAX)) return ds_set_error(ds, ZXC_ERROR_OVERFLOW);
+    // LCOV_EXCL_STOP
+    ds->payload_cap = (size_t)pb;
+    ds->payload = (uint8_t*)malloc(ds->payload_cap);
+
+    /* Decoded buffer is sized for the wild-copy fast path: block_size +
+     * ZXC_PAD_SIZE; same pattern as the buffer API uses internally.  Real
+     * decoded payload lives in [0..decoded_size); the trailing PAD bytes
+     * hold wild-copy overflow we never emit. */
+    ds->decoded_cap = ds->block_size + ZXC_PAD_SIZE;
+    ds->decoded = (uint8_t*)malloc(ds->decoded_cap);
+    // LCOV_EXCL_START
+    if (UNLIKELY(!ds->payload || !ds->decoded)) return ds_set_error(ds, ZXC_ERROR_MEMORY);
+
+    if (UNLIKELY(zxc_cctx_init(&ds->inner, ds->block_size, 0, 0,
+                               ds->file_has_checksum && ds->opts.checksum_enabled) != ZXC_OK)) {
+        return ds_set_error(ds, ZXC_ERROR_MEMORY);
+    }
+    // LCOV_EXCL_STOP
+    ds->inner_initialized = 1;
+
+    ds->state = DS_NEED_BLOCK_HEADER;
+    ds->scratch_used = 0;
+    ds->scratch_need = ZXC_BLOCK_HEADER_SIZE;
+    return 0;
+}
+
+/**
+ * @brief Handles the @c DS_NEED_BLOCK_HEADER state.
+ *
+ * Pulls 8 bytes into @c scratch and parses them as a block header.  If the
+ * block is an EOF block, transitions to @c DS_PEEK_TAIL to disambiguate
+ * between an optional SEK index and the file footer.  Otherwise, validates
+ * the announced @c comp_size against the @c payload buffer capacity, copies
+ * the parsed header into @c payload (the underlying decoder expects header
+ * + body + optional checksum as a single contiguous frame), and transitions
+ * to @c DS_NEED_BLOCK_PAYLOAD.
+ *
+ * @param[in,out] ds Decompression stream.
+ * @param[in,out] in Caller input buffer.
+ * @return @c 1 if more input is needed, @c 0 to continue the outer loop,
+ *         negative @ref zxc_error_t on validation/allocation failure.
+ */
+static int ds_handle_need_block_header(zxc_dstream* ds, zxc_inbuf_t* in) {
+    if (!ds_pull_scratch(ds, in)) return 1;
+
+    const int rc = zxc_read_block_header(ds->scratch, ds->scratch_used, &ds->cur_bh);
+    if (UNLIKELY(rc != ZXC_OK)) return ds_set_error(ds, rc);  // LCOV_EXCL_LINE
+
+    if (ds->cur_bh.block_type == (uint8_t)ZXC_BLOCK_EOF) {
+        /* EOF block: comp_size must be 0; no payload, no checksum. */
+        if (UNLIKELY(ds->cur_bh.comp_size != 0)) return ds_set_error(ds, ZXC_ERROR_BAD_BLOCK_SIZE);
+        ds->state = DS_PEEK_TAIL;
+        ds->scratch_used = 0;
+        ds->scratch_need = ZXC_BLOCK_HEADER_SIZE; /* sniff */
+        return 0;
+    }
+
+    /* Normal data block: read comp_size [+ ZXC_BLOCK_CHECKSUM_SIZE if file-level checksums]. */
+    const uint64_t need = (uint64_t)ds->cur_bh.comp_size +
+                          (ds->file_has_checksum ? (uint64_t)ZXC_BLOCK_CHECKSUM_SIZE : 0u);
+    if (UNLIKELY(need > ds->payload_cap)) return ds_set_error(ds, ZXC_ERROR_BAD_BLOCK_SIZE);
+
+    /* Feed the full block (header + payload + opt csum) to zxc_decompress_block,
+     * so prefix with the 8-byte header we just parsed. */
+    ZXC_MEMCPY(ds->payload, ds->scratch, ZXC_BLOCK_HEADER_SIZE);
+    ds->payload_used = ZXC_BLOCK_HEADER_SIZE;
+    ds->payload_need = (size_t)need + ZXC_BLOCK_HEADER_SIZE;
+    // LCOV_EXCL_START
+    if (UNLIKELY(ds->payload_need > ds->payload_cap)) {
+        /* grow */
+        uint8_t* nb = (uint8_t*)realloc(ds->payload, ds->payload_need);
+        if (UNLIKELY(!nb)) return ds_set_error(ds, ZXC_ERROR_MEMORY);
+        ds->payload = nb;
+        ds->payload_cap = ds->payload_need;
+    }
+    // LCOV_EXCL_STOP
+    ds->state = DS_NEED_BLOCK_PAYLOAD;
+    return 0;
+}
+
+/**
+ * @brief Push-side entry point: feeds compressed input and drains decoded output.
+ *
+ * Drives the @ref dstream_state_t machine: file header, then per-block
+ * (header + payload + optional checksum) -> decode -> emit, repeated until
+ * the EOF block, optional SEK index block, and file footer have been parsed
+ * and validated.  Each call makes as much progress as @p in and @p out
+ * allow; the function is fully reentrant.  See the public contract in
+ * @ref zxc_dstream_decompress for full semantics.
+ *
+ * @par End of stream
+ * Once @c DS_VALIDATE_FOOTER succeeds, the stream is in @c DS_DONE; further
+ * calls return @c 0 without consuming input.
+ *
+ * @par Errors
+ * On any negative return the stream becomes errored (sticky); subsequent
+ * calls keep returning the same code until @ref zxc_dstream_free.
+ *
+ * @param[in,out] ds  Decompression stream.
+ * @param[in,out] out Caller output buffer.
+ * @param[in,out] in  Caller input buffer.
+ * @return @c >0 number of decompressed bytes written into @p out this call,
+ *         @c 0 stream complete (DONE) or no progress possible,
+ *         @c <0 a @ref zxc_error_t code.
+ */
+int64_t zxc_dstream_decompress(zxc_dstream* ds, zxc_outbuf_t* out, zxc_inbuf_t* in) {
+    if (UNLIKELY(!ds || !out || !in || in->pos > in->size || out->pos > out->size ||
+                 (in->size > in->pos && !in->src) || (out->size > out->pos && !out->dst))) {
+        return ZXC_ERROR_NULL_INPUT;
+    }
+    if (UNLIKELY(ds->state == DS_ERRORED)) return ds->error_code;
+    if (UNLIKELY(ds->state == DS_DONE)) return 0;
+
+    size_t produced = 0;
+
+    for (;;) {
+        switch (ds->state) {
+            case DS_NEED_FILE_HEADER: {
+                const int rc = ds_handle_need_file_header(ds, in);
+                if (rc == 1) return (int64_t)produced;
+                if (rc < 0) return rc;
+                break;
+            }
+
+            case DS_NEED_BLOCK_HEADER: {
+                const int rc = ds_handle_need_block_header(ds, in);
+                if (rc == 1) return (int64_t)produced;
+                if (rc < 0) return rc;
+                break;
+            }
+
+            case DS_NEED_BLOCK_PAYLOAD: {
+                if (!ds_pull_payload(ds, in)) return (int64_t)produced;
+                ds->state = DS_DECODE_BLOCK;
+                break;
+            }
+
+            case DS_DECODE_BLOCK: {
+                const int dsz = zxc_decompress_chunk_wrapper(
+                    &ds->inner, ds->payload, ds->payload_used, ds->decoded, ds->decoded_cap);
+                if (UNLIKELY(dsz < 0)) return ds_set_error(ds, dsz);
+                ds->decoded_size = (size_t)dsz;
+                ds->decoded_pos = 0;
+
+                /* If file-level checksum verification is enabled, fold this
+                 * block's trailer into the rolling global hash (last
+                 * ZXC_BLOCK_CHECKSUM_SIZE bytes of the *raw* block). */
+                if (ds->opts.checksum_enabled && ds->file_has_checksum &&
+                    ds->payload_used >= ZXC_BLOCK_CHECKSUM_SIZE) {
+                    const uint32_t bh =
+                        zxc_le32(ds->payload + ds->payload_used - ZXC_BLOCK_CHECKSUM_SIZE);
+                    ds->global_hash = zxc_hash_combine_rotate(ds->global_hash, bh);
+                }
+                ds->state = DS_EMIT_DECODED;
+                break;
+            }
+
+            case DS_EMIT_DECODED: {
+                const int done = ds_drain_decoded(ds, out, &produced);
+                if (!done) return (int64_t)produced;
+                ds->state = DS_NEED_BLOCK_HEADER;
+                ds->scratch_used = 0;
+                ds->scratch_need = ZXC_BLOCK_HEADER_SIZE;
+                break;
+            }
+
+            case DS_PEEK_TAIL: {
+                if (!ds_pull_scratch(ds, in)) return (int64_t)produced;
+                /* Try to interpret as a block header (SEK). */
+                zxc_block_header_t peek;
+                const int sek_rc = zxc_read_block_header(ds->scratch, ds->scratch_used, &peek);
+                if (sek_rc == ZXC_OK && peek.block_type == (uint8_t)ZXC_BLOCK_SEK) {
+                    /* SEK block: skip its payload (peek.comp_size bytes). */
+                    ds->sek_remaining = (size_t)peek.comp_size;
+                    ds->state = DS_DRAIN_SEK_PAYLOAD;
+                    break;
+                }
+                /* Not SEK -> these 8 bytes are the first 8 of the 12-byte footer. */
+                ds->state = DS_NEED_FOOTER_REST;
+                ds->scratch_need = ZXC_FILE_FOOTER_SIZE; /* keep first 8, want 4 more */
+                break;
+            }
+
+            case DS_DRAIN_SEK_PAYLOAD: {
+                const size_t avail = in->size - in->pos;
+                const size_t n = avail < ds->sek_remaining ? avail : ds->sek_remaining;
+                in->pos += n;
+                ds->sek_remaining -= n;
+                if (ds->sek_remaining > 0) return (int64_t)produced;
+                ds->state = DS_NEED_FOOTER_FULL;
+                ds->scratch_used = 0;
+                ds->scratch_need = ZXC_FILE_FOOTER_SIZE;
+                break;
+            }
+
+            case DS_NEED_FOOTER_REST:
+            case DS_NEED_FOOTER_FULL: {
+                if (!ds_pull_scratch(ds, in)) return (int64_t)produced;
+                ds->state = DS_VALIDATE_FOOTER;
+                break;
+            }
+
+            case DS_VALIDATE_FOOTER: {
+                const uint64_t declared = zxc_le64(ds->scratch);
+                if (UNLIKELY(declared != ds->total_out))
+                    return ds_set_error(ds, ZXC_ERROR_CORRUPT_DATA);
+                if (ds->opts.checksum_enabled && ds->file_has_checksum) {
+                    const uint32_t fh = zxc_le32(ds->scratch + sizeof(uint64_t));
+                    if (UNLIKELY(fh != ds->global_hash))
+                        return ds_set_error(ds, ZXC_ERROR_BAD_CHECKSUM);
+                }
+                ds->state = DS_DONE;
+                return (int64_t)produced;
+            }
+
+            case DS_DONE:
+            case DS_ERRORED:
+                return ds->state == DS_ERRORED ? ds->error_code : (int64_t)produced;
+        }
+    }
+}


### PR DESCRIPTION
Update zxc to v0.11.0 

- Add new level 6
- Better compression ratio:
> -1: -0.10 %
> -2: -0.72 %
> -3: -1.21 %
> -4: -1.14 %
> -5: -0.98 %
> -6 (new): 36.28 % (11 % smaller than -5)
- Better decompression throughput: +1% to +3%
- Include the `zxc_huffman.o` & `zxc_pstream.o` object files in the ZXC_FILES list in the Makefile to ensure all necessary components are built for the zxc codec.
