### PR TITLE
openzl: Improve compressor settings

### DIFF
--- a/bench/lz_codecs.cpp
+++ b/bench/lz_codecs.cpp
@@ -1708,6 +1708,8 @@ char* lzbench_openzl_init_zstd(size_t insize, size_t level, size_t windowLog)
       abort();
     }
 
+    // Valid compression levels range from -99 (?) to -1 and from 1 to 22.
+    // Level 0 requests the default behaviour, which corresponds to level 6.
     report = ZL_Compressor_setParameter(params->cgraph, ZL_CParam_compressionLevel, level);
     if (ZL_isError(report)) {
       printf("OpenZL initialisation error: %s\n", ZL_Compressor_getErrorContextString(params->cgraph, report));
@@ -1728,6 +1730,8 @@ char* lzbench_openzl_init_lz4(size_t insize, size_t level, size_t windowLog)
       abort();
     }
 
+    // Valid compression levels range from -99 (?) to -1 and from 1 to 12.
+    // Level 0 requests the default behaviour, which corresponds to level 6.
     report = ZL_Compressor_setParameter(params->cgraph, ZL_CParam_compressionLevel, level);
     if (ZL_isError(report)) {
       printf("OpenZL initialisation error: %s\n", ZL_Compressor_getErrorContextString(params->cgraph, report));

--- a/bench/lz_codecs.cpp
+++ b/bench/lz_codecs.cpp
@@ -1708,8 +1708,10 @@ char* lzbench_openzl_init_zstd(size_t insize, size_t level, size_t windowLog)
       abort();
     }
 
-    // Valid compression levels range from -99 (?) to -1 and from 1 to 22.
+    // OpenZL does not validate the compression level; it is forwarded to zstd, which
+    // clamps it to [ZSTD_minCLevel(), ZSTD_maxCLevel()], i.e. [-131072, 22].
     // Level 0 requests the default behaviour, which corresponds to level 6.
+    // lzbench limits the range to [-99, 22]; -99 is an arbitrary practical floor.
     report = ZL_Compressor_setParameter(params->cgraph, ZL_CParam_compressionLevel, level);
     if (ZL_isError(report)) {
       printf("OpenZL initialisation error: %s\n", ZL_Compressor_getErrorContextString(params->cgraph, report));
@@ -1730,8 +1732,12 @@ char* lzbench_openzl_init_lz4(size_t insize, size_t level, size_t windowLog)
       abort();
     }
 
-    // Valid compression levels range from -99 (?) to -1 and from 1 to 12.
+    // OpenZL does not validate the compression level: the lz4 graph maps levels <= 1 to
+    // LZ4_compress_fast() with acceleration = 1 - level (lz4 clamps the acceleration to
+    // LZ4_ACCELERATION_MAX, i.e. 65537), and levels >= 2 to LZ4_compress_HC(), whose
+    // maximum is LZ4HC_CLEVEL_MAX, i.e. 12.
     // Level 0 requests the default behaviour, which corresponds to level 6.
+    // lzbench limits the range to [-99, 12]; -99 is an arbitrary practical floor.
     report = ZL_Compressor_setParameter(params->cgraph, ZL_CParam_compressionLevel, level);
     if (ZL_isError(report)) {
       printf("OpenZL initialisation error: %s\n", ZL_Compressor_getErrorContextString(params->cgraph, report));

--- a/bench/lzbench.h
+++ b/bench/lzbench.h
@@ -237,18 +237,18 @@ static const compressor_desc_t comp_desc[] =
     { "lzvn",       "lzvn 2017-03-08",         0,   0,    0,  BENCH_POOL_MT, lzbench_lzvn_compress,       lzbench_lzvn_decompress,       lzbench_lzvn_init,       lzbench_lzvn_deinit },
     { "memlz",      "memlz 0.2 beta",          0,   0,    0,  BENCH_POOL_MT, lzbench_memlz_compress,      lzbench_memlz_decompress,      lzbench_memlz_init,      lzbench_memlz_deinit },
     { "nvcomp_lz4", "nvcomp_lz4 2.2.0",        0,   7,    0,  BENCH_POOL_MT, lzbench_nvcomp_compress,     lzbench_nvcomp_decompress,     lzbench_nvcomp_init,     lzbench_nvcomp_deinit },
-    { "openzl_u8",  "openzl 0.2.0 -p u8",       0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(uint8_t),  lzbench_openzl_deinit },
-    { "openzl_i8",  "openzl 0.2.0 -p i8",       0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(int8_t),  lzbench_openzl_deinit },
-    { "openzl_le_u16",  "openzl 0.2.0 -p le-u16",   0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(uint16_t),  lzbench_openzl_deinit },
-    { "openzl_le_i16",  "openzl 0.2.0 -p le-i16",   0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(int16_t),  lzbench_openzl_deinit },
-    { "openzl_le_u32",  "openzl 0.2.0 -p le-u32",   0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(uint32_t),  lzbench_openzl_deinit },
-    { "openzl_le_i32",  "openzl 0.2.0 -p le-i32",   0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(int32_t),  lzbench_openzl_deinit },
-    { "openzl_le_u64",  "openzl 0.2.0 -p le-u64",   0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(uint64_t),  lzbench_openzl_deinit },
-    { "openzl_le_i64",  "openzl 0.2.0 -p le-i64",   0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(int64_t),  lzbench_openzl_deinit },
-    { "openzl_serial",  "openzl 0.2.0 -p serial",   0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_serial,  lzbench_openzl_deinit },
-    { "openzl_generic", "openzl 0.2.0 'generic'",   0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_generic, lzbench_openzl_deinit },
-    { "openzl_zstd",    "openzl 0.2.0 'zstd'",      1,  22,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_zstd,    lzbench_openzl_deinit },
-    { "openzl_lz4",     "openzl 0.2.0 'lz4'",      -5,   9,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_lz4,     lzbench_openzl_deinit },
+    { "openzl_u8",      "openzl 0.2.0 -p u8",      0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(uint8_t),  lzbench_openzl_deinit },
+    { "openzl_i8",      "openzl 0.2.0 -p i8",      0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(int8_t),   lzbench_openzl_deinit },
+    { "openzl_le_u16",  "openzl 0.2.0 -p le-u16",  0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(uint16_t), lzbench_openzl_deinit },
+    { "openzl_le_i16",  "openzl 0.2.0 -p le-i16",  0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(int16_t),  lzbench_openzl_deinit },
+    { "openzl_le_u32",  "openzl 0.2.0 -p le-u32",  0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(uint32_t), lzbench_openzl_deinit },
+    { "openzl_le_i32",  "openzl 0.2.0 -p le-i32",  0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(int32_t),  lzbench_openzl_deinit },
+    { "openzl_le_u64",  "openzl 0.2.0 -p le-u64",  0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(uint64_t), lzbench_openzl_deinit },
+    { "openzl_le_i64",  "openzl 0.2.0 -p le-i64",  0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(int64_t),  lzbench_openzl_deinit },
+    { "openzl_serial",  "openzl 0.2.0 -p serial",  0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_serial,            lzbench_openzl_deinit },
+    { "openzl_generic", "openzl 0.2.0 'generic'",  0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_generic,           lzbench_openzl_deinit },
+    { "openzl_zstd",    "openzl 0.2.0 'zstd'",   -99,  22,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_zstd,              lzbench_openzl_deinit },
+    { "openzl_lz4",     "openzl 0.2.0 'lz4'",    -99,  12,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_lz4,               lzbench_openzl_deinit },
     { "ppmd8",      "ppmd8 26.01",             1,   9,    0,  BENCH_POOL_MT, lzbench_ppmd_compress,       lzbench_ppmd_decompress,       NULL,                    NULL },
     { "quicklz",    "quicklz 1.5.1 beta 7",    1,   3,    0,  BENCH_POOL_MT, lzbench_quicklz_compress,    lzbench_quicklz_decompress,    NULL,                    NULL },
     { "skim",       "skim 0.1.0",              0,   0,    0,  BENCH_POOL_MT, lzbench_skim_compress,       lzbench_skim_decompress,       lzbench_skim_init,       lzbench_skim_deinit },
@@ -334,6 +334,13 @@ static const alias_desc_t alias_desc[] =
     { "LZO",      "Represents all LZO compressor variants.",
                   "lzo1/lzo1a/lzo1b/lzo1c/lzo1f/lzo1x/lzo1y/lzo1z/lzo2a" },
 #endif
+#ifndef BENCH_REMOVE_OPENZL
+    { "OPENZL",   "Represents all OpenZL compressor variants.",
+                  "openzl_u8/openzl_i8/openzl_le_u16/openzl_le_i16/openzl_le_u32/openzl_le_i32/openzl_le_u64/openzl_le_i64/" \
+                  "openzl_serial/openzl_generic/" \
+                  "openzl_zstd,-99,-90,-80,-70,-60,-50,-40,-30,-20,-10,-8,-6,-5,-4,-3,-2,-1,1,2,3,4,5,6,8,10,12,14,16,18,20,22/" \
+                  "openzl_lz4,-99,-90,-80,-70,-60,-50,-40,-30,-20,-10,-8,-6,-5,-4,-3,-2,-1,1,2,3,4,5,6,7,8,9,10,11,12/" },
+#endif
 #if !defined(BENCH_REMOVE_BSC)
     { "BSC",      "Represents all bsc compressor variants.",
                   "bsc0/bsc1/bsc2/bsc3/bsc4/bsc5/bsc6" },
@@ -353,6 +360,8 @@ static const alias_desc_t alias_desc[] =
     { "lzo1f",    nullptr, "lzo1f,1,999" },
     { "lzo1x",    nullptr, "lzo1x,1,11,12,15,999" },
     { "lzo1y",    nullptr, "lzo1y,1,999" },
+    { "openzl_zstd", nullptr, "openzl_zstd,-99,-90,-80,-70,-60,-50,-40,-30,-20,-10,-8,-6,-5,-4,-3,-2,-1,1,2,3,4,5,6,8,10,12,14,16,18,20,22" },
+    { "openzl_lz4",  nullptr, "openzl_lz4,-99,-90,-80,-70,-60,-50,-40,-30,-20,-10,-8,-6,-5,-4,-3,-2,-1,1,2,3,4,5,6,7,8,9,10,11,12" },
 };
 
 const long int LZBENCH_ALIASES_COUNT = sizeof(alias_desc)/sizeof(alias_desc[0]);

--- a/bench/lzbench.h
+++ b/bench/lzbench.h
@@ -337,9 +337,7 @@ static const alias_desc_t alias_desc[] =
 #ifndef BENCH_REMOVE_OPENZL
     { "OPENZL",   "Represents all OpenZL compressor variants.",
                   "openzl_u8/openzl_i8/openzl_le_u16/openzl_le_i16/openzl_le_u32/openzl_le_i32/openzl_le_u64/openzl_le_i64/" \
-                  "openzl_serial/openzl_generic/" \
-                  "openzl_zstd,-99,-90,-80,-70,-60,-50,-40,-30,-20,-10,-8,-6,-5,-4,-3,-2,-1,1,2,3,4,5,6,8,10,12,14,16,18,20,22/" \
-                  "openzl_lz4,-99,-90,-80,-70,-60,-50,-40,-30,-20,-10,-8,-6,-5,-4,-3,-2,-1,1,2,3,4,5,6,7,8,9,10,11,12/" },
+                  "openzl_serial/openzl_generic/openzl_zstd/openzl_lz4" },
 #endif
 #if !defined(BENCH_REMOVE_BSC)
     { "BSC",      "Represents all bsc compressor variants.",
@@ -360,8 +358,10 @@ static const alias_desc_t alias_desc[] =
     { "lzo1f",    nullptr, "lzo1f,1,999" },
     { "lzo1x",    nullptr, "lzo1x,1,11,12,15,999" },
     { "lzo1y",    nullptr, "lzo1y,1,999" },
+#ifndef BENCH_REMOVE_OPENZL
     { "openzl_zstd", nullptr, "openzl_zstd,-99,-90,-80,-70,-60,-50,-40,-30,-20,-10,-8,-6,-5,-4,-3,-2,-1,1,2,3,4,5,6,8,10,12,14,16,18,20,22" },
     { "openzl_lz4",  nullptr, "openzl_lz4,-99,-90,-80,-70,-60,-50,-40,-30,-20,-10,-8,-6,-5,-4,-3,-2,-1,1,2,3,4,5,6,7,8,9,10,11,12" },
+#endif
 };
 
 const long int LZBENCH_ALIASES_COUNT = sizeof(alias_desc)/sizeof(alias_desc[0]);


### PR DESCRIPTION
Improve the compression ranges for `openzl_lz4` and `openzl_zstd`, and add the `OPENZL` alias.