### PR TITLE
Add misa77 0.2.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 v2.x.y
 - added OpenZL v0.2.0 (thanks to @fwyzard)
 - updated zxc to 0.12.0
+- added misa77 0.2.0 (by @welcome-to-the-sunny-side)
 
 v2.3 (Jun 15, 2026)
 - improvement: Reorganized compressor alias groups by type — ALL is now a composite of LZ /

--- a/Makefile
+++ b/Makefile
@@ -888,6 +888,40 @@ else
     $(ZXC_DIR)/%_neon.o: $(ZXC_DIR)/%.c ; $(CMD_BUILD_ZXC)
 endif
 
+
+# misa77 targets 64-bit little-endian systems and needs C++20.
+MISA77_OK := $(shell printf 'int main(){static_assert(__BYTE_ORDER__==__ORDER_LITTLE_ENDIAN__);static_assert(sizeof(void*)==8);return 0;}' | $(CXX) -std=c++20 -fsyntax-only -x c++ - 2>/dev/null && echo ok)
+ifneq ($(MISA77_OK),ok)
+    DONT_BUILD_MISA77 ?= 1
+endif
+
+ifeq "$(DONT_BUILD_MISA77)" "1"
+    DEFINES += -DBENCH_REMOVE_MISA77
+else
+    MISA77_DIR = lz/misa77
+    MISA77_INC = -I$(MISA77_DIR)/include -I$(MISA77_DIR)/src
+    # always built:
+    MISA77_FILES  = $(MISA77_DIR)/src/compress.o $(MISA77_DIR)/src/decompress.o
+    MISA77_FILES += $(MISA77_DIR)/src/experimental/ecompress.o
+    MISA77_FILES += $(MISA77_DIR)/src/isa/target_portable.o
+    MISA77_FILES += $(MISA77_DIR)/src/experimental/isa/etarget_portable.o
+    # 64-bit x86 only:
+    ifneq (,$(filter x86_64% amd64%,$(TARGET_ARCH)))
+        MISA77_FILES += $(MISA77_DIR)/src/isa/target_sse2.o $(MISA77_DIR)/src/isa/target_avx2.o
+        MISA77_FILES += $(MISA77_DIR)/src/experimental/isa/etarget_sse2.o $(MISA77_DIR)/src/experimental/isa/etarget_avx2.o
+    endif
+
+    CMD_BUILD_MISA77 = @$(MKDIR) $(dir $@) && $(CXX) $(CXXFLAGS) -std=c++20 $(MISA77_INC) $(MISA77_FLAGS) $< -c -o $@
+
+    $(MISA77_DIR)/%_avx2.o: MISA77_FLAGS = -mavx2
+    $(MISA77_DIR)/%_avx2.o: $(MISA77_DIR)/%.cpp ; $(CMD_BUILD_MISA77)
+
+    $(MISA77_DIR)/%_sse2.o: MISA77_FLAGS = -msse2
+    $(MISA77_DIR)/%_sse2.o: $(MISA77_DIR)/%.cpp ; $(CMD_BUILD_MISA77)
+
+    $(MISA77_DIR)/%.o: $(MISA77_DIR)/%.cpp ; $(CMD_BUILD_MISA77)
+endif
+
 # Symmetric codecs
 ifeq "$(DONT_BUILD_BSC)" "1"
     DEFINES += -DBENCH_REMOVE_BSC
@@ -1051,7 +1085,7 @@ endif # ifeq "$(ENABLE_CUDA)"
 
 MKDIR = mkdir -p
 
-lzbench: $(BUGGY_C_FILES) $(BUGGY_CC_FILES) $(BUGGY_CXX_FILES) $(ACEAPEX_FILES) $(BSC_C_FILES) $(BSC_CXX_FILES) $(BSC_CUDA_FILES) $(ACEAPEX_CUDA_FILES) $(BZIP2_FILES) $(BZIP3_FILES) $(CSC_FILES) $(KANZI_FILES) $(FASTLZMA2_OBJ) $(ZSTD_FILES) $(LZSSE_FILES) $(LZFSE_FILES) $(XZ_FILES) $(LIBLZG_FILES) $(BRIEFLZ_FILES) $(LZF_FILES) $(BROTLI_FILES) $(LZMA_FILES) $(ZLING_FILES) $(QUICKLZ_FILES) $(OPENZL_C_FILES) $(OPENZL_S_FILES) $(SNAPPY_FILES) $(ZLIB_FILES) $(ZLIB_NG_FILES) $(LZHAM_FILES) $(LZO_FILES) $(UCL_FILES) $(LZ4_FILES) $(LIZARD_FILES) $(LIBDEFLATE_FILES) $(ZXC_FILES) $(MISC_FILES) $(NVCOMP_FILES) $(PPMD_FILES) $(BENCH_FILES) $(SKIM_FILE)
+lzbench: $(BUGGY_C_FILES) $(BUGGY_CC_FILES) $(BUGGY_CXX_FILES) $(ACEAPEX_FILES) $(BSC_C_FILES) $(BSC_CXX_FILES) $(BSC_CUDA_FILES) $(ACEAPEX_CUDA_FILES) $(BZIP2_FILES) $(BZIP3_FILES) $(CSC_FILES) $(KANZI_FILES) $(FASTLZMA2_OBJ) $(ZSTD_FILES) $(LZSSE_FILES) $(LZFSE_FILES) $(XZ_FILES) $(LIBLZG_FILES) $(BRIEFLZ_FILES) $(LZF_FILES) $(BROTLI_FILES) $(LZMA_FILES) $(ZLING_FILES) $(QUICKLZ_FILES) $(OPENZL_C_FILES) $(OPENZL_S_FILES) $(SNAPPY_FILES) $(ZLIB_FILES) $(ZLIB_NG_FILES) $(LZHAM_FILES) $(LZO_FILES) $(UCL_FILES) $(LZ4_FILES) $(LIZARD_FILES) $(LIBDEFLATE_FILES) $(ZXC_FILES) $(MISA77_FILES) $(MISC_FILES) $(NVCOMP_FILES) $(PPMD_FILES) $(BENCH_FILES) $(SKIM_FILE)
 	$(CXX) $^ -o $@ $(LDFLAGS)
 	@echo Linked GCC_VERSION=$(GCC_VERSION) CLANG_VERSION=$(CLANG_VERSION) COMPILER=$(COMPILER)
 
@@ -1123,7 +1157,7 @@ $(LIZARD_FILES): %.o : %.c
 
 $(LZ_CODECS): %.o : %.cpp
 	@$(MKDIR) $(dir $@)
-	$(CXX) $(CXXFLAGS) -Ilz -Ilz/brotli/include -Ilz/openzl/include -Ilz/zxc/src/lib/vendors $< -c -o $@
+	$(CXX) $(CXXFLAGS) -Ilz -Ilz/brotli/include -Ilz/openzl/include -Ilz/zxc/src/lib/vendors -Ilz/misa77/include $< -c -o $@
 
 $(LZHAM_FILES): %.o : %.cpp
 	@$(MKDIR) $(dir $@)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Notes column says otherwise.
 | [lzo 2.10](http://www.oberhumer.com/opensource/lzo) | 2017-03-01 | |
 | [lzsse 2019-04-18 (1847c3e827)](https://github.com/ConorStokes/LZSSE) | 2019-04-18 | 64-bit x86 only — requires SSE4.1 (Windows: MinGW-w64 only); lzsse8fast has a [bug](https://github.com/ConorStokes/LZSSE/issues/14) |
 | [memlz 0.2 beta](https://github.com/rrrlasse/memlz) | 2025-11-03 | Disabled on 32-bit ARM — unaligned access faults (SIGBUS) |
+| [misa77 0.2.0](https://github.com/welcome-to-the-sunny-side/misa77) | 2026-07-09 | Little-endian 64-bit only |
 | [nvcomp 2.2.0](https://github.com/NVIDIA/nvcomp) | 2022-02-07 | CUDA only — built with `make ENABLE_CUDA=1`; not in the default CI matrix |
 | [openzl 0.2.0](https://openzl.org/) | 2026-05-07 | 64-bit only — upstream does not support 32-bit builds |
 | [ppmd8 26.01](http://7-zip.org) | 2026-04-27 | |

--- a/bench/codecs.h
+++ b/bench/codecs.h
@@ -416,6 +416,17 @@ int64_t lzbench_memcpy(char *inbuf, size_t insize, char *outbuf, size_t outsize,
 #endif
 
 
+#ifndef BENCH_REMOVE_MISA77
+    int64_t lzbench_misa77_compress(char* inbuf, size_t insize, char* outbuf, size_t outsize, codec_options_t* codec_options);
+    int64_t lzbench_misa77_adaptive_compress(char* inbuf, size_t insize, char* outbuf, size_t outsize, codec_options_t* codec_options);
+    int64_t lzbench_misa77_decompress(char* inbuf, size_t insize, char* outbuf, size_t outsize, codec_options_t* codec_options);
+#else
+    #define lzbench_misa77_compress NULL
+    #define lzbench_misa77_adaptive_compress NULL
+    #define lzbench_misa77_decompress NULL
+#endif
+
+
 #ifndef BENCH_REMOVE_OPENZL
     char* lzbench_openzl_init_serial(size_t insize, size_t level, size_t);
     template <typename TInteger>

--- a/bench/lz_codecs.cpp
+++ b/bench/lz_codecs.cpp
@@ -57,6 +57,31 @@ int64_t lzbench_memlz_decompress(char* inbuf, size_t insize, char* outbuf, size_
 
 
 
+#ifndef BENCH_REMOVE_MISA77
+#include "misa77/misa77.h"
+#include "misa77/experimental.h"
+
+int64_t lzbench_misa77_compress(char* inbuf, size_t insize, char* outbuf, size_t outsize, codec_options_t* codec_options)
+{
+    // level 0 = fastest decompression, level 1 = best ratio (the library default)
+    return (int64_t)misa77::compress((const uint8_t*)inbuf, insize, (uint8_t*)outbuf, outsize, misa77::config((uint8_t)codec_options->level));
+}
+
+int64_t lzbench_misa77_adaptive_compress(char* inbuf, size_t insize, char* outbuf, size_t outsize, codec_options_t* codec_options)
+{
+    // level 0 = loose (larger decode gain, some ratio cost), level 1 = tight (tiny ratio cost)
+    return (int64_t)misa77::experimental::adaptive_compress((const uint8_t*)inbuf, insize, (uint8_t*)outbuf, outsize, (uint8_t)codec_options->level);
+}
+
+// All misa77 modes emit one format, so every misa77_* codec shares this decompressor.
+int64_t lzbench_misa77_decompress(char* inbuf, size_t insize, char* outbuf, size_t outsize, codec_options_t* codec_options)
+{
+    return (int64_t)misa77::decompress((const uint8_t*)inbuf, insize, (uint8_t*)outbuf, outsize);
+}
+#endif // BENCH_REMOVE_MISA77
+
+
+
 #ifndef BENCH_REMOVE_BRIEFLZ
 #include "lz/brieflz/brieflz.h"
 

--- a/bench/lzbench.h
+++ b/bench/lzbench.h
@@ -236,6 +236,8 @@ static const compressor_desc_t comp_desc[] =
     { "lzsse8fast", "lzsse8fast 2019-04-18",   0,   0,    0,  BENCH_POOL_MT, lzbench_lzsse8fast_compress, lzbench_lzsse8_decompress,     lzbench_lzsse8fast_init, lzbench_lzsse8fast_deinit },
     { "lzvn",       "lzvn 2017-03-08",         0,   0,    0,  BENCH_POOL_MT, lzbench_lzvn_compress,       lzbench_lzvn_decompress,       lzbench_lzvn_init,       lzbench_lzvn_deinit },
     { "memlz",      "memlz 0.2 beta",          0,   0,    0,  BENCH_POOL_MT, lzbench_memlz_compress,      lzbench_memlz_decompress,      lzbench_memlz_init,      lzbench_memlz_deinit },
+    { "misa77",          "misa77 0.2.0",           0,   1,    0,  BENCH_POOL_MT, lzbench_misa77_compress,          lzbench_misa77_decompress, NULL, NULL },
+    { "misa77_adaptive", "misa77 0.2.0 adaptive",  0,   1,    0,  BENCH_POOL_MT, lzbench_misa77_adaptive_compress, lzbench_misa77_decompress, NULL, NULL },
     { "nvcomp_lz4", "nvcomp_lz4 2.2.0",        0,   7,    0,  BENCH_POOL_MT, lzbench_nvcomp_compress,     lzbench_nvcomp_decompress,     lzbench_nvcomp_init,     lzbench_nvcomp_deinit },
     { "openzl_u8",  "openzl 0.2.0 -p u8",       0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(uint8_t),  lzbench_openzl_deinit },
     { "openzl_i8",  "openzl 0.2.0 -p i8",       0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(int8_t),  lzbench_openzl_deinit },

--- a/lz/misa77/LICENSE
+++ b/lz/misa77/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lz/misa77/README.md
+++ b/lz/misa77/README.md
@@ -1,0 +1,15 @@
+# misa77
+
+A fast-decode LZ compressor.
+
+- Upstream: https://github.com/welcome-to-the-sunny-side/misa77
+- License:  MIT
+
+Registered lzbench codecs:
+
+| name              | description                                              |
+| ----------------- | -------------------------------------------------------- |
+| `misa77`          | the library codec; levels 0 (fastest decompression) / 1 (best ratio, the library default) |
+| `misa77_adaptive` | decoder-friendly adaptive parse for homogeneous data; levels 0 (loose) / 1 (tight) |
+
+Both emit bitstreams conforming to the same format and share one decompressor.

--- a/lz/misa77/include/misa77/experimental.h
+++ b/lz/misa77/include/misa77/experimental.h
@@ -1,0 +1,64 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include <cstdint>
+
+namespace misa77
+{
+    namespace experimental
+    {
+        // Be careful with possible overflow
+        class param
+        {
+        public:
+            bool use_default = false;
+            uint64_t size = 0;
+            uint64_t block = 0;
+            uint64_t short4_7 = 0;
+            uint64_t short8_15 = 0;
+            uint64_t lit7 = 0;
+            uint64_t lit17 = 0;
+            uint64_t lit33 = 0;
+        };
+
+        // Returns number of bytes written to `dst`, and 0 on failure.
+        // PRECONDITION: `src_size <= max_src_size`
+        uint64_t compress_tuned(const uint8_t* __restrict src,
+                                uint64_t src_size,
+                                uint8_t* __restrict dst,
+                                uint64_t dst_cap,
+                                const param& given);
+
+        // Chooses a good compression parameter vector for `src` by sampling a small portion of it.
+        // - `option = 0` gives significant decompress throughput gains with moderate ratio costs.
+        // - `option = 1` gives moderate decompress throughput gains with tiny ratio costs.
+        param suggest_homogeneous(const uint8_t* __restrict src,
+                                  uint64_t src_size,
+                                  uint8_t* __restrict dst,
+                                  uint64_t dst_cap,
+                                  uint8_t option);
+
+        // Returns number of bytes written to `dst`, and 0 on failure.
+        // PERFORMANCE ON HETEROGENEOUS DATA CAN VARY WILDLY, KEEP THAT IN MIND
+        // PRECONDITION: `src_size <= max_src_size`
+        // - `option = 0` gives significant decompress throughput gains with moderate ratio costs
+        // - `option = 1` gives moderate decompress throughput gains with tiny ratio costs
+        uint64_t adaptive_compress(const uint8_t* __restrict src,
+                                   uint64_t src_size,
+                                   uint8_t* __restrict dst,
+                                   uint64_t dst_cap,
+                                   uint8_t option);
+
+        // Returns number of bytes written to `dst`, and 0 on failure.
+        // PRECONDITION: `src_size <= max_src_size`
+        // YOLO
+        // (will improve decomp throughput a lot on most data distributions, and cost some ratio)
+        uint64_t yolo_compress(const uint8_t* __restrict src,
+                               uint64_t src_size,
+                               uint8_t* __restrict dst,
+                               uint64_t dst_cap);
+    } // namespace experimental
+} // namespace misa77

--- a/lz/misa77/include/misa77/misa77.h
+++ b/lz/misa77/include/misa77/misa77.h
@@ -1,0 +1,59 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include <cstdint>
+
+namespace misa77
+{
+    // `1e17`
+    inline constexpr uint64_t max_src_size = 100'000'000'000'000'000;
+
+    class config
+    {
+    public:
+        // Only integers in [0, max_level] are valid levels
+        static constexpr uint8_t max_level = 1;
+        static constexpr uint8_t default_level = 1;
+        static_assert(default_level <= max_level);
+
+        uint8_t level;
+        config() : level(default_level) {}
+        explicit config(uint8_t l) : level(l) {}
+    };
+
+    // Upper-bound on compressed size (in bytes) for any input of size `src_size` bytes.
+    // Use to size destination buffer.
+    // PRECONDITION: `src_size <= max_src_size`
+    uint64_t compress_bound(uint64_t src_size);
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // `cfg.level` selects the compressor to be used (all levels conform to the same format).
+    // PRECONDITION: `src_size <= max_src_size` and `0 <= cfg.level <= config::max_level`
+    uint64_t compress(const uint8_t* __restrict src,
+                      uint64_t src_size,
+                      uint8_t* __restrict dst,
+                      uint64_t dst_cap,
+                      config cfg = config());
+
+    // Returns the exact size (in bytes) of the file that the given compressed file will be
+    // decompressed to.
+    // Only call this on buffers that were compressed in the misa77 format, as it
+    // requires the size of the buffer to be >= 8.
+    uint64_t decompressed_size(const uint8_t* src);
+
+    // Minimum size of buffer required to decompress a compressed file that corresponds to an
+    // original file of `src_size` bytes.
+    // Usage: decompressed_buffer_bound(decompressed_size(src))
+    uint64_t decompressed_buffer_bound(uint64_t src_size);
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // PRECONDITION: `src` and `src_size` must correspond to a valid misa77 stream.
+    // `decompress` does not validate input, and malformed/malicious data can lead to UB or worse.
+    uint64_t decompress(const uint8_t* __restrict src,
+                        uint64_t src_size,
+                        uint8_t* __restrict dst,
+                        uint64_t dst_cap);
+} // namespace misa77

--- a/lz/misa77/src/compress.cpp
+++ b/lz/misa77/src/compress.cpp
@@ -1,0 +1,40 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#include "compress_dispatch.h"
+#include "misa77/misa77.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    // Upper-bound on compressed size (in bytes) for any input of size `src_size` bytes.
+    // Use to size destination buffer.
+    // PRECONDITION: `src_size <= max_src_size`
+    uint64_t compress_bound(uint64_t src_size)
+    {
+        return uint64_t(8)   // uncompressed size
+               + uint64_t(8) // number of trailing raw literals (>= `literal_suffix`)
+               + src_size + (src_size / uint64_t(255)) +
+               uint64_t(16); // compressed data length upper-bound
+    }
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // Resolves the best finder path once per call, depending on the ISA.
+    // PRECONDITION: `src_size <= max_src_size`
+    uint64_t compress(const uint8_t* __restrict src,
+                      uint64_t src_size,
+                      uint8_t* __restrict dst,
+                      uint64_t dst_cap,
+                      config cfg)
+    {
+#if defined(__x86_64__)
+        if (__builtin_cpu_supports("avx2"))
+            return compress_avx2(src, src_size, dst, dst_cap, cfg);
+        return compress_sse2(src, src_size, dst, dst_cap, cfg);
+#else
+        return compress_portable(src, src_size, dst, dst_cap, cfg);
+#endif
+    }
+} // namespace misa77

--- a/lz/misa77/src/compress_dispatch.h
+++ b/lz/misa77/src/compress_dispatch.h
@@ -1,0 +1,31 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "misa77/misa77.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    // ISA-specialized compress entry points. Each is defined in a per-target TU in src/isa/,
+    // compiled with that ISA's flags (target_avx2.cpp with -mavx2, target_sse2.cpp /
+    // target_portable.cpp at baseline), and selected at runtime by compress() (see compress.cpp).
+    uint64_t compress_avx2(const uint8_t* __restrict src,
+                           uint64_t src_size,
+                           uint8_t* __restrict dst,
+                           uint64_t dst_cap,
+                           config cfg);
+    uint64_t compress_sse2(const uint8_t* __restrict src,
+                           uint64_t src_size,
+                           uint8_t* __restrict dst,
+                           uint64_t dst_cap,
+                           config cfg);
+    uint64_t compress_portable(const uint8_t* __restrict src,
+                               uint64_t src_size,
+                               uint8_t* __restrict dst,
+                               uint64_t dst_cap,
+                               config cfg);
+} // namespace misa77

--- a/lz/misa77/src/compressor_zoo/default_compress_impl.h
+++ b/lz/misa77/src/compressor_zoo/default_compress_impl.h
@@ -1,0 +1,261 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "format.h"
+#include "misa77/misa77.h"
+#include "util.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace misa77
+{
+    static_assert(max_match_len >= 32);
+
+    namespace default_detail
+    {
+        constexpr uint32_t hash_top = 16;
+        constexpr uint32_t hash_siz = 1 << hash_top;
+        constexpr uint32_t hash_mul = 2654435761;
+
+        // Size of ring buffer per hash in the hashtable.
+        inline constexpr uint64_t hashtab_wid = 16;
+
+        // Hash 4 bytes to an integer in `[0, 1 << (hash_top))`.
+        [[gnu::always_inline]]
+        inline uint32_t hash4(const uint32_t val)
+        {
+            return (val * hash_mul) >> (32 - hash_top);
+        }
+
+        // Assuming that rem contains top 3 bits of the token, emits bytes specifying `n`.
+        [[gnu::always_inline]]
+        inline void emit_length_extras(uint8_t* dst, uint64_t& dlpos, uint64_t n, uint8_t rem)
+        {
+            if (rem != uint8_t(7)) [[likely]]
+                return;
+
+            // Write this unconditionally first, if it's wrong we'll just overwrite
+            dst[dlpos] = static_cast<uint8_t>(n);
+
+            constexpr uint64_t block = 255;
+            if (n >= block) [[unlikely]]
+            {
+                while (n >= block) [[unlikely]]
+                    dst[dlpos] = block, ++dlpos, n -= block;
+                dst[dlpos] = static_cast<uint8_t>(n);
+            }
+
+            ++dlpos;
+        }
+
+        // Don't look further ahead once you have a match `>= la_gate`
+        constexpr uint64_t la_gate = 16;
+
+        // Once you have match `>= la_pate`, only keep looking if you get gains
+        constexpr uint64_t la_pate = 8;
+
+        // When you've gone `p` hashtab searches without a match, advance the pointer by `p >>
+        // skip_shift`
+        constexpr uint64_t skip_shift = 6;
+    } // namespace default_detail
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // `isa_lib` is ISA-dependent.
+    template <class isa_lib>
+    uint64_t default_compress_impl(const uint8_t* __restrict src,
+                                   uint64_t src_size,
+                                   uint8_t* __restrict dst,
+                                   uint64_t dst_cap)
+    {
+        using namespace default_detail;
+
+        if (compress_bound(src_size) > dst_cap)
+            return 0;
+
+        // Left pointer in the destination buffer (metadata and control bytes)
+        uint64_t dlpos = 0;
+
+        // Right pointer in the destination buffer (literal bytes)
+        // We've written to `[drpos, dst_cap)` at any given point of time
+        uint64_t drpos = dst_cap;
+
+        storeu8(dst, src_size);
+        dlpos += 8;
+
+        // Small source
+        if (src_size <= small_lim)
+        {
+            if (src_size != 0)
+                memcpy(dst + dlpos, src, src_size);
+            dlpos += src_size;
+            return dlpos;
+        }
+
+        uint64_t literal_suffix_pos = dlpos;
+        dlpos += 8;
+
+        // Ensure that the last `literal_suffix` bytes will be literals
+        uint64_t match_end_limit = (src_size < literal_suffix ? 0 : src_size - literal_suffix);
+
+        // Beginning of the pending literal window
+        uint64_t lit = 0;
+
+        // `[lit, pos]` corresponds to the new range from the src buffer we're going to be
+        // turning into a lit + match pair
+        uint64_t pos = 0;
+
+        // `[0, hpos)` represents the range we've written into the hashtable
+        uint64_t hpos = 0;
+
+        uint64_t miss_run = 0;
+
+        std::vector<std::array<uint16_t, hashtab_wid>> hashtab(hash_siz);
+        std::vector<uint8_t> hashtab_idx(hash_siz);
+        while (pos + max_match_len <= match_end_limit)
+        {
+            // Reduce branch misses, `batch = 8` performs well empirically
+            constexpr uint64_t batch = 8;
+            while (pos >= hpos + hashtab_lag + batch) [[unlikely]]
+            {
+#pragma GCC unroll batch
+                for (uint64_t i = 0; i < batch; i++)
+                {
+                    uint32_t hsh = hash4(loadu4(src + hpos + i));
+                    hashtab[hsh][hashtab_idx[hsh]] =
+                        uint16_t(hpos + i); // We just store the lowest 2 bytes
+                    hashtab_idx[hsh] =
+                        (hashtab_idx[hsh] == hashtab_wid - 1
+                             ? uint8_t(0)
+                             : hashtab_idx[hsh] + 1); // Just cycle the pointer in the ring buffer
+                }
+                hpos += batch;
+            }
+
+            uint32_t val = loadu4(src + pos);
+            uint32_t hsh = hash4(val);
+
+            uint64_t lst = 0;
+            uint64_t match_len = 0;
+
+            typename isa_lib::vec reg = isa_lib::loadvec(src + pos);
+
+            if (pos > hashtab_lag) [[likely]]
+            {
+// MLP
+#pragma GCC unroll hashtab_wid
+                for (uint8_t i = 0; i < hashtab_wid; i++)
+                {
+                    uint16_t d = uint16_t(pos - hashtab[hsh][i] - hashtab_lag - 1);
+
+                    // Guaranteed to lie within `[pos - 2^16 - hashtab_lag, pos - hashtab_lag)`
+                    uint64_t ilst = (pos - max_match_len - 1 - d);
+
+                    typename isa_lib::vec ireg = isa_lib::loadvec(src + ilst);
+                    uint32_t imatch_len = isa_lib::lcp(reg, ireg);
+                    lst = (imatch_len > match_len ? ilst : lst);
+                    match_len = (imatch_len > match_len ? imatch_len : match_len);
+                }
+            }
+
+            if (match_len >= min_match_len)
+            {
+                for (uint64_t npos = pos + 1;
+                     npos <= pos + lookahead and npos + max_match_len <= match_end_limit and
+                     match_len < la_gate;
+                     npos++)
+                {
+                    uint64_t nlst = 0;
+                    uint64_t nmatch_len = 0;
+
+                    uint32_t val = loadu4(src + npos);
+                    uint32_t hsh = hash4(val);
+                    typename isa_lib::vec reg = isa_lib::loadvec(src + npos);
+#pragma GCC unroll hashtab_wid
+                    for (uint8_t i = 0; i < hashtab_wid; i++)
+                    {
+                        uint16_t d = uint16_t(npos - hashtab[hsh][i] - hashtab_lag - 1);
+
+                        // Guaranteed to lie within `[npos - 2^16 - hashtab_lag, npos -
+                        // hashtab_lag)`
+                        uint64_t ilst = (npos - max_match_len - 1 - d);
+
+                        typename isa_lib::vec ireg = isa_lib::loadvec(src + ilst);
+                        uint32_t imatch_len = isa_lib::lcp(reg, ireg);
+
+                        nlst = (imatch_len > nmatch_len ? ilst : nlst);
+                        nmatch_len = (imatch_len > nmatch_len ? imatch_len : nmatch_len);
+                    }
+
+                    bool improved = (nmatch_len > match_len);
+                    pos = (improved ? npos : pos);
+                    lst = (improved ? nlst : lst);
+                    match_len = (improved ? nmatch_len : match_len);
+
+                    if (!improved and match_len >= la_pate)
+                        break;
+                }
+
+                uint64_t norm_match_len = match_len - min_match_len + 1;
+
+                // `src[lit, pos)` are the literals
+                uint64_t lit_len = pos - lit;
+
+                // Token Byte
+                uint8_t lrem = std::min(uint64_t(7), lit_len);
+                dst[dlpos] = static_cast<uint8_t>((lrem << 5) | (norm_match_len));
+                lit_len -= lrem;
+                ++dlpos;
+
+                // 2 Distance bytes
+                uint64_t dis = pos - lst;
+                uint16_t dbytes = dis - hashtab_lag - 1;
+                storeu2(dst + dlpos, dbytes);
+                dlpos += 2;
+
+                // Extra literal length bytes
+                emit_length_extras(dst, dlpos, lit_len, lrem);
+
+                // Literal bytes
+                if (lit < pos)
+                {
+                    uint64_t lit_cnt = pos - lit;
+                    drpos -= lit_cnt;
+                    memcpy(dst + drpos, src + lit, lit_cnt);
+                }
+
+                pos += match_len;
+                lit = pos;
+                miss_run = 0;
+            }
+            else
+            {
+                pos += 1 + (miss_run >> skip_shift);
+                ++miss_run;
+            }
+        }
+
+        // Close the gap between the two streams by moving the literal stream to the left
+        if (drpos < dst_cap)
+        {
+            memmove(dst + dlpos, dst + drpos, dst_cap - drpos);
+            dlpos += dst_cap - drpos;
+        }
+
+        // Just deal with the last few literals (guaranteed to be `>= literal_suffix >=
+        // vector_width` bytes)
+        uint64_t literal_suffix_cnt = src_size - lit;
+        storeu8(dst + literal_suffix_pos, literal_suffix_cnt);
+        memcpy(dst + dlpos, src + lit, literal_suffix_cnt);
+        dlpos += literal_suffix_cnt;
+
+        return dlpos;
+    }
+
+} // namespace misa77

--- a/lz/misa77/src/compressor_zoo/loose_compress_impl.h
+++ b/lz/misa77/src/compressor_zoo/loose_compress_impl.h
@@ -1,0 +1,294 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "format.h"
+#include "misa77/misa77.h"
+#include "util.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace misa77
+{
+    static_assert(max_match_len >= 32);
+
+    namespace loose_detail
+    {
+        constexpr uint32_t hash_top = 16;
+        constexpr uint32_t hash_siz = 1 << hash_top;
+        constexpr uint32_t hash_mul = 2654435761;
+
+        // Size of ring buffer per hash in the hashtable.
+        inline constexpr uint64_t hashtab_wid = 16;
+
+        // Hash 4 bytes to an integer in `[0, 1 << (hash_top))`.
+        [[gnu::always_inline]]
+        inline uint32_t hash4(const uint32_t val)
+        {
+            return (val * hash_mul) >> (32 - hash_top);
+        }
+
+        // Assuming that rem contains top 3 bits of the token, emits bytes specifying `n`.
+        [[gnu::always_inline]]
+        inline void emit_length_extras(uint8_t* dst, uint64_t& dlpos, uint64_t n, uint8_t rem)
+        {
+            if (rem != uint8_t(7)) [[likely]]
+                return;
+
+            // Write this unconditionally first, if it's wrong we'll just overwrite
+            dst[dlpos] = static_cast<uint8_t>(n);
+
+            constexpr uint64_t block = 255;
+            if (n >= block) [[unlikely]]
+            {
+                while (n >= block) [[unlikely]]
+                    dst[dlpos] = block, ++dlpos, n -= block;
+                dst[dlpos] = static_cast<uint8_t>(n);
+            }
+
+            ++dlpos;
+        }
+
+        // Preferable lowerbound for match length (derived from the YOLO vector for now)
+        constexpr uint64_t accept_len = 7;
+        static_assert(accept_len >= min_match_len);
+
+        // We ideally want to keep literal length `<= fire_at`
+        constexpr uint64_t fire_at = 6;
+
+        // When you've gone `p` hashtab searches without a match, advance the pointer by `p >>
+        // skip_shift`
+        constexpr uint64_t skip_shift = 6;
+
+        // Regime counter: an adaptive value in `[0, regime_cap]`
+        // Runs with literal length in `[7, 32]` have a vote of `+2`, others `-1`
+        inline constexpr int64_t regime_cap = 64;
+        inline constexpr int64_t regime_threshold = 32;
+
+    } // namespace loose_detail
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // `isa_lib` is ISA-dependent.
+    template <class isa_lib>
+    uint64_t loose_compress_impl(const uint8_t* __restrict src,
+                                 uint64_t src_size,
+                                 uint8_t* __restrict dst,
+                                 uint64_t dst_cap)
+    {
+        using namespace loose_detail;
+
+        if (compress_bound(src_size) > dst_cap)
+            return 0;
+
+        // Left pointer in the destination buffer (metadata and control bytes)
+        uint64_t dlpos = 0;
+
+        // Right pointer in the destination buffer (literal bytes)
+        // We've written to `[drpos, dst_cap)` at any given point of time
+        uint64_t drpos = dst_cap;
+
+        storeu8(dst, src_size);
+        dlpos += 8;
+
+        // Small source
+        if (src_size <= small_lim)
+        {
+            if (src_size != 0)
+                memcpy(dst + dlpos, src, src_size);
+            dlpos += src_size;
+            return dlpos;
+        }
+
+        uint64_t literal_suffix_pos = dlpos;
+        dlpos += 8;
+
+        // Ensure that the last `literal_suffix` bytes will be literals
+        uint64_t match_end_limit = (src_size < literal_suffix ? 0 : src_size - literal_suffix);
+
+        // Beginning of the pending literal window
+        uint64_t lit = 0;
+
+        // `[lit, pos]` corresponds to the new range from the src buffer we're going to be
+        // turning into a lit + match pair
+        uint64_t pos = 0;
+
+        // `[0, hpos)` represents the range we've written into the hashtable
+        uint64_t hpos = 0;
+
+        uint64_t miss_run = 0;
+
+        std::vector<std::array<uint16_t, hashtab_wid>> hashtab(hash_siz);
+        std::vector<uint8_t> hashtab_idx(hash_siz);
+
+        // Last remembered match
+        uint64_t cand_pos = 0, cand_len = 0, cand_lst = 0;
+
+        // Adaptive variable that reflects values of lit_len we've been getting for recent blocks
+        int64_t regime = 0;
+
+        while (pos + max_match_len <= match_end_limit)
+        {
+            // Reduce branch misses, `batch = 8` performs well empirically
+            constexpr uint64_t batch = 8;
+            while (pos >= hpos + hashtab_lag + batch) [[unlikely]]
+            {
+#pragma GCC unroll batch
+                for (uint64_t i = 0; i < batch; i++)
+                {
+                    uint32_t hsh = hash4(loadu4(src + hpos + i));
+                    hashtab[hsh][hashtab_idx[hsh]] =
+                        uint16_t(hpos + i); // We just store the lowest 2 bytes
+                    hashtab_idx[hsh] =
+                        (hashtab_idx[hsh] == hashtab_wid - 1
+                             ? uint8_t(0)
+                             : hashtab_idx[hsh] + 1); // Just cycle the pointer in the ring buffer
+                }
+                hpos += batch;
+            }
+
+            uint32_t val = loadu4(src + pos);
+            uint32_t hsh = hash4(val);
+
+            uint64_t lst = 0;
+            uint64_t match_len = 0;
+
+            typename isa_lib::vec reg = isa_lib::loadvec(src + pos);
+
+            if (pos > hashtab_lag) [[likely]]
+            {
+// MLP
+#pragma GCC unroll hashtab_wid
+                for (uint8_t i = 0; i < hashtab_wid; i++)
+                {
+                    uint16_t d = uint16_t(pos - hashtab[hsh][i] - hashtab_lag - 1);
+
+                    // Guaranteed to lie within `[pos - 2^16 - hashtab_lag, pos - hashtab_lag)`
+                    uint64_t ilst = (pos - max_match_len - 1 - d);
+                    typename isa_lib::vec ireg = isa_lib::loadvec(src + ilst);
+                    uint32_t imatch_len = isa_lib::lcp(reg, ireg);
+                    lst = (imatch_len > match_len ? ilst : lst);
+                    match_len = (imatch_len > match_len ? imatch_len : match_len);
+                }
+            }
+
+            // We've inserted stuff into the hashtable assuming this value of `pos`, so we cannot
+            // probe the hashtable for any starting position behind this one going forward. This is
+            // important as `pos` is regressed ahead.
+            uint64_t pos_safe_bound = pos;
+
+            bool accept = (match_len >= accept_len);
+
+            uint64_t pend = pos - lit;
+            bool fire = (regime >= regime_threshold ? pend >= fire_at : pend == fire_at);
+
+            // We don't have an ideal match
+            if (!accept)
+            {
+                if (fire)
+                {
+                    // Prefer the one ending later between this position and the last remembered one
+                    if (cand_len != 0 and
+                        (match_len < min_match_len or cand_pos + cand_len >= pos + match_len))
+                    {
+                        pos = cand_pos;
+                        lst = cand_lst;
+                        match_len = cand_len;
+                    }
+
+                    // Note that if `accept` becomes false here, pos isn't pushed back by the above
+                    // branch
+                    accept = (match_len >= min_match_len);
+                }
+                else if (match_len >= min_match_len and
+                         (cand_len == 0 or pos + match_len >= cand_pos + cand_len))
+                {
+                    // This position becomes the new candidate
+                    cand_pos = pos;
+                    cand_len = match_len;
+                    cand_lst = lst;
+                }
+            }
+
+            if (accept)
+            {
+                // Extend the match backwards (note that `dis` in `(hashtab_lag, 2^16 +
+                // hashtab_lag]` holds).
+                // Extending `pos` backwards here is safe because we're not looking into the
+                // hashtable.
+                while (pos > lit and lst > 0 and match_len < max_match_len and
+                       src[pos - 1] == src[lst - 1])
+                {
+                    --pos;
+                    --lst;
+                    ++match_len;
+                }
+
+                uint64_t norm_match_len = match_len - min_match_len + 1;
+
+                // `src[lit, pos)` are the literals
+                uint64_t lit_len = pos - lit;
+
+                // regime vote
+                regime += (7 <= lit_len and lit_len <= 32 ? 2 : -1);
+                regime = std::clamp<int64_t>(regime, 0, regime_cap);
+
+                // Token Byte
+                uint8_t lrem = std::min(uint64_t(7), lit_len);
+                dst[dlpos] = static_cast<uint8_t>((lrem << 5) | (norm_match_len));
+                lit_len -= lrem;
+                ++dlpos;
+
+                // 2 Distance bytes
+                uint64_t dis = pos - lst;
+                uint16_t dbytes = dis - hashtab_lag - 1;
+                storeu2(dst + dlpos, dbytes);
+                dlpos += 2;
+
+                // Extra literal length bytes
+                emit_length_extras(dst, dlpos, lit_len, lrem);
+
+                // Literal bytes
+                if (lit < pos)
+                {
+                    uint64_t lit_cnt = pos - lit;
+                    drpos -= lit_cnt;
+                    memcpy(dst + drpos, src + lit, lit_cnt);
+                }
+
+                pos += match_len;
+                lit = pos;
+                pos = std::max(pos, pos_safe_bound);
+                cand_len = 0;
+                miss_run = 0;
+            }
+            else
+            {
+                pos += 1 + (miss_run >> skip_shift);
+                ++miss_run;
+            }
+        }
+
+        // Close the gap between the two streams by moving the literal stream to the left
+        if (drpos < dst_cap)
+        {
+            memmove(dst + dlpos, dst + drpos, dst_cap - drpos);
+            dlpos += dst_cap - drpos;
+        }
+
+        // Just deal with the last few literals (guaranteed to be `>= literal_suffix >=
+        // vector_width` bytes)
+        uint64_t literal_suffix_cnt = src_size - lit;
+        storeu8(dst + literal_suffix_pos, literal_suffix_cnt);
+        memcpy(dst + dlpos, src + lit, literal_suffix_cnt);
+        dlpos += literal_suffix_cnt;
+
+        return dlpos;
+    }
+
+} // namespace misa77

--- a/lz/misa77/src/decompress.cpp
+++ b/lz/misa77/src/decompress.cpp
@@ -1,0 +1,54 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#include "decompress_dispatch.h"
+#include "format.h"
+#include "misa77/misa77.h"
+#include "util.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    static_assert(vector_width == 32);
+    static_assert(hashtab_lag >= vector_width);
+    static_assert(vector_width >= max_match_len);
+    static_assert(literal_suffix >= dec_literal_copy);
+
+    // Returns the exact size (in bytes) of the file that the given compressed file will be
+    // decompressed to.
+    // Only call this on buffers that were compressed in the misa77 format, as it
+    // requires the size of the buffer to be >= 8.
+    uint64_t decompressed_size(const uint8_t* src)
+    {
+        return loadu8(src);
+    }
+
+    // Minimum size of buffer required to decompress a compressed file that corresponds to an
+    // original file of `src_size` bytes.
+    // Usage: decompressed_buffer_bound(decompressed_size(src))
+    uint64_t decompressed_buffer_bound(uint64_t src_size)
+    {
+        return src_size;
+    }
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // Resolves the best decode path once per call, depending on the ISA.
+    // PRECONDITION: `src` and `src_size` must correspond to a valid misa77 stream.
+    // `decompress` does not validate input, and malformed/malicious data can lead to UB or worse.
+    uint64_t decompress(const uint8_t* __restrict src,
+                        uint64_t src_size,
+                        uint8_t* __restrict dst,
+                        uint64_t dst_cap)
+    {
+#if defined(__x86_64__)
+        if (__builtin_cpu_supports("avx2"))
+            return decompress_avx2(src, src_size, dst, dst_cap);
+        return decompress_sse2(src, src_size, dst, dst_cap);
+#else
+        return decompress_portable(src, src_size, dst, dst_cap);
+#endif
+    }
+
+} // namespace misa77

--- a/lz/misa77/src/decompress_dispatch.h
+++ b/lz/misa77/src/decompress_dispatch.h
@@ -1,0 +1,27 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include <cstdint>
+
+namespace misa77
+{
+    // ISA-specialized decompress entry points. Each is defined in a per-target TU in src/isa/,
+    // compiled with that ISA's flags (target_avx2.cpp with -mavx2, target_sse2.cpp /
+    // target_portable.cpp at baseline), and selected at runtime by decompress() (see
+    // decompress.cpp).
+    uint64_t decompress_avx2(const uint8_t* __restrict src,
+                             uint64_t src_size,
+                             uint8_t* __restrict dst,
+                             uint64_t dst_cap);
+    uint64_t decompress_sse2(const uint8_t* __restrict src,
+                             uint64_t src_size,
+                             uint8_t* __restrict dst,
+                             uint64_t dst_cap);
+    uint64_t decompress_portable(const uint8_t* __restrict src,
+                                 uint64_t src_size,
+                                 uint8_t* __restrict dst,
+                                 uint64_t dst_cap);
+} // namespace misa77

--- a/lz/misa77/src/decompress_impl.h
+++ b/lz/misa77/src/decompress_impl.h
@@ -1,0 +1,120 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "format.h"
+#include "misa77/misa77.h"
+#include "util.h"
+
+#include <cstdint>
+#include <cstring>
+
+namespace misa77
+{
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // `isa_lib` is ISA-dependent.
+    template <class isa_lib>
+    uint64_t decompress_impl(const uint8_t* __restrict src,
+                             uint64_t src_size,
+                             uint8_t* __restrict dst,
+                             uint64_t dst_cap)
+    {
+        const uint64_t original_size = decompressed_size(src);
+
+        if (dst_cap < original_size)
+            return 0;
+
+        // Small source
+        if (original_size <= small_lim)
+        {
+            if (original_size > 0)
+                memcpy(dst, src + uint64_t(8), original_size);
+            return original_size;
+        }
+
+        // Left and right pointers in the source buffer
+        uint64_t lpos = 0, rpos = src_size;
+
+        // Read the original size
+        lpos += 8;
+
+        // Size of literal suffix
+        uint64_t literal_suffix_cnt = loadu8(src + lpos);
+        lpos += 8;
+        rpos -= literal_suffix_cnt;
+
+        // Position in the destination buffer
+        uint64_t dpos = 0;
+
+        // Initial loop with safe overwrites in the destination buffer and safe overreads from
+        // source buffer
+        while (lpos < rpos)
+        {
+            // Overread is safe here
+            uint8_t token = src[lpos];
+            uint64_t lit_len = token >> 5;
+            uint64_t match_len = (token & uint8_t(0x1F)) + min_match_len - 1;
+
+            uint16_t dis_small = loadu2(src + lpos + 1);
+            uint32_t dis = dis_small + hashtab_lag + 1;
+
+            lpos += 3;
+
+            if (lit_len == 7) [[unlikely]]
+            {
+                uint64_t pot_add = src[lpos];
+                lit_len += pot_add;
+                lpos++;
+
+                constexpr uint64_t block = 255;
+                if (pot_add == block) [[unlikely]]
+                {
+                    while (src[lpos] == block) [[unlikely]]
+                        lit_len += block, ++lpos;
+                    lit_len += src[lpos], ++lpos;
+                }
+            }
+
+            if (lit_len > dec_literal_copy) [[unlikely]]
+            {
+                rpos -= lit_len;
+
+                isa_lib::copy32(dst + dpos, src + rpos);
+
+                if (lit_len > vector_width) [[unlikely]]
+                {
+                    memcpy(dst + (dpos + vector_width),
+                           src + (rpos + vector_width),
+                           lit_len - vector_width);
+                }
+            }
+            else
+            {
+                // Unconditional copy, safe because we have `dec_literal_copy` bytes of
+                // breathing room at the end in src and dst due to `literal_suffix`
+                rpos -= lit_len;
+                memcpy(dst + dpos, src + rpos, dec_literal_copy);
+            }
+            dpos += lit_len;
+
+            // When we enter cyccpy, we're guaranteed to have `literal_suffix` >= vector_width
+            // bytes of breathing room in the destination buffer as the last `literal_suffix`
+            // bytes are literals
+            isa_lib::cyccpy(dst + (dpos - dis), dis);
+            dpos += match_len;
+        }
+
+        if (dpos != original_size - literal_suffix_cnt)
+            return 0;
+
+        // Literal suffix at the end
+        memcpy(dst + (original_size - literal_suffix_cnt),
+               src + (src_size - literal_suffix_cnt),
+               literal_suffix_cnt);
+        dpos += literal_suffix_cnt;
+
+        return dpos;
+    }
+} // namespace misa77

--- a/lz/misa77/src/experimental/ecompress.cpp
+++ b/lz/misa77/src/experimental/ecompress.cpp
@@ -1,0 +1,128 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#include "experimental/ecompress_dispatch.h"
+#include "experimental/params.h"
+#include "misa77/experimental.h"
+#include "misa77/misa77.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+namespace misa77
+{
+    namespace experimental
+    {
+        uint64_t compress_tuned(const uint8_t* __restrict src,
+                                uint64_t src_size,
+                                uint8_t* __restrict dst,
+                                uint64_t dst_cap,
+                                const param& given)
+        {
+#if defined(__x86_64__)
+            if (__builtin_cpu_supports("avx2"))
+                return compress_tuned_avx2(src, src_size, dst, dst_cap, given);
+            return compress_tuned_sse2(src, src_size, dst, dst_cap, given);
+#else
+            return compress_tuned_portable(src, src_size, dst, dst_cap, given);
+#endif
+        }
+
+        namespace
+        {
+            // number of times we decode a sample in suggest_homogenous
+            constexpr uint64_t iters = 25;
+        } // namespace
+
+        param suggest_homogeneous(const uint8_t* __restrict src,
+                                  uint64_t src_size,
+                                  uint8_t* __restrict dst,
+                                  uint64_t dst_cap,
+                                  uint8_t option)
+        {
+            auto fn = &compress_tuned_portable;
+#if defined(__x86_64__)
+            if (__builtin_cpu_supports("avx2"))
+                fn = &compress_tuned_avx2;
+            else
+                fn = &compress_tuned_sse2;
+#endif
+            std::vector<uint8_t> decode_buf(decompressed_buffer_bound(src_size));
+
+            // min-of-iters decode time in ns (of the compressed stream currently in `dst`)
+            auto decode_time = [&](uint64_t csz) -> uint64_t
+            {
+                uint64_t here_time = std::numeric_limits<uint64_t>::max();
+                for (uint64_t i = 0; i < iters; i++)
+                {
+                    auto start = std::chrono::steady_clock::now();
+                    decompress(dst, csz, decode_buf.data(), decode_buf.size());
+                    auto end = std::chrono::steady_clock::now();
+                    here_time = std::min(
+                        here_time,
+                        static_cast<uint64_t>(
+                            std::chrono::duration_cast<std::chrono::nanoseconds>(end - start)
+                                .count()));
+                }
+                return here_time;
+            };
+
+            // Ratio baseline
+            uint64_t base_csz = fn(src, src_size, dst, dst_cap, params::p_default);
+
+            // Largest acceptable compressed size on the sample (pray that it generalizes).
+            uint64_t limit = (option == 1) ? base_csz + base_csz / 20
+                                           : base_csz + std::max(base_csz / 5, src_size / 10);
+
+            param suggestion = params::p_default;
+            uint64_t best_time = decode_time(base_csz);
+
+            for (const param& p : params::all_candidates)
+            {
+                uint64_t csz = fn(src, src_size, dst, dst_cap, p);
+                if (csz == 0 or csz > limit)
+                    continue;
+                uint64_t here_time = decode_time(csz);
+                if (here_time < best_time)
+                    suggestion = p, best_time = here_time;
+            }
+
+            return suggestion;
+        }
+
+        uint64_t adaptive_compress(const uint8_t* __restrict src,
+                                   uint64_t src_size,
+                                   uint8_t* __restrict dst,
+                                   uint64_t dst_cap,
+                                   uint8_t option)
+        {
+            constexpr uint64_t sample_size = 1
+                                             << 20; // 1 MB for now, I think 512 KB will suffice too
+
+            // We just use the prefix for now, look into making this more sophisticated later
+            param opt =
+                suggest_homogeneous(src, std::min(src_size, sample_size), dst, dst_cap, option);
+
+#if defined(__x86_64__)
+            if (__builtin_cpu_supports("avx2"))
+                return compress_tuned_avx2(src, src_size, dst, dst_cap, opt);
+            return compress_tuned_sse2(src, src_size, dst, dst_cap, opt);
+#else
+            return compress_tuned_portable(src, src_size, dst, dst_cap, opt);
+#endif
+        }
+
+        uint64_t yolo_compress(const uint8_t* __restrict src,
+                               uint64_t src_size,
+                               uint8_t* __restrict dst,
+                               uint64_t dst_cap)
+        {
+            return compress_tuned(src, src_size, dst, dst_cap, params::loose_champion);
+        }
+
+    } // namespace experimental
+} // namespace misa77

--- a/lz/misa77/src/experimental/ecompress_dispatch.h
+++ b/lz/misa77/src/experimental/ecompress_dispatch.h
@@ -1,0 +1,34 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "misa77/experimental.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    // ISA-specialized compress entry points. Each is defined in a per-target TU in
+    // src/experimental/isa/, compiled with that ISA's flags, and selected at runtime by compress()
+    // (see compress.cpp).
+    namespace experimental
+    {
+        uint64_t compress_tuned_avx2(const uint8_t* __restrict src,
+                                     uint64_t src_size,
+                                     uint8_t* __restrict dst,
+                                     uint64_t dst_cap,
+                                     const param& given);
+        uint64_t compress_tuned_sse2(const uint8_t* __restrict src,
+                                     uint64_t src_size,
+                                     uint8_t* __restrict dst,
+                                     uint64_t dst_cap,
+                                     const param& given);
+        uint64_t compress_tuned_portable(const uint8_t* __restrict src,
+                                         uint64_t src_size,
+                                         uint8_t* __restrict dst,
+                                         uint64_t dst_cap,
+                                         const param& given);
+    } // namespace experimental
+} // namespace misa77

--- a/lz/misa77/src/experimental/ecompress_impl.h
+++ b/lz/misa77/src/experimental/ecompress_impl.h
@@ -1,0 +1,360 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "format.h"
+#include "misa77/experimental.h"
+#include "misa77/misa77.h"
+#include "util.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <vector>
+
+namespace misa77
+{
+    namespace experimental
+    {
+        namespace
+        {
+            static_assert(max_match_len >= 32);
+
+            constexpr uint32_t hash_top = 16;
+            constexpr uint32_t hash_siz = 1 << hash_top;
+            constexpr uint32_t hash_mul = 2654435761;
+
+            // Hash 4 bytes to an integer in `[0, 1 << (hash_top))`.
+            [[gnu::always_inline]]
+            inline uint32_t hash4(const uint32_t val)
+            {
+                return (val * hash_mul) >> (32 - hash_top);
+            }
+
+            // Assuming that rem contains top 3 bits of the token, emits bytes specifying `n`.
+            [[gnu::always_inline]]
+            inline void emit_length_extras(uint8_t* dst, uint64_t& dlpos, uint64_t n, uint8_t rem)
+            {
+                if (rem != uint64_t(7)) [[likely]]
+                    return;
+
+                // Write this unconditionally first, if it's wrong we'll just overwrite
+                dst[dlpos] = static_cast<uint8_t>(n);
+
+                constexpr uint64_t block = 255;
+                if (n >= block) [[unlikely]]
+                {
+                    while (n >= block) [[unlikely]]
+                        dst[dlpos] = block, ++dlpos, n -= block;
+                    dst[dlpos] = static_cast<uint8_t>(n);
+                }
+
+                ++dlpos;
+            }
+
+            // Size of region in bytes
+            constexpr uint64_t region_width = 1 << 16;
+            static_assert(region_width == dis_lim);
+
+            constexpr uint64_t hashtab_wid = 16;
+            constexpr uint64_t cand_lookahead = 8;
+            constexpr uint64_t inf = std::numeric_limits<uint64_t>::max();
+
+            [[gnu::always_inline]]
+            // returns block cost - match length cost
+            inline uint64_t l_cost(const uint32_t& lit_len, const param& given)
+            {
+                uint64_t extra = (lit_len < 7) ? 0 : (lit_len - 7) / 255 + 1;
+                uint64_t add_cost = given.block + given.size * (3 + extra + lit_len);
+                uint64_t lit_cost = (lit_len >= 7) * given.lit7 + (lit_len >= 17) * given.lit17 +
+                                    (lit_len >= 33) * given.lit33;
+                return add_cost + lit_cost;
+            }
+
+            [[gnu::always_inline]]
+            // returns match length cost
+            inline uint64_t m_cost(const uint32_t& match_len, const param& given)
+            {
+                if (match_len < 8)
+                    return given.short4_7;
+                if (match_len < 16)
+                    return given.short8_15;
+                return 0;
+            }
+
+        } // namespace
+
+        template <class isa_lib>
+        uint64_t compress_tuned_impl(const uint8_t* __restrict src,
+                                     uint64_t src_size,
+                                     uint8_t* __restrict dst,
+                                     uint64_t dst_cap,
+                                     const param& given)
+        {
+            if (given.use_default)
+                return compress(src, src_size, dst, dst_cap);
+
+            if (compress_bound(src_size) > dst_cap)
+                return 0;
+
+            // Left pointer in the destination buffer (metadata and control bytes)
+            uint64_t dlpos = 0;
+
+            // Right pointer in the destination buffer (literal bytes)
+            // We've written to `[drpos, dst_cap)` at any given point of time
+            uint64_t drpos = dst_cap;
+
+            storeu8(dst, src_size);
+            dlpos += 8;
+
+            // Small source
+            if (src_size <= small_lim)
+            {
+                if (src_size != 0)
+                    memcpy(dst + dlpos, src, src_size);
+                dlpos += src_size;
+                return dlpos;
+            }
+
+            uint64_t literal_suffix_pos = dlpos;
+            dlpos += 8;
+
+            // Ensure that the last `literal_suffix` bytes will be literals
+            uint64_t match_end_limit = (src_size < literal_suffix ? 0 : src_size - literal_suffix);
+
+            // Beginning of the pending literal window
+            uint64_t lit = 0;
+
+            // `[0, hpos)` represents the range we've written into the hashtable
+            uint64_t hpos = 0;
+
+            std::vector<std::array<uint16_t, hashtab_wid>> hashtab(hash_siz);
+            std::vector<uint8_t> hashtab_idx(hash_siz);
+
+            // We reuse buffers across regions
+            std::vector<uint8_t> match_len(region_width);
+            std::vector<uint16_t> match_pos(region_width);
+
+            // dp[u] = optimum cost for [u, region_width)
+            std::vector<uint64_t> dp(region_width);
+            // If optimal transition for dp[u] is choosing match start at u + x with length l, we
+            // store ([top 16 bits = x] | [bottom 16 bits = l])
+            std::vector<uint32_t> dp_forward(region_width);
+
+            uint16_t seen_head = 0;
+            // Bottom 16 bits of location
+            std::vector<uint16_t> seen(cand_lookahead);
+            // Optimal match length to take here
+            std::vector<uint16_t> seen_ml(cand_lookahead);
+            // Suffix dp value when we take optimal match length seen_ml
+            std::vector<uint64_t> seen_dp(cand_lookahead);
+
+            for (uint64_t region_lb = 0; region_lb < match_end_limit; region_lb += region_width)
+            {
+                const uint64_t region_rb =
+                    std::min(region_lb + region_width, match_end_limit); // exclusive
+
+                // Reset every region
+                seen_head = 0;
+                std::fill(seen.begin(), seen.end(), 0);
+                std::fill(seen_dp.begin(), seen_dp.end(), 0);
+                std::fill(seen_ml.begin(), seen_ml.end(), 0);
+
+                // Compute match_len and match_pos from left to right
+                bool match_found = false;
+                for (uint64_t pos = region_lb; pos < region_rb; pos++)
+                {
+                    // Insert into hash structure (table for now, might swap out for chain walking
+                    // later)
+                    constexpr uint64_t batch = 8;
+                    while (pos >= hpos + hashtab_lag + batch) [[unlikely]]
+                    {
+#pragma GCC unroll batch
+                        for (uint64_t i = 0; i < batch; i++)
+                        {
+                            uint32_t hsh = hash4(loadu4(src + hpos + i));
+                            hashtab[hsh][hashtab_idx[hsh]] =
+                                uint16_t(hpos + i); // We just store the lowest 2 bytes
+                            hashtab_idx[hsh] =
+                                (hashtab_idx[hsh] == hashtab_wid - 1
+                                     ? uint8_t(0)
+                                     : hashtab_idx[hsh] +
+                                           1); // Just cycle the pointer in the ring buffer
+                        }
+                        hpos += batch;
+                    }
+
+                    uint16_t idx_into = pos & (region_width - 1);
+
+                    uint32_t val = loadu4(src + pos);
+                    uint32_t hsh = hash4(val);
+
+                    match_len[idx_into] = match_pos[idx_into] = 0;
+
+                    // Get best possible match, trim it so that it's within bounds
+                    if (pos > hashtab_lag and pos + min_match_len <= region_rb) [[likely]]
+                    {
+                        typename isa_lib::vec reg = isa_lib::loadvec(src + pos);
+// MLP
+#pragma GCC unroll hashtab_wid
+                        for (uint8_t i = 0; i < hashtab_wid; i++)
+                        {
+                            uint16_t d = uint16_t(pos - hashtab[hsh][i] - hashtab_lag - 1);
+
+                            static_assert(max_match_len == hashtab_lag);
+                            // Guaranteed to lie within `[pos - 2^16 - hashtab_lag, pos -
+                            // hashtab_lag)`
+                            uint64_t ilst = (pos - max_match_len - 1 - d);
+
+                            typename isa_lib::vec ireg = isa_lib::loadvec(src + ilst);
+                            uint32_t imatch_len = isa_lib::lcp(reg, ireg);
+                            match_pos[idx_into] =
+                                (imatch_len > match_len[idx_into] ? hashtab[hsh][i]
+                                                                  : match_pos[idx_into]);
+                            match_len[idx_into] =
+                                (imatch_len > match_len[idx_into] ? imatch_len
+                                                                  : match_len[idx_into]);
+                        }
+                        match_len[idx_into] =
+                            std::min(static_cast<uint64_t>(match_len[idx_into]), region_rb - pos);
+                        match_found = match_found or (match_len[idx_into] >= min_match_len);
+                    }
+                }
+
+                if (!match_found)
+                {
+                    // nothing to do here
+                    continue;
+                }
+
+                // Compute dp from right to left
+                for (uint64_t pos = region_rb; (pos--) > region_lb;)
+                {
+                    uint16_t idx_into = pos & (region_width - 1);
+                    dp[idx_into] = inf;
+                    dp_forward[idx_into] = 0;
+
+                    // Insert ourselves into the lookahead ring first, and attempt a transition
+                    if (match_len[idx_into] >= min_match_len)
+                    {
+                        seen[seen_head] = idx_into;
+                        seen_dp[seen_head] = inf;
+                        for (uint64_t m = min_match_len; m <= match_len[idx_into]; m++)
+                        {
+                            uint64_t s_cost_here =
+                                m_cost(m, given) + (pos + m == region_rb ? 0 : dp[idx_into + m]);
+                            if (s_cost_here < seen_dp[seen_head])
+                            {
+                                seen_dp[seen_head] = s_cost_here;
+                                seen_ml[seen_head] = m;
+                            }
+                        }
+
+                        // Transition with 0 lit length
+                        uint64_t lit_len_here = idx_into - idx_into;
+                        uint64_t l_cost_here = l_cost(lit_len_here, given);
+                        uint64_t m_cost_here = seen_dp[seen_head];
+                        if (dp[idx_into] > l_cost_here + m_cost_here)
+                        {
+                            // Yay
+                            dp[idx_into] = l_cost_here + m_cost_here;
+                            dp_forward[idx_into] = (lit_len_here << 16) | (seen_ml[seen_head]);
+                        }
+
+                        seen_head = (seen_head + 1 == cand_lookahead ? 0 : seen_head + 1);
+                    }
+
+                    for (uint16_t i = 0; i < cand_lookahead; i++)
+                    {
+                        uint16_t nxt = seen[i];
+                        if (nxt > idx_into) [[likely]]
+                        {
+                            // Attempt transition
+                            uint64_t lit_len_here = nxt - idx_into;
+                            uint64_t l_cost_here = l_cost(lit_len_here, given);
+                            uint64_t m_cost_here = seen_dp[i];
+                            if (dp[idx_into] > l_cost_here + m_cost_here)
+                            {
+                                // Yay
+                                dp[idx_into] = l_cost_here + m_cost_here;
+                                dp_forward[idx_into] = (lit_len_here << 16) | (seen_ml[i]);
+                            }
+                        }
+                    }
+
+                    // Assuming sensible weights, this only happens when there's no match ahead, so
+                    // we can just pretend that this is the end
+                    if (dp[idx_into] == inf)
+                        dp[idx_into] = 0;
+                }
+
+                // Reconstruct optimal sequence from left to right and emit stream
+                uint64_t pos = region_lb;
+                while (pos < region_rb)
+                {
+                    uint16_t idx_into = pos & (region_width - 1);
+
+                    uint32_t trans = dp_forward[idx_into];
+                    uint64_t match_start = pos + (trans >> 16);
+                    uint16_t match_length = trans ^ ((trans >> 16) << 16);
+
+                    // Incomplete block at the end in this region
+                    if (match_length == 0)
+                        break;
+
+                    uint64_t norm_match_len = match_length - min_match_len + 1;
+
+                    uint16_t d =
+                        uint16_t(match_start - match_pos[match_start & (region_width - 1)] -
+                                 hashtab_lag - 1);
+                    uint64_t match_from = (match_start - max_match_len - 1 - d);
+
+                    // `src[lit, match_start)` are the literals
+                    uint64_t lit_len = match_start - lit;
+                    uint8_t lrem = std::min(uint64_t(7), lit_len);
+                    dst[dlpos] = static_cast<uint8_t>((lrem << 5) | (norm_match_len));
+                    lit_len -= lrem;
+                    ++dlpos;
+
+                    // 2 Distance bytes
+                    uint64_t dis = match_start - match_from;
+                    uint16_t dbytes = dis - hashtab_lag - 1;
+                    storeu2(dst + dlpos, dbytes);
+                    dlpos += 2;
+
+                    // Extra literal length bytes
+                    emit_length_extras(dst, dlpos, lit_len, lrem);
+
+                    // Literal bytes
+                    if (lit < match_start)
+                    {
+                        uint64_t lit_cnt = match_start - lit;
+                        drpos -= lit_cnt;
+                        memcpy(dst + drpos, src + lit, lit_cnt);
+                    }
+
+                    pos = match_start + match_length;
+                    lit = pos;
+                }
+            }
+
+            // Close the gap between the two streams by moving the literal stream to the left
+            if (drpos < dst_cap)
+            {
+                memmove(dst + dlpos, dst + drpos, dst_cap - drpos);
+                dlpos += dst_cap - drpos;
+            }
+
+            uint64_t literal_suffix_cnt = src_size - lit;
+            storeu8(dst + literal_suffix_pos, literal_suffix_cnt);
+            memcpy(dst + dlpos, src + lit, literal_suffix_cnt);
+            dlpos += literal_suffix_cnt;
+
+            return dlpos;
+        }
+    } // namespace experimental
+} // namespace misa77

--- a/lz/misa77/src/experimental/isa/etarget_avx2.cpp
+++ b/lz/misa77/src/experimental/isa/etarget_avx2.cpp
@@ -1,0 +1,28 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+// AVX2 TU.
+// Built only on x86 targets and the implementations herein are chosen at dispatch iff the cpu has
+// AVX2 support.
+
+#include "experimental/ecompress_dispatch.h"
+#include "experimental/ecompress_impl.h"
+#include "isa/lib_avx2.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    namespace experimental
+    {
+        uint64_t compress_tuned_avx2(const uint8_t* __restrict src,
+                                     uint64_t src_size,
+                                     uint8_t* __restrict dst,
+                                     uint64_t dst_cap,
+                                     const param& given)
+        {
+            return compress_tuned_impl<lib_avx2>(src, src_size, dst, dst_cap, given);
+        }
+    } // namespace experimental
+} // namespace misa77

--- a/lz/misa77/src/experimental/isa/etarget_portable.cpp
+++ b/lz/misa77/src/experimental/isa/etarget_portable.cpp
@@ -1,0 +1,26 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+// Built on every target
+
+#include "experimental/ecompress_dispatch.h"
+#include "experimental/ecompress_impl.h"
+#include "isa/lib_portable.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    namespace experimental
+    {
+        uint64_t compress_tuned_portable(const uint8_t* __restrict src,
+                                         uint64_t src_size,
+                                         uint8_t* __restrict dst,
+                                         uint64_t dst_cap,
+                                         const param& given)
+        {
+            return compress_tuned_impl<lib_portable>(src, src_size, dst, dst_cap, given);
+        }
+    } // namespace experimental
+} // namespace misa77

--- a/lz/misa77/src/experimental/isa/etarget_sse2.cpp
+++ b/lz/misa77/src/experimental/isa/etarget_sse2.cpp
@@ -1,0 +1,26 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+// Baseline for x86-64 (SSE2 support is guaranteed in the ISA).
+
+#include "experimental/ecompress_dispatch.h"
+#include "experimental/ecompress_impl.h"
+#include "isa/lib_sse2.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    namespace experimental
+    {
+        uint64_t compress_tuned_sse2(const uint8_t* __restrict src,
+                                     uint64_t src_size,
+                                     uint8_t* __restrict dst,
+                                     uint64_t dst_cap,
+                                     const param& given)
+        {
+            return compress_tuned_impl<lib_sse2>(src, src_size, dst, dst_cap, given);
+        }
+    } // namespace experimental
+} // namespace misa77

--- a/lz/misa77/src/experimental/params.h
+++ b/lz/misa77/src/experimental/params.h
@@ -1,0 +1,55 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "misa77/experimental.h"
+
+#include <array>
+#include <cstdint>
+
+namespace misa77
+{
+    namespace experimental
+    {
+        namespace params
+        {
+            // BASE is the weight of the size param, other weights are implicitly scaled relative to
+            // it (well, they were when I ran an offline search)
+            constexpr uint64_t BASE = 1024;
+
+            // param aggregate order:
+            // {use_default, size, block, short4_7, short8_15, lit7, lit17, lit33}
+
+            // Default compressor
+            inline constexpr param p_default = {true, 0, 0, 0, 0, 0, 0, 0};
+
+            // Tight tier (get >= default decode speed, might slightly worsen ratio)
+            inline constexpr param tight_general = {false, BASE, 2500, 0, 0, 11253, 25502, 0};
+            inline constexpr param tight_short = {false, BASE, 0, 1076, 732, 3393, 37798, 27218};
+            inline constexpr param tight_deeplit = {false, BASE, 2065, 0, 206, 4617, 21109, 41277};
+            inline constexpr param tight_guarded = {false, BASE, 4096, 0, 0, 16384, 65536, 131072};
+            inline constexpr param tight_lean = {false, BASE, 0, 540, 0, 6012, 0, 0};
+
+            // Loose tier (very likely to produce significantly greater decode speed than default,
+            // moderate ratio loss)
+            inline constexpr param loose_general = {false, BASE, 5292, 0, 0, 13367, 0, 130367};
+            inline constexpr param loose_champion = {false, BASE, 7254, 264, 0, 32768, 0, 129083};
+            inline constexpr param loose_blockonly = {false, BASE, 3381, 219, 0, 0, 0, 0};
+            inline constexpr param loose_longlit = {false, BASE, 4474, 0, 1147, 2514, 0, 96248};
+
+            // Both tiers search through all 10 candidates
+            inline constexpr std::array<param, 10> all_candidates = {{p_default,
+                                                                      tight_general,
+                                                                      tight_short,
+                                                                      tight_deeplit,
+                                                                      tight_guarded,
+                                                                      tight_lean,
+                                                                      loose_general,
+                                                                      loose_champion,
+                                                                      loose_blockonly,
+                                                                      loose_longlit}};
+        } // namespace params
+    } // namespace experimental
+} // namespace misa77

--- a/lz/misa77/src/format.h
+++ b/lz/misa77/src/format.h
@@ -1,0 +1,58 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include <cstdint>
+
+namespace misa77
+{
+    // Width in bytes of several unconditional operations we perform.
+    inline constexpr uint64_t vector_width = 32;
+
+    // (`raw file size <= small_lim`) => small mode, we just write the raw bytes.
+    inline constexpr uint32_t small_lim = 32;
+
+    // When we find a match, we check `lookahead` positions ahead for a potentially better match.
+    inline constexpr uint64_t lookahead = 2;
+
+    // The distance in bytes by which the start of the active hashtable window lags the pointer.
+    // Don't set this too high, as there were a lot of matches for dis in [32, 512].
+    inline constexpr uint64_t hashtab_lag = 32;
+    static_assert(hashtab_lag >= vector_width);
+
+    // If we're asked to copy a match after having processed `c` bytes of raw data, then the match
+    // will begin in `[c - dis_lim - hashtab_lag, c - hashtab_lag)`.
+    inline constexpr uint64_t dis_lim = (uint32_t(1) << 16);
+
+    // We have exactly 2 bytes to indicate distance.
+    static_assert(dis_lim <= (1 << 16));
+
+    inline constexpr uint32_t min_match_len = 4;
+
+    // `min_match_len >= 4` is needed for the compression bound to hold.
+    static_assert(min_match_len >= 4);
+
+    inline constexpr uint32_t max_match_len = 32;
+
+    // One `cyccpy` call should deal with the entire match.
+    static_assert(max_match_len <= vector_width);
+
+    // Lowerbound for the number of literals in the final raw suffix.
+    // This MUST be >= `vector_width` because:
+    // 1. During decompression, `cyccpy` performs unconditional writes in the destination buffer,
+    // and we're using this suffix as padding that we can safely overwrite!!!
+    // 2. During decompression, we perform unconditional reads from the source buffer, and this
+    // literal suffix acts as padding that we can safely "over-read" into!!!
+    inline constexpr uint32_t literal_suffix = 32;
+    static_assert(literal_suffix >= vector_width);
+
+    // Need enough source bytes to be able to guarantee that we can produce the appropriate raw
+    // literal suffix.
+    static_assert(literal_suffix <= small_lim + 1);
+
+    // Unconditionally copied number of literal bytes in decompressor.
+    inline constexpr uint64_t dec_literal_copy = 16;
+    static_assert(literal_suffix >= dec_literal_copy);
+} // namespace misa77

--- a/lz/misa77/src/isa/lib_avx2.h
+++ b/lz/misa77/src/isa/lib_avx2.h
@@ -1,0 +1,64 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+// AVX2 copy/finder policy (256-bit).
+//
+// CONTRACT: the intrinsics below are AVX2, so this header MUST only be included
+// from a TU compiled with -mavx2.
+
+#include <cstdint>
+#include <immintrin.h>
+
+namespace misa77
+{
+    class lib_avx2
+    {
+    public:
+        // Copies `src[0, vector_width)` to `src[dis, dis + vector_width)`.
+        // It's guaranteed that `dis >= vector_width`, so there's no aliasing.
+        [[gnu::always_inline]]
+        static inline void cyccpy(uint8_t* src, uint64_t dis)
+        {
+            __m256i reg = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
+            _mm256_storeu_si256(reinterpret_cast<__m256i*>(src + dis), reg);
+        }
+
+        // Copies `src[0, vector_width)` to `dst[0, vector_width)`.
+        // It's guaranteed that the two ranges don't alias.
+        [[gnu::always_inline]]
+        static inline void copy32(uint8_t* __restrict dst, const uint8_t* __restrict src)
+        {
+            __m256i reg = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
+            _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst), reg);
+        }
+
+        using vec = __m256i;
+
+        // Return internal representation of `src[0, vector_width)`.
+        [[gnu::always_inline]]
+        static inline vec loadvec(const uint8_t* src)
+        {
+            return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
+        }
+
+        // First differing byte index (0-indexed) between `reg1` and `reg2`.
+        // If there's no such index, return `vector_width`.
+        [[gnu::always_inline]]
+        static inline uint64_t lcp(const vec& reg1, const vec& reg2)
+        {
+            const __m256i eq = _mm256_cmpeq_epi8(reg1, reg2);
+            const uint32_t mask = static_cast<uint32_t>(_mm256_movemask_epi8(eq));
+            const uint32_t diff = ~mask;
+
+// __builtin_ctz(0) is UB, but tzcnt is defined for 0 and conveniently returns 32
+#if defined(__BMI__)
+            return static_cast<uint64_t>(_tzcnt_u32(diff));
+#else
+            return diff ? static_cast<uint64_t>(__builtin_ctz(diff)) : 32;
+#endif
+        }
+    };
+} // namespace misa77

--- a/lz/misa77/src/isa/lib_portable.h
+++ b/lz/misa77/src/isa/lib_portable.h
@@ -1,0 +1,69 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+// Portable copy/finder policy.
+//
+// CONTRACT: no ISA requirement, safe to include from any TU.
+
+#include "format.h" // vector_width
+#include "util.h"   // loadu8
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+
+namespace misa77
+{
+    // The compiler should auto-vectorize the `memcpy` calls in here w.r.t. the target architecture,
+    // whenever possible.
+    class lib_portable
+    {
+    public:
+        // Copies `src[0, vector_width)` to `src[dis, dis + vector_width)`
+        // It's guaranteed that `dis >= vector_width`, so there's no aliasing.
+        [[gnu::always_inline]]
+        static inline void cyccpy(uint8_t* src, uint64_t dis)
+        {
+            memcpy(src + dis, src, vector_width);
+        }
+
+        // Copies `src[0, vector_width)` to `dst[0, vector_width)`.
+        // It's guaranteed that the two ranges don't alias.
+        [[gnu::always_inline]]
+        static inline void copy32(uint8_t* __restrict dst, const uint8_t* __restrict src)
+        {
+            memcpy(dst, src, vector_width);
+        }
+
+        // Any internal representation of 32 bytes of contiguous data is fine.
+        using vec = std::array<uint8_t, vector_width>;
+
+        // Return internal representation of `src[0, vector_width)`.
+        [[gnu::always_inline]]
+        static inline vec loadvec(const uint8_t* src)
+        {
+            vec ret;
+            std::memcpy(ret.data(), src, vector_width);
+            return ret;
+        }
+
+        // First differing byte index (0-indexed) between `reg1` and `reg2`.
+        // If there's no such index, return `vector_width`.
+        // Little-endian assumed:
+        // ctz of the XOR points at the lowest differing bit, hence the lowest byte.
+        [[gnu::always_inline]]
+        static inline uint64_t lcp(const vec& reg1, const vec& reg2)
+        {
+            for (uint64_t off = 0; off < vector_width; off += 8)
+            {
+                const uint64_t x = loadu8(reg1.data() + off) ^ loadu8(reg2.data() + off);
+                if (x)
+                    return off + (static_cast<uint64_t>(__builtin_ctzll(x)) >> 3);
+            }
+            return vector_width;
+        }
+    };
+} // namespace misa77

--- a/lz/misa77/src/isa/lib_sse2.h
+++ b/lz/misa77/src/isa/lib_sse2.h
@@ -1,0 +1,77 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+// SSE2 (2x128-bit) copy/finder policy.
+//
+// CONTRACT: SSE2 is guaranteed by the x86-64 ISA, so this header only requires
+// the including TU to be a genuine x86-64 baseline build (-march=x86-64).
+
+#include "format.h" // vector_width
+
+#include <cstdint>
+#include <immintrin.h>
+
+namespace misa77
+{
+    class lib_sse2
+    {
+    public:
+        // Copies `src[0, vector_width)` to `src[dis, dis + vector_width)`.
+        // It's guaranteed that `dis >= vector_width`, so there's no aliasing.
+        [[gnu::always_inline]]
+        static inline void cyccpy(uint8_t* src, uint64_t dis)
+        {
+            __m128i reg1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(src));
+            __m128i reg2 =
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + vector_width / 2));
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(src + dis), reg1);
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(src + dis + vector_width / 2), reg2);
+        }
+
+        // Copies `src[0, vector_width)` to `dst[0, vector_width)`.
+        // It's guaranteed that the two ranges don't alias.
+        [[gnu::always_inline]]
+        static inline void copy32(uint8_t* __restrict dst, const uint8_t* __restrict src)
+        {
+            __m128i reg1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(src));
+            __m128i reg2 =
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + vector_width / 2));
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(dst), reg1);
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(dst + vector_width / 2), reg2);
+        }
+
+        struct vec
+        {
+            __m128i lo, hi;
+        };
+
+        // Return internal representation of `src[0, vector_width)`.
+        [[gnu::always_inline]]
+        static inline vec loadvec(const uint8_t* src)
+        {
+            return vec{_mm_loadu_si128(reinterpret_cast<const __m128i*>(src)),
+                       _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + vector_width / 2))};
+        }
+
+        // First differing byte index (0-indexed) between `reg1` and `reg2`.
+        // If there's no such index, return `vector_width`.
+        [[gnu::always_inline]]
+        static inline uint64_t lcp(const vec& reg1, const vec& reg2)
+        {
+            const __m128i eq0 = _mm_cmpeq_epi8(reg1.lo, reg2.lo);
+            const __m128i eq1 = _mm_cmpeq_epi8(reg1.hi, reg2.hi);
+            const uint32_t mask0 = static_cast<uint32_t>(_mm_movemask_epi8(eq0));
+            const uint32_t mask1 = static_cast<uint32_t>(_mm_movemask_epi8(eq1));
+            const uint32_t diff = ~(mask0 | (mask1 << 16));
+// __builtin_ctz(0) is UB, but tzcnt is defined for 0 and conveniently returns 32
+#if defined(__BMI__)
+            return static_cast<uint64_t>(_tzcnt_u32(diff));
+#else
+            return diff ? static_cast<uint64_t>(__builtin_ctz(diff)) : 32;
+#endif
+        }
+    };
+} // namespace misa77

--- a/lz/misa77/src/isa/target_avx2.cpp
+++ b/lz/misa77/src/isa/target_avx2.cpp
@@ -1,0 +1,40 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+// AVX2 TU.
+// Built only on x86 targets and the implementations herein are chosen at dispatch iff the cpu has
+// AVX2 support.
+
+#include "compress_dispatch.h"
+#include "compressor_zoo/default_compress_impl.h"
+#include "compressor_zoo/loose_compress_impl.h"
+#include "decompress_dispatch.h"
+#include "decompress_impl.h"
+#include "isa/lib_avx2.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    uint64_t compress_avx2(const uint8_t* __restrict src,
+                           uint64_t src_size,
+                           uint8_t* __restrict dst,
+                           uint64_t dst_cap,
+                           config cfg)
+    {
+        if (cfg.level == 0)
+            return loose_compress_impl<lib_avx2>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 1)
+            return default_compress_impl<lib_avx2>(src, src_size, dst, dst_cap);
+        return 0;
+    }
+
+    uint64_t decompress_avx2(const uint8_t* __restrict src,
+                             uint64_t src_size,
+                             uint8_t* __restrict dst,
+                             uint64_t dst_cap)
+    {
+        return decompress_impl<lib_avx2>(src, src_size, dst, dst_cap);
+    }
+} // namespace misa77

--- a/lz/misa77/src/isa/target_portable.cpp
+++ b/lz/misa77/src/isa/target_portable.cpp
@@ -1,0 +1,38 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+// Built on every target.
+
+#include "compress_dispatch.h"
+#include "compressor_zoo/default_compress_impl.h"
+#include "compressor_zoo/loose_compress_impl.h"
+#include "decompress_dispatch.h"
+#include "decompress_impl.h"
+#include "isa/lib_portable.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    uint64_t compress_portable(const uint8_t* __restrict src,
+                               uint64_t src_size,
+                               uint8_t* __restrict dst,
+                               uint64_t dst_cap,
+                               config cfg)
+    {
+        if (cfg.level == 0)
+            return loose_compress_impl<lib_portable>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 1)
+            return default_compress_impl<lib_portable>(src, src_size, dst, dst_cap);
+        return 0;
+    }
+
+    uint64_t decompress_portable(const uint8_t* __restrict src,
+                                 uint64_t src_size,
+                                 uint8_t* __restrict dst,
+                                 uint64_t dst_cap)
+    {
+        return decompress_impl<lib_portable>(src, src_size, dst, dst_cap);
+    }
+} // namespace misa77

--- a/lz/misa77/src/isa/target_sse2.cpp
+++ b/lz/misa77/src/isa/target_sse2.cpp
@@ -1,0 +1,38 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+// Baseline for x86-64 (SSE2 support is guaranteed in the ISA).
+
+#include "compress_dispatch.h"
+#include "compressor_zoo/default_compress_impl.h"
+#include "compressor_zoo/loose_compress_impl.h"
+#include "decompress_dispatch.h"
+#include "decompress_impl.h"
+#include "isa/lib_sse2.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    uint64_t compress_sse2(const uint8_t* __restrict src,
+                           uint64_t src_size,
+                           uint8_t* __restrict dst,
+                           uint64_t dst_cap,
+                           config cfg)
+    {
+        if (cfg.level == 0)
+            return loose_compress_impl<lib_sse2>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 1)
+            return default_compress_impl<lib_sse2>(src, src_size, dst, dst_cap);
+        return 0;
+    }
+
+    uint64_t decompress_sse2(const uint8_t* __restrict src,
+                             uint64_t src_size,
+                             uint8_t* __restrict dst,
+                             uint64_t dst_cap)
+    {
+        return decompress_impl<lib_sse2>(src, src_size, dst, dst_cap);
+    }
+} // namespace misa77

--- a/lz/misa77/src/util.h
+++ b/lz/misa77/src/util.h
@@ -1,0 +1,56 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+
+// ISA-agnostic helpers.
+// See src/isa for ISA-specialized helpers
+
+namespace misa77
+{
+    [[gnu::always_inline]]
+    inline uint16_t loadu2(const uint8_t* ptr)
+    {
+        uint16_t v;
+        memcpy(&v, ptr, 2);
+        return v;
+    }
+
+    [[gnu::always_inline]]
+    inline void storeu2(uint8_t* ptr, const uint16_t val)
+    {
+        memcpy(ptr, &val, 2);
+    }
+
+    [[gnu::always_inline]]
+    inline uint32_t loadu4(const uint8_t* ptr)
+    {
+        uint32_t v;
+        memcpy(&v, ptr, 4);
+        return v;
+    }
+
+    [[gnu::always_inline]]
+    inline void storeu4(uint8_t* ptr, const uint32_t val)
+    {
+        memcpy(ptr, &val, 4);
+    }
+
+    [[gnu::always_inline]]
+    inline uint64_t loadu8(const uint8_t* ptr)
+    {
+        uint64_t v;
+        memcpy(&v, ptr, 8);
+        return v;
+    }
+
+    [[gnu::always_inline]]
+    inline void storeu8(uint8_t* ptr, const uint64_t val)
+    {
+        memcpy(ptr, &val, 8);
+    }
+} // namespace misa77


### PR DESCRIPTION
misa77 is an LZ77 codec for the "write once, read many" niche. It trades compression speed for very high decompression throughput and decent ratios. It decodes much faster than most codecs in its ratio class on most data types and architectures.

- **License**: MIT
- **Repository**: https://github.com/welcome-to-the-sunny-side/misa77

### Registered variants

- `misa77`: fast default compressor (two levels).
- `misa77_adaptive`: autotuned according to input (intended for homogeneous data) (two levels).

Both produce compression streams that conform to the same bitstream format. Therefore, they share the same decoder.

Detailed benchmark results can be found [here](https://github.com/welcome-to-the-sunny-side/misa77/blob/main/README.md). A small portion is attached below.

### Results (silesia.tar, Intel i7-14650HX (@2.2 GHz), single core)

| Compressor name          | Compression | Decompress. |  Ratio |
| ------------------------ | ----------- | ----------- | ------ |
| misa77 0.2.0 -0          |   54.5 MB/s |   5219 MB/s |  42.64 |
| misa77 0.2.0 -1          |   51.2 MB/s |   4274 MB/s |  39.65 |
| zxc 0.12.0 -3            |    115 MB/s |   2841 MB/s |  45.46 |
| zxc 0.12.0 -4            |   80.8 MB/s |   2726 MB/s |  42.63 |
| lzsse8fast 2019-04-18    |    183 MB/s |   2661 MB/s |  44.80 |
| zxc 0.12.0 -5            |   48.6 MB/s |   2599 MB/s |  40.25 |
| lz4hc 1.10.0 -12         |   7.31 MB/s |   2531 MB/s |  36.45 |
| lzsse4fast 2019-04-18    |    186 MB/s |   2522 MB/s |  45.26 |
| lz4 1.10.0               |    371 MB/s |   2505 MB/s |  47.59 |
| lizard 2.1 -10           |    320 MB/s |   2452 MB/s |  48.79 |
| zstd 1.5.7 -1            |    297 MB/s |    901 MB/s |  34.54 |
| snappy 1.2.2             |    375 MB/s |    855 MB/s |  47.89 |

(misa77 rows first, then competitors sorted by decompression speed)

### Requirements

- C++20
- A 64-bit little-endian system.

### Integration

- Added the codec source under `lz/misa77/` (MIT licensed).
- Registered in `bench/codecs.h`, `bench/lz_codecs.cpp`, and `bench/lzbench.h`; listed in `README.md` + `CHANGELOG`.
- Only 64-bit Little-Endian systems are supported, and this is reflected in the additions to the Makefile.
- Runtime ISA dispatch: AVX2/SSE2 on x86-64, portable path elsewhere. The Makefile ensures that TUs with intrinsics are only compiled for x86-64.

### Verification

Benchmarked across the Silesia corpus on x86-64 (Intel + AMD, GCC) and ARM64 (Apple M3). lzbench's built-in decompression check passed on all runs.