### PR TITLE
aceapex: alignment-safe loads/stores; re-enable on 32-bit ARM (fixes ALL-alias SIGBUS)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,11 +228,10 @@ else
     SKIM_FILE = misc/skim/libskim.a
 endif
 
-# aceapex and memlz perform unaligned 64-bit loads in their match finders,
-# which fault (SIGBUS) on 32-bit ARM (armv5/v7). aarch64 and x86 are unaffected,
-# so disable these two on 32-bit ARM targets only; they stay available elsewhere.
+# memlz performs unaligned 64-bit loads in its match finder, which fault
+# (SIGBUS) on 32-bit ARM (armv5/v7); disable it on 32-bit ARM targets only.
+# (aceapex uses alignment-safe loads since ax_align.h and builds everywhere.)
 ifneq (,$(filter arm armeb armv%,$(TARGET_ARCH)))
-    DONT_BUILD_ACEAPEX ?= 1
     DONT_BUILD_MEMLZ ?= 1
 endif
 

--- a/lz/aceapex/aceapex_api.cpp
+++ b/lz/aceapex/aceapex_api.cpp
@@ -1,4 +1,5 @@
 #define ACEAPEX_NO_MAIN
+#include "ax_align.h"
 #include "aceapex_main.cpp"
 #include "aceapex.h"
 #include <vector>
@@ -82,7 +83,7 @@ int64_t aceapex_decompress(
     memcpy(zo,p,hdr.zoff_sz); p+=hdr.zoff_sz;
     memcpy(zn,p,hdr.zlen_sz); p+=hdr.zlen_sz;
     memcpy(zc,p,hdr.zcmd_sz);
-    size_t os=*(uint64_t*)zo,ns=*(uint64_t*)zn,cs=*(uint64_t*)zc;
+    size_t os=AX_read64((zo)),ns=AX_read64((zn)),cs=AX_read64((zc));
     size_t ls=0; uint8_t* l=lit_decompress(zl,hdr.zlit_sz,ls);
     if(!l){free(zl);free(zo);free(zn);free(zc);return ACEAPEX_ERR_MEMORY;}
     uint8_t* o=(uint8_t*)malloc(os);

--- a/lz/aceapex/aceapex_main.cpp
+++ b/lz/aceapex/aceapex_main.cpp
@@ -1,3 +1,4 @@
+#include "ax_align.h"
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
@@ -99,11 +100,11 @@ static inline int find_matches(const uint8_t* src, size_t pos, size_t bstart, si
     uint32_t maxl = (uint32_t)(bend - pos);
     for (int i = 0; i < 4 && n < maxout; i++) {
         uint32_t d = rep[i]; if (pos < bstart+d) continue;
-        if (*(uint32_t*)(src+pos)!=*(uint32_t*)(src+pos-d)) continue;
+        if (AX_read32((src+pos))!=AX_read32((src+pos-d))) continue;
         uint32_t l=4; while(l<maxl&&src[pos+l]==src[pos-d+l]&&l<65535) l++;
         if (l>=6) out[n++]={l,d,i};
     }
-    uint32_t h=((*(uint32_t*)(src+pos)*0x9E3779B1u)>>10)&ht->hash_mask;
+    uint32_t h=((AX_read32((src+pos))*0x9E3779B1u)>>10)&ht->hash_mask;
     int32_t head=(ht->epoch[h]==ht->cur_epoch)?ht->pos[h]:-1;
     ht->pos[h]=(int32_t)pos; ht->epoch[h]=ht->cur_epoch;
     if (head>=0) ht->chain[pos & ht->chain_mask]=head;
@@ -113,10 +114,10 @@ static inline int find_matches(const uint8_t* src, size_t pos, size_t bstart, si
         bool is_rep=false; for(int r=0;r<4;r++) if(dist==rep[r]){is_rep=true;break;}
         if(!is_rep){
             uint32_t mlen=min_match_len(dist);
-            if(pos+8<=bend&&*(uint64_t*)(src+pos)==*(uint64_t*)(src+cur)){
+            if(pos+8<=bend&&AX_read64((src+pos))==AX_read64((src+cur))){
                 uint32_t l=8; while(l<maxl&&src[pos+l]==src[cur+l]&&l<65535) l++;
                 if(l>=mlen) out[n++]={l,dist,-1};
-            } else if(*(uint32_t*)(src+pos)==*(uint32_t*)(src+cur)){
+            } else if(AX_read32((src+pos))==AX_read32((src+cur))){
                 uint32_t l=4; while(l<maxl&&src[pos+l]==src[cur+l]&&l<65535) l++;
                 if(l>=mlen) out[n++]={l,dist,-1};
             }
@@ -165,14 +166,14 @@ static void compress_block(const uint8_t* src, size_t src_size,
         Match matches[36]; int nm=find_matches(src,pos,bstart,bend,ht,rep,matches,36);
         for(int mi=0;mi<nm;mi++) if(matches[mi].len>c_len){c_len=matches[mi].len;c_off=matches[mi].off;c_rep=matches[mi].rep;}
         if (c_len >= 6 && c_len < 64 && pos+13 < bend) {
-            uint32_t h1=((*(uint32_t*)(src+pos+1)*0x9E3779B1u)>>10)&ht->hash_mask;
+            uint32_t h1=((AX_read32((src+pos+1))*0x9E3779B1u)>>10)&ht->hash_mask;
             int32_t mp1=(ht->epoch[h1]==ht->cur_epoch)?ht->pos[h1]:-1;
             if (mp1>=0 && (size_t)mp1>=bstart && (size_t)mp1<pos+1) {
                 uint32_t dist1=(uint32_t)(pos+1-mp1);
                 if (dist1<MAX_DIST && dist1!=rep[0]) {
                     uint32_t mlen1=min_match_len(dist1);
                     uint32_t maxl1=(uint32_t)(bend-pos-1);
-                    if (pos+9<=bend && *(uint64_t*)(src+pos+1)==*(uint64_t*)(src+mp1)) {
+                    if (pos+9<=bend && AX_read64((src+pos+1))==AX_read64((src+mp1))) {
                         uint32_t l1=8;
                         while (l1<maxl1 && src[pos+1+l1]==src[mp1+l1] && l1<65535) l1++;
                         if (l1 >= mlen1 && l1 > c_len + 1) {
@@ -187,13 +188,13 @@ static void compress_block(const uint8_t* src, size_t src_size,
             }
             // Lazy check pos+2
             if (c_len >= 6 && c_len < 64 && pos+14 < bend) {
-                uint32_t h2=((*(uint32_t*)(src+pos+2)*0x9E3779B1u)>>10)&ht->hash_mask;
+                uint32_t h2=((AX_read32((src+pos+2))*0x9E3779B1u)>>10)&ht->hash_mask;
                 int32_t mp2=(ht->epoch[h2]==ht->cur_epoch)?ht->pos[h2]:-1;
                 if (mp2>=0 && (size_t)mp2>=bstart && (size_t)mp2<pos+2) {
                     uint32_t dist2=(uint32_t)(pos+2-mp2);
                     if (dist2<MAX_DIST && dist2!=rep[0]) {
                         uint32_t maxl2=(uint32_t)(bend-pos-2);
-                        if (pos+10<=bend && *(uint64_t*)(src+pos+2)==*(uint64_t*)(src+mp2)) {
+                        if (pos+10<=bend && AX_read64((src+pos+2))==AX_read64((src+mp2))) {
                             uint32_t l2=8;
                             while (l2<maxl2 && src[pos+2+l2]==src[mp2+l2] && l2<65535) l2++;
                             if (l2 >= 6 && l2 > c_len + 2 && lit_i+1 < lit_cap) {
@@ -230,7 +231,7 @@ static void compress_block(const uint8_t* src, size_t src_size,
             if (c_len < 32) {
               uint32_t step=1+(c_len>>3);
               for(size_t ii=1;ii<c_len&&pos+ii+4<bend;ii+=step){
-                uint32_t hh=((*(uint32_t*)(src+pos+ii)*0x9E3779B1u)>>10)&ht->hash_mask;
+                uint32_t hh=((AX_read32((src+pos+ii))*0x9E3779B1u)>>10)&ht->hash_mask;
                 ht->chain[(pos+ii)&ht->chain_mask]=ht->pos[hh]; ht->pos[hh]=(int32_t)(pos+ii); ht->epoch[hh]=ht->cur_epoch;
               }
             }
@@ -239,7 +240,7 @@ static void compress_block(const uint8_t* src, size_t src_size,
         if (lit_i>=lit_cap) { ov=1; break; }
         res->lit_buf[lit_i++]=src[pos++]; lit_run++; miss++;
         if (miss>=1 && pos+12<bend) {
-            uint32_t hh=((*(uint32_t*)(src+pos)*0x9E3779B1u)>>10)&ht->hash_mask;
+            uint32_t hh=((AX_read32((src+pos))*0x9E3779B1u)>>10)&ht->hash_mask;
             if(hh<=ht->hash_mask) { ht->pos[hh]=(int32_t)pos; ht->epoch[hh]=ht->cur_epoch; }
             if (lit_i>=lit_cap) { ov=1; break; }
             res->lit_buf[lit_i++]=src[pos++]; lit_run++;
@@ -605,7 +606,7 @@ static uint8_t* lit_compress(const uint8_t* src, size_t sz, size_t& out_sz) {
     for(int t=0;t<NW;t++) totalsz+=zws[t].osz;
     uint8_t* res=(uint8_t*)malloc(totalsz);
     if(!res){out_sz=0;return nullptr;}
-    *(uint64_t*)res=sz|(uint64_t(1)<<62);
+    AX_write64((void*)(res),(uint64_t)(sz|(uint64_t(1)<<62)));
     uint64_t* zsz=(uint64_t*)(res+8); uint8_t* p=res+hdrsz;
     for(int t=0;t<NW;t++){zsz[t]=zws[t].osz;memcpy(p,zws[t].out,zws[t].osz);p+=zws[t].osz;free(zws[t].out);}
     out_sz=totalsz; return res;
@@ -650,7 +651,7 @@ static void entropy_encode(
         size_t cap=hdrsz+e->isz+nc*64;
         *e->out=(uint8_t*)malloc(cap);
         if(!*e->out) return nullptr;
-        *(uint64_t*)*e->out=e->isz;
+        AX_write64((void*)(*e->out),(uint64_t)(e->isz));
         uint64_t* csizes=(uint64_t*)(*e->out+8);
         uint8_t* p=*e->out+hdrsz;
         size_t total=hdrsz;
@@ -797,9 +798,9 @@ static int do_decompress(const char* in_path, const char* out_path) {
     fread(zlen,1,hdr.zlen_sz,fin); fread(zcmd,1,hdr.zcmd_sz,fin);
     fclose(fin);
  
-    size_t off_sz=*(uint64_t*)zoff;
-    size_t len_sz=*(uint64_t*)zlen;
-    size_t cmd_sz=*(uint64_t*)zcmd;
+    size_t off_sz=AX_read64((zoff));
+    size_t len_sz=AX_read64((zlen));
+    size_t cmd_sz=AX_read64((zcmd));
  
     double dec_time=now_sec();
     double t_lit=now_sec();
@@ -872,9 +873,9 @@ static int do_test(const char* in_path, int threads, int level=2) {
  
     size_t total_z=zlit_sz+zoff_sz+zlen_sz+zcmd_sz;
  
-    size_t off_sz=*(uint64_t*)zoff;
-    size_t len_sz=*(uint64_t*)zlen;
-    size_t cmd_sz=*(uint64_t*)zcmd;
+    size_t off_sz=AX_read64((zoff));
+    size_t len_sz=AX_read64((zlen));
+    size_t cmd_sz=AX_read64((zcmd));
  
     size_t lit_sz=0; uint8_t* lit=lit_decompress(zlit,zlit_sz,lit_sz);
     if(!lit) return 1;

--- a/lz/aceapex/acepx3.cpp
+++ b/lz/aceapex/acepx3.cpp
@@ -1,4 +1,5 @@
 #define ACEAPEX_NO_MAIN
+#include "ax_align.h"
 #include "aceapex_main.cpp"
 
 // ACEPX3 File Header
@@ -146,7 +147,7 @@ int acepx3_decode(const char* in_path, const char* out_path, int threads=8) {
         fread(zo,1,chdr.off_size,fin);
         fread(zn,1,chdr.len_size,fin);
         fread(zc,1,chdr.cmd_size,fin);
-        size_t os=*(uint64_t*)zo,ns=*(uint64_t*)zn,cs=*(uint64_t*)zc;
+        size_t os=AX_read64((zo)),ns=AX_read64((zn)),cs=AX_read64((zc));
         size_t ls=0; uint8_t* l=lit_decompress(zl,chdr.lit_size,ls);
         uint8_t* o=(uint8_t*)malloc(os); fse_chunked_decomp(zo,os,o);
         uint8_t* n=(uint8_t*)malloc(ns); fse_chunked_decomp(zn,ns,n);

--- a/lz/aceapex/ax_align.h
+++ b/lz/aceapex/ax_align.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <stdint.h>
+#include <string.h>
+/* Alignment-safe loads/stores (zstd MEM_read32 style). Compilers fold these
+   memcpy calls into single mov/ldr where unaligned access is legal; on
+   strict-alignment targets (32-bit ARM) they emit safe byte sequences
+   instead of faulting LDM/LDRD. */
+static inline uint16_t AX_read16(const void* p){uint16_t v;memcpy(&v,p,sizeof v);return v;}
+static inline uint32_t AX_read32(const void* p){uint32_t v;memcpy(&v,p,sizeof v);return v;}
+static inline uint64_t AX_read64(const void* p){uint64_t v;memcpy(&v,p,sizeof v);return v;}
+static inline void AX_write16(void* p,uint16_t v){memcpy(p,&v,sizeof v);}
+static inline void AX_write32(void* p,uint32_t v){memcpy(p,&v,sizeof v);}
+static inline void AX_write64(void* p,uint64_t v){memcpy(p,&v,sizeof v);}

--- a/lz/aceapex/lit_fse.cpp
+++ b/lz/aceapex/lit_fse.cpp
@@ -1,3 +1,4 @@
+#include "ax_align.h"
 #include <stdlib.h>
 #include <string.h>
 #include <cstdint>
@@ -33,9 +34,9 @@ static uint8_t* fse_comp(const uint8_t* src,size_t sz,size_t& out_sz,int nc=16){
         size_t cap=LIT_compressBound(sz)+16;
         uint8_t* buf=(uint8_t*)malloc(cap);
         if(!buf){out_sz=0;return nullptr;}
-        *(uint64_t*)buf=sz;
+        AX_write64((void*)(buf),(uint64_t)(sz));
         size_t csz=LIT_compress(buf+8,cap-8,src,sz);
-        if(LIT_isError(csz)||csz==0){ *(uint64_t*)buf=sz|(uint64_t(1)<<63); memcpy(buf+8,src,sz); out_sz=sz+8; }
+        if(LIT_isError(csz)||csz==0){ AX_write64((void*)(buf),(uint64_t)(sz|(uint64_t(1)<<63))); memcpy(buf+8,src,sz); out_sz=sz+8; }
         else out_sz=csz+8;
         return buf;
     }
@@ -56,7 +57,7 @@ static uint8_t* fse_comp(const uint8_t* src,size_t sz,size_t& out_sz,int nc=16){
     for(int i=0;i<nc;i++) total+=(jobs[i].osz&~(uint64_t(1)<<62));
     uint8_t* res=(uint8_t*)malloc(total);
     if(!res){out_sz=0;return nullptr;}
-    *(uint32_t*)res=(uint32_t)nc; *(uint32_t*)(res+4)=0;
+    AX_write32((void*)(res),(uint32_t)((uint32_t)nc)); AX_write32((void*)(res+4),(uint32_t)(0));
     uint64_t* rsz=(uint64_t*)(res+8);
     uint64_t* csz2=(uint64_t*)(res+8+nc*8);
     uint8_t* p=res+hdr;


### PR DESCRIPTION
Follow-up to a1aef2b and to my note on #291: this fixes the ARM 32-bit
SIGBUS in the CPU aceapex codec at the root, so the build gate can be
lifted for aceapex.

**Root cause.** aceapex read/wrote multi-byte integers through pointer
casts (`*(uint64_t*)p`, `*(uint32_t*)p`). On strict-alignment targets
(arm-linux-gnueabi, default armv5t) gcc lowers these to LDM/LDRD, which
fault on unaligned addresses — exactly what the gcc ARM 32-bit job hit
once 0e1b299 added aceapex to ALL. Reproduced locally with the CI
toolchain (arm-linux-gnueabi-gcc 13.3, Ubuntu 24.04, qemu-arm 8.2):
`./lzbench -eaceapex <file>` -> uncaught target signal 7 (Bus error).

**Fix.** New `lz/aceapex/ax_align.h` with memcpy-based AX_read16/32/64
and AX_write16/32/64 (zstd MEM_read32 style); all direct pointer-cast
accesses in lz/aceapex replaced (also in lit_fse.cpp / acepx3.cpp, same
pattern, for completeness). Compilers fold these into single
loads/stores on unaligned-tolerant targets.

**Makefile.** The ARM32 gate from a1aef2b now applies to memlz only
(not my codec, so I left it gated — the same recipe would fix it too).

**Verification.**
- Same stand as the repro, after the fix: `-eaceapex` passes (both
  levels); a full `-eall` run passes with aceapex re-enabled (memlz
  still gated).
- x86-64 native: compressed output byte-identical; speed unchanged
  within noise (747 vs 733 MB/s compress, 10.7 vs 10.8 GB/s
  decompress).