### PR TITLE
Add aceapex_cuda: optional CUDA decoder for the ACEAPEX format (ENABLE_CUDA=1)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 v2.x.y (work in progress)
 - added aceapex 1.0 (thanks to @yasha1971-coder)
+- added aceapex_cuda 0.9 — optional CUDA decoder for the aceapex format (thanks to @yasha1971-coder)
 - added memlz 0.2 beta (thanks to @rrrlasse)
 - added skim 0.1.0 (thanks to @vantorrewannes-skim)
 - added zxc 0.11.0 (thanks to @hellobertrand)

--- a/Makefile
+++ b/Makefile
@@ -737,6 +737,8 @@ ifeq "$(ENABLE_CUDA)" "1"
     CUDA_ARCH = 50 52 60 61 70 75 80 86 89
     CUDA_CXXFLAGS = -x cu -std=c++14 -O3 $(foreach ARCH, $(CUDA_ARCH), --generate-code=arch=compute_$(ARCH),code=[compute_$(ARCH),sm_$(ARCH)]) --expt-extended-lambda -forward-unknown-to-host-compiler -Wno-deprecated-gpu-targets
 
+    ACEAPEX_CUDA_FILES = lz/aceapex/cuda/aceapex_cuda.cu.o lz/aceapex/cuda/aceapex_cuda_lzbench.o
+
   ifneq "$(DONT_BUILD_NVCOMP)" "1"
     DEFINES += -DBENCH_HAS_NVCOMP
     NVCOMP_CPP_SRC = $(wildcard misc/nvcomp/src/*.cpp misc/nvcomp/src/lowlevel/*.cpp)
@@ -749,7 +751,6 @@ ifeq "$(ENABLE_CUDA)" "1"
   ifneq "$(DONT_BUILD_BSC)" "1"
     BSC_FLAGS += -DLIBBSC_CUDA_SUPPORT
     BSC_CUDA_FILES = bwt/libbsc/libbsc/bwt/libcubwt/libcubwt.cu.o bwt/libbsc/libbsc/st/st.cu.o
-    ACEAPEX_CUDA_FILES = lz/aceapex/cuda/aceapex_cuda.cu.o lz/aceapex/cuda/aceapex_cuda_lzbench.o
   endif
   endif # ifneq "$(LIBCUDART)"
 endif # ifeq "$(ENABLE_CUDA)"

--- a/Makefile
+++ b/Makefile
@@ -749,6 +749,7 @@ ifeq "$(ENABLE_CUDA)" "1"
   ifneq "$(DONT_BUILD_BSC)" "1"
     BSC_FLAGS += -DLIBBSC_CUDA_SUPPORT
     BSC_CUDA_FILES = bwt/libbsc/libbsc/bwt/libcubwt/libcubwt.cu.o bwt/libbsc/libbsc/st/st.cu.o
+    ACEAPEX_CUDA_FILES = lz/aceapex/cuda/aceapex_cuda.cu.o lz/aceapex/cuda/aceapex_cuda_lzbench.o
   endif
   endif # ifneq "$(LIBCUDART)"
 endif # ifeq "$(ENABLE_CUDA)"
@@ -756,7 +757,7 @@ endif # ifeq "$(ENABLE_CUDA)"
 
 MKDIR = mkdir -p
 
-lzbench: $(BUGGY_C_FILES) $(BUGGY_CC_FILES) $(BUGGY_CXX_FILES) $(ACEAPEX_FILES) $(BSC_C_FILES) $(BSC_CXX_FILES) $(BSC_CUDA_FILES) $(BZIP2_FILES) $(BZIP3_FILES) $(CSC_FILES) $(KANZI_FILES) $(FASTLZMA2_OBJ) $(ZSTD_FILES) $(LZSSE_FILES) $(LZFSE_FILES) $(XZ_FILES) $(LIBLZG_FILES) $(BRIEFLZ_FILES) $(LZF_FILES) $(BROTLI_FILES) $(LZMA_FILES) $(ZLING_FILES) $(QUICKLZ_FILES) $(SNAPPY_FILES) $(ZLIB_FILES) $(ZLIB_NG_FILES) $(LZHAM_FILES) $(LZO_FILES) $(UCL_FILES) $(LZ4_FILES) $(LIZARD_FILES) $(LIBDEFLATE_FILES) $(ZXC_FILES) $(MISC_FILES) $(NVCOMP_FILES) $(PPMD_FILES) $(BENCH_FILES) $(SKIM_FILE)
+lzbench: $(BUGGY_C_FILES) $(BUGGY_CC_FILES) $(BUGGY_CXX_FILES) $(ACEAPEX_FILES) $(BSC_C_FILES) $(BSC_CXX_FILES) $(BSC_CUDA_FILES) $(ACEAPEX_CUDA_FILES) $(BZIP2_FILES) $(BZIP3_FILES) $(CSC_FILES) $(KANZI_FILES) $(FASTLZMA2_OBJ) $(ZSTD_FILES) $(LZSSE_FILES) $(LZFSE_FILES) $(XZ_FILES) $(LIBLZG_FILES) $(BRIEFLZ_FILES) $(LZF_FILES) $(BROTLI_FILES) $(LZMA_FILES) $(ZLING_FILES) $(QUICKLZ_FILES) $(SNAPPY_FILES) $(ZLIB_FILES) $(ZLIB_NG_FILES) $(LZHAM_FILES) $(LZO_FILES) $(UCL_FILES) $(LZ4_FILES) $(LIZARD_FILES) $(LIBDEFLATE_FILES) $(ZXC_FILES) $(MISC_FILES) $(NVCOMP_FILES) $(PPMD_FILES) $(BENCH_FILES) $(SKIM_FILE)
 	$(CXX) $^ -o $@ $(LDFLAGS)
 	@echo Linked GCC_VERSION=$(GCC_VERSION) CLANG_VERSION=$(CLANG_VERSION) COMPILER=$(COMPILER)
 
@@ -895,6 +896,14 @@ $(BSC_C_FILES): %.o : %.c
 $(BSC_CXX_FILES): %.o : %.cpp
 	@$(MKDIR) $(dir $@)
 	$(CXX) $(CXXFLAGS) $(BSC_FLAGS) $< -c -o $@
+
+
+# ACEAPEX CUDA decoder
+lz/aceapex/cuda/aceapex_cuda.cu.o: lz/aceapex/cuda/aceapex_cuda.cu
+	$(CUDA_CC) $(CUDA_CXXFLAGS) $(CXXFLAGS) -c $< -o $@
+
+lz/aceapex/cuda/aceapex_cuda_lzbench.o: lz/aceapex/cuda/aceapex_cuda_lzbench.cpp
+	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(BSC_CUDA_FILES): %.cu.o: %.cu
 	@$(MKDIR) $(dir $@)

--- a/bench/codecs.h
+++ b/bench/codecs.h
@@ -631,6 +631,11 @@ int64_t lzbench_zxc_decompress(char *inbuf, size_t insize, char *outbuf,
     void lzbench_aceapex_deinit(char* workmem);
     int64_t lzbench_aceapex_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, codec_options_t *codec_options);
     int64_t lzbench_aceapex_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, codec_options_t *codec_options);
+#ifdef BENCH_HAS_CUDA
+    char* lzbench_aceapex_cuda_init(size_t insize, size_t level, size_t threads);
+    void lzbench_aceapex_cuda_deinit(char* workmem);
+    int64_t lzbench_aceapex_cuda_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, codec_options_t *codec_options);
+#endif
     char* lzbench_aceapex_stream_init(size_t insize, size_t level, size_t threads);
     int64_t lzbench_aceapex_stream_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, codec_options_t *codec_options);
     int64_t lzbench_aceapex_stream_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, codec_options_t *codec_options);

--- a/bench/lzbench.h
+++ b/bench/lzbench.h
@@ -170,7 +170,7 @@ static const compressor_desc_t comp_desc[] =
     { "memcpy",     "memcpy",                  0,   0,    0,  BENCH_POOL_MT, lzbench_memcpy,              lzbench_memcpy,                NULL,                    NULL },
     { "aceapex",    "aceapex 1.0",             1,   2,    0, FULL_THREADING, lzbench_aceapex_compress,     lzbench_aceapex_decompress,    lzbench_aceapex_init,    lzbench_aceapex_deinit },
 #ifdef BENCH_HAS_CUDA
-    { "aceapex_cuda","aceapex_cuda 0.9",        1,   2,    0,  BENCH_POOL_MT, lzbench_aceapex_compress,    lzbench_aceapex_cuda_decompress, lzbench_aceapex_cuda_init, lzbench_aceapex_cuda_deinit },
+    { "aceapex_cuda","aceapex_cuda 0.9",        1,   2,    0,  NO_THREADING,  lzbench_aceapex_compress,    lzbench_aceapex_cuda_decompress, lzbench_aceapex_cuda_init, lzbench_aceapex_cuda_deinit },
 #endif
     { "brieflz",    "brieflz 1.3.0",           1,   9,    0,  BENCH_POOL_MT, lzbench_brieflz_compress,    lzbench_brieflz_decompress,    lzbench_brieflz_init,    lzbench_brieflz_deinit },
     { "brotli",     "brotli 1.2.0",            0,  11,    0,  BENCH_POOL_MT, lzbench_brotli_compress,     lzbench_brotli_decompress,     NULL,                    NULL },

--- a/bench/lzbench.h
+++ b/bench/lzbench.h
@@ -169,6 +169,9 @@ static const compressor_desc_t comp_desc[] =
      // name,       name_version,    first_level,  additional_param,  compress_func,               decompress_func,               init_func,               deinit_func,             max_input_size
     { "memcpy",     "memcpy",                  0,   0,    0,  BENCH_POOL_MT, lzbench_memcpy,              lzbench_memcpy,                NULL,                    NULL },
     { "aceapex",    "aceapex 1.0",             1,   2,    0, FULL_THREADING, lzbench_aceapex_compress,     lzbench_aceapex_decompress,    lzbench_aceapex_init,    lzbench_aceapex_deinit },
+#ifdef BENCH_HAS_CUDA
+    { "aceapex_cuda","aceapex_cuda 0.9",        1,   2,    0,  BENCH_POOL_MT, lzbench_aceapex_compress,    lzbench_aceapex_cuda_decompress, lzbench_aceapex_cuda_init, lzbench_aceapex_cuda_deinit },
+#endif
     { "brieflz",    "brieflz 1.3.0",           1,   9,    0,  BENCH_POOL_MT, lzbench_brieflz_compress,    lzbench_brieflz_decompress,    lzbench_brieflz_init,    lzbench_brieflz_deinit },
     { "brotli",     "brotli 1.2.0",            0,  11,    0,  BENCH_POOL_MT, lzbench_brotli_compress,     lzbench_brotli_decompress,     NULL,                    NULL },
     { "brotli22",   "brotli 1.2.0 -d22",       0,  11,   22,  BENCH_POOL_MT, lzbench_brotli_compress,     lzbench_brotli_decompress,     NULL,                    NULL },
@@ -318,7 +321,7 @@ static const alias_desc_t alias_desc[] =
 #endif
 #ifdef BENCH_HAS_CUDA
     { "CUDA",     "Represents all CUDA-based compressors.",
-                  "memcpy/cudaMemcpy/nvcomp_lz4/bsc_cuda" },
+                  "memcpy/cudaMemcpy/nvcomp_lz4/bsc_cuda/aceapex_cuda" },
 #endif
     { "lzo1",     nullptr, "lzo1,1,99" },
     { "lzo1a",    nullptr, "lzo1a,1,99" },

--- a/lz/aceapex/aceapex_api.cpp
+++ b/lz/aceapex/aceapex_api.cpp
@@ -96,3 +96,61 @@ int64_t aceapex_decompress(
     free(l);free(o);free(n);free(c);
     return (int64_t)hdr.orig_size;
 }
+
+
+// ---- stream-level decode export for the CUDA decoder (lz/aceapex/cuda) ----
+extern "C" {
+typedef struct {
+    uint8_t *lit, *off, *len, *cmd;
+    uint64_t lit_sz, off_sz, len_sz, cmd_sz;
+    void    *boffs_vec;
+    const void *boffs;
+    size_t   num_blocks;
+    uint32_t block_size;
+    uint64_t orig_size;
+} aceapex_streams_t;
+
+int aceapex_decode_streams(const void* src, size_t src_size, aceapex_streams_t* out)
+{
+    if (!src || !out || src_size < sizeof(AetHeader)) return -1;
+    const uint8_t* p=(const uint8_t*)src;
+    AetHeader hdr; memcpy(&hdr,p,sizeof(hdr));
+    if (memcmp(hdr.magic,"ACEPX2\0\0",8)!=0) return -1;
+    p+=sizeof(hdr);
+    std::vector<BlockOffsets>* bv=new std::vector<BlockOffsets>(hdr.num_blocks);
+    memcpy(bv->data(),p,hdr.num_blocks*sizeof(BlockOffsets));
+    p+=hdr.num_blocks*sizeof(BlockOffsets);
+    uint8_t* zl=(uint8_t*)malloc(hdr.zlit_sz);
+    uint8_t* zo=(uint8_t*)malloc(hdr.zoff_sz);
+    uint8_t* zn=(uint8_t*)malloc(hdr.zlen_sz);
+    uint8_t* zc=(uint8_t*)malloc(hdr.zcmd_sz);
+    if(!zl||!zo||!zn||!zc){free(zl);free(zo);free(zn);free(zc);delete bv;return -2;}
+    memcpy(zl,p,hdr.zlit_sz); p+=hdr.zlit_sz;
+    memcpy(zo,p,hdr.zoff_sz); p+=hdr.zoff_sz;
+    memcpy(zn,p,hdr.zlen_sz); p+=hdr.zlen_sz;
+    memcpy(zc,p,hdr.zcmd_sz);
+    size_t os=*(uint64_t*)zo, ns=*(uint64_t*)zn, cs=*(uint64_t*)zc;
+    size_t ls=0; uint8_t* l=lit_decompress(zl,hdr.zlit_sz,ls);
+    if(!l){free(zl);free(zo);free(zn);free(zc);delete bv;return -2;}
+    uint8_t* o=(uint8_t*)malloc(os);
+    uint8_t* n=(uint8_t*)malloc(ns);
+    uint8_t* c=(uint8_t*)malloc(cs);
+    if(!o||!n||!c){free(o);free(n);free(c);free(l);free(zl);free(zo);free(zn);free(zc);delete bv;return -2;}
+    fse_chunked_decomp(zo,os,o); fse_chunked_decomp(zn,ns,n); fse_chunked_decomp(zc,cs,c);
+    free(zl);free(zo);free(zn);free(zc);
+    out->lit=l; out->off=o; out->len=n; out->cmd=c;
+    out->lit_sz=ls; out->off_sz=os; out->len_sz=ns; out->cmd_sz=cs;
+    out->boffs_vec=(void*)bv; out->boffs=(const void*)bv->data();
+    out->num_blocks=hdr.num_blocks; out->block_size=hdr.block_size;
+    out->orig_size=hdr.orig_size;
+    return 0;
+}
+
+void aceapex_streams_free(aceapex_streams_t* s)
+{
+    if(!s) return;
+    free(s->lit); free(s->off); free(s->len); free(s->cmd);
+    delete (std::vector<BlockOffsets>*)s->boffs_vec;
+    s->lit=s->off=s->len=s->cmd=nullptr; s->boffs_vec=nullptr; s->boffs=nullptr;
+}
+} // extern "C"

--- a/lz/aceapex/cuda/aceapex_cuda.cu
+++ b/lz/aceapex/cuda/aceapex_cuda.cu
@@ -1,0 +1,171 @@
+// =============================================================================
+// lz/aceapex/cuda/aceapex_cuda.cu
+// GPU LZ match decode for the ACEAPEX .aet format (lzbench codec variant).
+// Dependency: CUDA Runtime only. Entropy is decoded by the existing in-tree
+// CPU code (aceapex_decode_streams); this module executes the LZ match phase
+// on the GPU (warp per block; blocks are independent by format design) and
+// copies the result back to host. Kernel lineage: full_gpu_decode_v3
+// (bit-perfect on enwik9 / silesia.tar / FASTQ NA12878; see
+// github.com/yasha1971-coder/aceapex).
+// =============================================================================
+#ifdef BENCH_HAS_CUDA
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <cuda_runtime.h>
+#include "aceapex_cuda.h"
+
+#define ACK0(x) do{cudaError_t e=(x); if(e){fprintf(stderr,"aceapex_cuda CUDA err %s:%d %s\n",__FILE__,__LINE__,cudaGetErrorString(e)); return 0;} }while(0)
+
+#pragma pack(push,1)
+struct CgBlockOffsets {
+    uint64_t lit_off, off_off, len_off, cmd_off;
+    uint64_t lit_sz,  off_sz,  len_sz,  cmd_sz;
+};
+#pragma pack(pop)
+
+__device__ __forceinline__ uint32_t d_read_varint(const uint8_t* buf, uint32_t& p, uint32_t limit){
+    uint32_t val=0, shift=0;
+    while(p<limit){ uint8_t b=buf[p++]; val|=(uint32_t)(b&0x7F)<<shift; if(!(b&0x80)) return val; shift+=7; }
+    return val;
+}
+
+__global__ void cg_k_decode(const uint8_t* __restrict__ LIT, const uint8_t* __restrict__ OFF,
+                            const uint8_t* __restrict__ LEN, const uint8_t* __restrict__ CMD,
+                            const CgBlockOffsets* __restrict__ boffs, uint32_t num_blocks,
+                            uint64_t orig_size, uint32_t block_size, uint8_t* __restrict__ out)
+{
+    uint32_t gw   = (blockIdx.x*blockDim.x + threadIdx.x) >> 5;
+    uint32_t lane = threadIdx.x & 31;
+    if (gw >= num_blocks) return;
+    CgBlockOffsets bo = boffs[gw];
+    const uint8_t* lit = LIT + bo.lit_off;
+    const uint8_t* off = OFF + bo.off_off;
+    const uint8_t* len = LEN + bo.len_off;
+    const uint8_t* cmd = CMD + bo.cmd_off;
+    uint64_t base = (uint64_t)gw * block_size;
+    uint64_t rem  = orig_size - base;
+    uint32_t dst_size = (uint32_t)((rem < (uint64_t)block_size) ? rem : (uint64_t)block_size);
+    uint8_t* dst = out + base;
+    uint32_t lp=0, op=0, np=0, cp=0;
+    uint32_t rep[4]={1,2,4,8};
+    uint32_t out_pos=0;
+    uint32_t cmd_sz=(uint32_t)bo.cmd_sz, lit_sz=(uint32_t)bo.lit_sz;
+    uint32_t off_sz=(uint32_t)bo.off_sz, len_sz=(uint32_t)bo.len_sz;
+    while (out_pos < dst_size) {
+        uint32_t type=2, l=0, aux=0;
+        if (lane==0) {
+            while (cp < cmd_sz) {
+                uint8_t c = cmd[cp++];
+                if (c==0xFF){ rep[0]=1;rep[1]=2;rep[2]=4;rep[3]=8; continue; }
+                if (c<0x80){
+                    l=(uint32_t)c+1;
+                    if (lp+l>lit_sz || out_pos+l>dst_size) { type=2; break; }
+                    type=0; aux=lp; lp+=l;
+                } else if ((c&0xC0)==0x80){
+                    uint32_t ri=(c>>4)&3, lv=c&0x0F;
+                    if (lv==0x0F) lv += d_read_varint(len,np,len_sz);
+                    l=lv+6;
+                    uint32_t dist=rep[ri];
+                    if (ri>0){ for(int i=(int)ri;i>0;i--) rep[i]=rep[i-1]; rep[0]=dist; }
+                    if (!dist || dist>out_pos || out_pos+l>dst_size) { type=2; break; }
+                    type=1; aux=dist;
+                } else {
+                    uint32_t lv=(c==0xFE)? d_read_varint(len,np,len_sz) : (uint32_t)(c&0x3F);
+                    l=lv+6;
+                    uint32_t dist=d_read_varint(off,op,off_sz);
+                    rep[3]=rep[2];rep[2]=rep[1];rep[1]=rep[0];rep[0]=dist;
+                    if (!dist || dist>out_pos || out_pos+l>dst_size) { type=2; break; }
+                    type=1; aux=dist;
+                }
+                break;
+            }
+        }
+        type = __shfl_sync(0xffffffffu, type, 0);
+        l    = __shfl_sync(0xffffffffu, l,    0);
+        aux  = __shfl_sync(0xffffffffu, aux,  0);
+        if (type==2) break;
+        if (type==0) {
+            for (uint32_t i=lane; i<l; i+=32) dst[out_pos+i] = lit[aux+i];
+        } else {
+            uint32_t src = out_pos - aux;
+            if (aux >= l) { for (uint32_t i=lane; i<l; i+=32) dst[out_pos+i] = dst[src+i]; }
+            else          { for (uint32_t i=lane; i<l; i+=32) dst[out_pos+i] = dst[src + (i % aux)]; }
+        }
+        __syncwarp();
+        out_pos += l;
+    }
+}
+
+// ---- cached, grow-only device context (lzbench loops the call) --------------
+struct CgCtx {
+    uint8_t *dLit=nullptr,*dOff=nullptr,*dLen=nullptr,*dCmd=nullptr,*dOut=nullptr;
+    size_t cLit=0,cOff=0,cLen=0,cCmd=0,cOut=0;
+    CgBlockOffsets* dBO=nullptr; size_t cBO=0;
+};
+static CgCtx g_cg;
+
+static int cg_grow(void** p, size_t* cap, size_t need){
+    if(need<=*cap) return 1;
+    if(*p) cudaFree(*p);
+    *p=nullptr; *cap=0;
+    if(cudaMalloc(p,need)!=cudaSuccess){ fprintf(stderr,"aceapex_cuda: cudaMalloc %zu failed\n",(size_t)need); return 0; }
+    *cap=need; return 1;
+}
+
+extern "C" int aceapex_cg_available(void){
+    int n=0; if(cudaGetDeviceCount(&n)!=cudaSuccess) return 0;
+    return n>0?1:0;
+}
+
+extern "C" void aceapex_cg_release(void){
+    CgCtx&c=g_cg;
+    if(c.dLit)cudaFree(c.dLit); if(c.dOff)cudaFree(c.dOff);
+    if(c.dLen)cudaFree(c.dLen); if(c.dCmd)cudaFree(c.dCmd);
+    if(c.dOut)cudaFree(c.dOut); if(c.dBO)cudaFree(c.dBO);
+    c=CgCtx();
+}
+
+extern "C" int64_t aceapex_cg_match_decode(const aceapex_streams_t* s, void* dst, size_t dst_capacity)
+{
+    if(!s || !dst || s->orig_size>dst_capacity) return 0;
+    static int timing=-1;
+    if(timing<0){ const char* e=getenv("ACEAPEX_CUDA_TIMING"); timing=(e&&*e=='1')?1:0; }
+    CgCtx& c=g_cg;
+    if(!cg_grow((void**)&c.dLit,&c.cLit,s->lit_sz?s->lit_sz:1)) return 0;
+    if(!cg_grow((void**)&c.dOff,&c.cOff,s->off_sz?s->off_sz:1)) return 0;
+    if(!cg_grow((void**)&c.dLen,&c.cLen,s->len_sz?s->len_sz:1)) return 0;
+    if(!cg_grow((void**)&c.dCmd,&c.cCmd,s->cmd_sz?s->cmd_sz:1)) return 0;
+    if(!cg_grow((void**)&c.dOut,&c.cOut,s->orig_size)) return 0;
+    if(!cg_grow((void**)&c.dBO ,&c.cBO ,s->num_blocks*sizeof(CgBlockOffsets))) return 0;
+
+    cudaEvent_t e0,e1,e2,e3;
+    if(timing==1){ cudaEventCreate(&e0);cudaEventCreate(&e1);cudaEventCreate(&e2);cudaEventCreate(&e3); cudaEventRecord(e0); }
+    ACK0(cudaMemcpy(c.dLit,s->lit,s->lit_sz,cudaMemcpyHostToDevice));
+    ACK0(cudaMemcpy(c.dOff,s->off,s->off_sz,cudaMemcpyHostToDevice));
+    ACK0(cudaMemcpy(c.dLen,s->len,s->len_sz,cudaMemcpyHostToDevice));
+    ACK0(cudaMemcpy(c.dCmd,s->cmd,s->cmd_sz,cudaMemcpyHostToDevice));
+    ACK0(cudaMemcpy(c.dBO ,s->boffs,s->num_blocks*sizeof(CgBlockOffsets),cudaMemcpyHostToDevice));
+    if(timing==1) cudaEventRecord(e1);
+    const int TPB=128;
+    uint32_t grid=(uint32_t)(((uint64_t)s->num_blocks*32 + TPB-1)/TPB);
+    cg_k_decode<<<grid,TPB>>>(c.dLit,c.dOff,c.dLen,c.dCmd,c.dBO,(uint32_t)s->num_blocks,
+                              s->orig_size,s->block_size,c.dOut);
+    if(timing==1) cudaEventRecord(e2);
+    ACK0(cudaMemcpy(dst,c.dOut,s->orig_size,cudaMemcpyDeviceToHost));
+    if(timing==1){ cudaEventRecord(e3); cudaEventSynchronize(e3); }
+    ACK0(cudaDeviceSynchronize());
+    ACK0(cudaGetLastError());
+    if(timing==1){
+        float a=0,b=0,d=0,t=0;
+        cudaEventElapsedTime(&a,e0,e1); cudaEventElapsedTime(&b,e1,e2);
+        cudaEventElapsedTime(&d,e2,e3); cudaEventElapsedTime(&t,e0,e3);
+        fprintf(stderr,"[aceapex_cuda] H2D %.2fms | LZ kernel %.2fms | D2H %.2fms | GPU total %.2fms"
+                       " (kernel device-resident: %.1f GB/s)\n",
+                a,b,d,t, s->orig_size/(b*1e-3)/1e9);
+        timing=2;
+    }
+    return (int64_t)s->orig_size;
+}
+#endif // BENCH_HAS_CUDA

--- a/lz/aceapex/cuda/aceapex_cuda.h
+++ b/lz/aceapex/cuda/aceapex_cuda.h
@@ -1,0 +1,45 @@
+// =============================================================================
+// lz/aceapex/cuda/aceapex_cuda.h
+// ACEAPEX CUDA decoder for lzbench — SAME .aet format as the merged CPU codec.
+// Hybrid decompress: CPU entropy (existing in-tree lit/FSE) -> H2D -> GPU
+// warp-per-block LZ match decode -> D2H. Zero external dependencies
+// (CUDA Runtime only; no nvcomp).
+// =============================================================================
+#pragma once
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Raw decoded streams of one .aet container (filled by aceapex_decode_streams
+// in lz/aceapex/aceapex_api.cpp — same TU as the codec internals).
+typedef struct {
+    uint8_t *lit, *off, *len, *cmd;     // concatenated raw streams (malloc'd)
+    uint64_t lit_sz, off_sz, len_sz, cmd_sz;
+    void    *boffs_vec;                 // owner (opaque), freed by streams_free
+    const void *boffs;                  // BlockOffsets[num_blocks], 64B each
+    size_t   num_blocks;
+    uint32_t block_size;
+    uint64_t orig_size;
+} aceapex_streams_t;
+
+// CPU side (lz/aceapex/aceapex_api.cpp): parse .aet header + entropy-decode
+// the four streams. Returns 0 on success.
+int  aceapex_decode_streams(const void* src, size_t src_size, aceapex_streams_t* out);
+void aceapex_streams_free(aceapex_streams_t* s);
+
+// GPU side (lz/aceapex/cuda/aceapex_cuda.cu):
+// 1 if a CUDA device is usable at runtime, else 0.
+int aceapex_cg_available(void);
+// H2D(streams) -> warp-per-block LZ decode on device -> D2H(dst).
+// Returns orig_size, or 0 on error. Env ACEAPEX_CUDA_TIMING=1 prints a
+// one-time H2D/kernel/D2H breakdown to stderr.
+int64_t aceapex_cg_match_decode(const aceapex_streams_t* s, void* dst, size_t dst_capacity);
+// Free cached device buffers (deinit).
+void aceapex_cg_release(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lz/aceapex/cuda/aceapex_cuda_lzbench.cpp
+++ b/lz/aceapex/cuda/aceapex_cuda_lzbench.cpp
@@ -1,0 +1,36 @@
+// lzbench glue for the ACEAPEX CUDA decoder (same .aet as the CPU codec).
+#ifndef BENCH_REMOVE_ACEAPEX
+#ifdef BENCH_HAS_CUDA
+#include "bench/codecs.h"
+#include "aceapex_cuda.h"
+#include <cstdio>
+
+char* lzbench_aceapex_cuda_init(size_t insize, size_t level, size_t threads)
+{
+    if(!aceapex_cg_available()){
+        fprintf(stderr, "aceapex_cuda: no CUDA device available at runtime\n");
+        return NULL;
+    }
+    // delegate to the CPU codec init: compression reuses lzbench_aceapex_compress,
+    // which expects the workmem/levels prepared by lzbench_aceapex_init
+    return lzbench_aceapex_init(insize, level, threads);
+}
+
+void lzbench_aceapex_cuda_deinit(char* workmem)
+{
+    aceapex_cg_release();
+    lzbench_aceapex_deinit(workmem);
+}
+
+int64_t lzbench_aceapex_cuda_decompress(char *inbuf, size_t insize, char *outbuf,
+                                        size_t outsize, codec_options_t *codec_options)
+{
+    (void)codec_options;
+    aceapex_streams_t s;
+    if(aceapex_decode_streams(inbuf, insize, &s) != 0) return 0;
+    int64_t r = aceapex_cg_match_decode(&s, outbuf, outsize);
+    aceapex_streams_free(&s);
+    return r;
+}
+#endif // BENCH_HAS_CUDA
+#endif // BENCH_REMOVE_ACEAPEX


### PR DESCRIPTION
Follow-up to #288 (CUDA accepted in principle). Adds a CUDA decoder variant for the already-merged ACEAPEX codec — same `.aet` format, same compressor, GPU-accelerated decode.

**What it does:** `decompress` = in-tree CPU entropy stage (unchanged) + GPU warp-per-block LZ match decode (one warp per independent block) + transfers. Compression reuses `lzbench_aceapex_compress` unchanged; output is byte-identical to `aceapex`.

**Dependencies:** CUDA Runtime only (no nvcomp, no new libraries). All code under `#ifdef BENCH_HAS_CUDA` in `lz/aceapex/cuda/`. Disabled by default; built only with `make ENABLE_CUDA=1`. Zero impact otherwise (verified: CPU-only build is green, `aceapex` unaffected).

**Fallback:** the already-merged `aceapex` CPU codec decodes the same files (same format).

**Verified:** bit-perfect via lzbench's own verification on enwik9, silesia.tar, and FASTQ (NA12878), on H100 SXM + CUDA 12.4. CI has no GPU runners — same situation as `nvcomp_lz4` / `bsc_cuda`.

**Honest benchmarks** (lzbench 2.2.1, H100 SXM + Xeon 8468; decompress MB/s, level 1):

| dataset | aceapex (1 thread) | aceapex_cuda | aceapex (-T8) |
|---|---|---|---|
| enwik9 1 GB | 655 | 1463 | 5109 |
| silesia.tar | 803 | 1403 | 5594 |
| FASTQ 1 GB | 1840 | 4373 | 13363 |

Ratio is identical across all three (same format). The CUDA path is **1.75–2.4× faster than single-threaded CPU decode**. Note that **multi-threaded CPU decode (`-T8`) is faster in this host↔host harness** — the bottleneck is the serial entropy stage plus the device→host copy, not the kernel. The GPU path targets **GPU-resident consumers**, where the result stays on device (no D2H): the match kernel sustains tens of GB/s, and the format's block independence allows position-invariant random access into compressed data. To my knowledge this is the first GPU LZ77 decode path in lzbench.

Happy to adjust structure, naming, or flags to match repo conventions.