### PR TITLE
Add misa77 0.3.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 v2.x.y
 - added OpenZL v0.2.0 (thanks to @fwyzard)
 - updated zxc to 0.13.1 (thanks to @hellobertrand)
+- added misa77 0.3.0 (by @welcome-to-the-sunny-side)
 
 v2.3 (Jun 15, 2026)
 - improvement: Reorganized compressor alias groups by type — ALL is now a composite of LZ /

--- a/Makefile
+++ b/Makefile
@@ -888,6 +888,41 @@ else
     $(ZXC_DIR)/%_neon.o: $(ZXC_DIR)/%.c ; $(CMD_BUILD_ZXC)
 endif
 
+
+# misa77 targets 64-bit little-endian systems and needs C++20.
+MISA77_OK := $(shell printf 'int main(){static_assert(__BYTE_ORDER__==__ORDER_LITTLE_ENDIAN__);static_assert(sizeof(void*)==8);return 0;}' | $(CXX) -std=c++20 -fsyntax-only -x c++ - 2>/dev/null && echo ok)
+ifneq ($(MISA77_OK),ok)
+    DONT_BUILD_MISA77 ?= 1
+endif
+
+ifeq "$(DONT_BUILD_MISA77)" "1"
+    DEFINES += -DBENCH_REMOVE_MISA77
+else
+    MISA77_DIR = lz/misa77
+    MISA77_INC = -I$(MISA77_DIR)/include -I$(MISA77_DIR)/src
+    # always built:
+    MISA77_FILES  = $(MISA77_DIR)/src/compress.o $(MISA77_DIR)/src/decompress.o
+    MISA77_FILES += $(MISA77_DIR)/src/isa/target_portable.o
+    # 64-bit x86 only:
+    ifneq (,$(filter x86_64% amd64%,$(TARGET_ARCH)))
+        MISA77_FILES += $(MISA77_DIR)/src/isa/target_sse2.o $(MISA77_DIR)/src/isa/target_avx2.o
+    endif
+    # 64-bit ARM only
+    ifneq (,$(filter aarch64% arm64%,$(TARGET_ARCH)))
+        MISA77_FILES += $(MISA77_DIR)/src/isa/target_neon.o
+    endif
+
+    CMD_BUILD_MISA77 = @$(MKDIR) $(dir $@) && $(CXX) $(CXXFLAGS) -std=c++20 $(MISA77_INC) $(MISA77_FLAGS) $< -c -o $@
+
+    $(MISA77_DIR)/%_avx2.o: MISA77_FLAGS = -mavx2
+    $(MISA77_DIR)/%_avx2.o: $(MISA77_DIR)/%.cpp ; $(CMD_BUILD_MISA77)
+
+    $(MISA77_DIR)/%_sse2.o: MISA77_FLAGS = -msse2
+    $(MISA77_DIR)/%_sse2.o: $(MISA77_DIR)/%.cpp ; $(CMD_BUILD_MISA77)
+
+    $(MISA77_DIR)/%.o: $(MISA77_DIR)/%.cpp ; $(CMD_BUILD_MISA77)
+endif
+
 # Symmetric codecs
 ifeq "$(DONT_BUILD_BSC)" "1"
     DEFINES += -DBENCH_REMOVE_BSC
@@ -1051,7 +1086,7 @@ endif # ifeq "$(ENABLE_CUDA)"
 
 MKDIR = mkdir -p
 
-lzbench: $(BUGGY_C_FILES) $(BUGGY_CC_FILES) $(BUGGY_CXX_FILES) $(ACEAPEX_FILES) $(BSC_C_FILES) $(BSC_CXX_FILES) $(BSC_CUDA_FILES) $(ACEAPEX_CUDA_FILES) $(BZIP2_FILES) $(BZIP3_FILES) $(CSC_FILES) $(KANZI_FILES) $(FASTLZMA2_OBJ) $(ZSTD_FILES) $(LZSSE_FILES) $(LZFSE_FILES) $(XZ_FILES) $(LIBLZG_FILES) $(BRIEFLZ_FILES) $(LZF_FILES) $(BROTLI_FILES) $(LZMA_FILES) $(ZLING_FILES) $(QUICKLZ_FILES) $(OPENZL_C_FILES) $(OPENZL_S_FILES) $(SNAPPY_FILES) $(ZLIB_FILES) $(ZLIB_NG_FILES) $(LZHAM_FILES) $(LZO_FILES) $(UCL_FILES) $(LZ4_FILES) $(LIZARD_FILES) $(LIBDEFLATE_FILES) $(ZXC_FILES) $(MISC_FILES) $(NVCOMP_FILES) $(PPMD_FILES) $(BENCH_FILES) $(SKIM_FILE)
+lzbench: $(BUGGY_C_FILES) $(BUGGY_CC_FILES) $(BUGGY_CXX_FILES) $(ACEAPEX_FILES) $(BSC_C_FILES) $(BSC_CXX_FILES) $(BSC_CUDA_FILES) $(ACEAPEX_CUDA_FILES) $(BZIP2_FILES) $(BZIP3_FILES) $(CSC_FILES) $(KANZI_FILES) $(FASTLZMA2_OBJ) $(ZSTD_FILES) $(LZSSE_FILES) $(LZFSE_FILES) $(XZ_FILES) $(LIBLZG_FILES) $(BRIEFLZ_FILES) $(LZF_FILES) $(BROTLI_FILES) $(LZMA_FILES) $(ZLING_FILES) $(QUICKLZ_FILES) $(OPENZL_C_FILES) $(OPENZL_S_FILES) $(SNAPPY_FILES) $(ZLIB_FILES) $(ZLIB_NG_FILES) $(LZHAM_FILES) $(LZO_FILES) $(UCL_FILES) $(LZ4_FILES) $(LIZARD_FILES) $(LIBDEFLATE_FILES) $(ZXC_FILES) $(MISA77_FILES) $(MISC_FILES) $(NVCOMP_FILES) $(PPMD_FILES) $(BENCH_FILES) $(SKIM_FILE)
 	$(CXX) $^ -o $@ $(LDFLAGS)
 	@echo Linked GCC_VERSION=$(GCC_VERSION) CLANG_VERSION=$(CLANG_VERSION) COMPILER=$(COMPILER)
 
@@ -1123,7 +1158,7 @@ $(LIZARD_FILES): %.o : %.c
 
 $(LZ_CODECS): %.o : %.cpp
 	@$(MKDIR) $(dir $@)
-	$(CXX) $(CXXFLAGS) -Ilz -Ilz/brotli/include -Ilz/openzl/include -Ilz/zxc/src/lib/vendors $< -c -o $@
+	$(CXX) $(CXXFLAGS) -Ilz -Ilz/brotli/include -Ilz/openzl/include -Ilz/zxc/src/lib/vendors -Ilz/misa77/include $< -c -o $@
 
 $(LZHAM_FILES): %.o : %.cpp
 	@$(MKDIR) $(dir $@)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Notes column says otherwise.
 | [lzo 2.10](http://www.oberhumer.com/opensource/lzo) | 2017-03-01 | |
 | [lzsse 2019-04-18 (1847c3e827)](https://github.com/ConorStokes/LZSSE) | 2019-04-18 | 64-bit x86 only — requires SSE4.1 (Windows: MinGW-w64 only); lzsse8fast has a [bug](https://github.com/ConorStokes/LZSSE/issues/14) |
 | [memlz 0.2 beta](https://github.com/rrrlasse/memlz) | 2025-11-03 | Disabled on 32-bit ARM — unaligned access faults (SIGBUS) |
+| [misa77 0.3.0](https://github.com/welcome-to-the-sunny-side/misa77) | 2026-07-18 | Little-endian 64-bit only |
 | [nvcomp 2.2.0](https://github.com/NVIDIA/nvcomp) | 2022-02-07 | CUDA only — built with `make ENABLE_CUDA=1`; not in the default CI matrix |
 | [openzl 0.2.0](https://openzl.org/) | 2026-05-07 | 64-bit only — upstream does not support 32-bit builds |
 | [ppmd8 26.01](http://7-zip.org) | 2026-04-27 | |

--- a/bench/codecs.h
+++ b/bench/codecs.h
@@ -416,6 +416,17 @@ int64_t lzbench_memcpy(char *inbuf, size_t insize, char *outbuf, size_t outsize,
 #endif
 
 
+#ifndef BENCH_REMOVE_MISA77
+    int64_t lzbench_misa77_compress(char* inbuf, size_t insize, char* outbuf, size_t outsize, codec_options_t* codec_options);
+    int64_t lzbench_misa77_decompress(char* inbuf, size_t insize, char* outbuf, size_t outsize, codec_options_t* codec_options);
+    int64_t lzbench_misa77_safe_decompress(char* inbuf, size_t insize, char* outbuf, size_t outsize, codec_options_t* codec_options);
+#else
+    #define lzbench_misa77_compress NULL
+    #define lzbench_misa77_decompress NULL
+    #define lzbench_misa77_safe_decompress NULL
+#endif
+
+
 #ifndef BENCH_REMOVE_OPENZL
     char* lzbench_openzl_init_serial(size_t insize, size_t level, size_t);
     template <typename TInteger>

--- a/bench/lz_codecs.cpp
+++ b/bench/lz_codecs.cpp
@@ -57,6 +57,30 @@ int64_t lzbench_memlz_decompress(char* inbuf, size_t insize, char* outbuf, size_
 
 
 
+#ifndef BENCH_REMOVE_MISA77
+#include "misa77/misa77.h"
+
+int64_t lzbench_misa77_compress(char* inbuf, size_t insize, char* outbuf, size_t outsize, codec_options_t* codec_options)
+{
+    // level 0 = fastest decompression, level 1 = best ratio (the library default)
+    return (int64_t)misa77::compress((const uint8_t*)inbuf, insize, (uint8_t*)outbuf, outsize, misa77::config((uint8_t)codec_options->level));
+}
+
+// All misa77 levels emit one format, so the misa77_* codecs share compressed streams; the
+// two decompressors below differ only in input validation.
+int64_t lzbench_misa77_decompress(char* inbuf, size_t insize, char* outbuf, size_t outsize, codec_options_t* codec_options)
+{
+    return (int64_t)misa77::decompress((const uint8_t*)inbuf, insize, (uint8_t*)outbuf, outsize);
+}
+
+int64_t lzbench_misa77_safe_decompress(char* inbuf, size_t insize, char* outbuf, size_t outsize, codec_options_t* codec_options)
+{
+    return (int64_t)misa77::decompress((const uint8_t*)inbuf, insize, (uint8_t*)outbuf, outsize, misa77::dconfig(true));
+}
+#endif // BENCH_REMOVE_MISA77
+
+
+
 #ifndef BENCH_REMOVE_BRIEFLZ
 #include "lz/brieflz/brieflz.h"
 

--- a/bench/lzbench.h
+++ b/bench/lzbench.h
@@ -236,6 +236,8 @@ static const compressor_desc_t comp_desc[] =
     { "lzsse8fast", "lzsse8fast 2019-04-18",   0,   0,    0,  BENCH_POOL_MT, lzbench_lzsse8fast_compress, lzbench_lzsse8_decompress,     lzbench_lzsse8fast_init, lzbench_lzsse8fast_deinit },
     { "lzvn",       "lzvn 2017-03-08",         0,   0,    0,  BENCH_POOL_MT, lzbench_lzvn_compress,       lzbench_lzvn_decompress,       lzbench_lzvn_init,       lzbench_lzvn_deinit },
     { "memlz",      "memlz 0.2 beta",          0,   0,    0,  BENCH_POOL_MT, lzbench_memlz_compress,      lzbench_memlz_decompress,      lzbench_memlz_init,      lzbench_memlz_deinit },
+    { "misa77",      "misa77 0.3.0",           0,   1,    0,  BENCH_POOL_MT, lzbench_misa77_compress,     lzbench_misa77_decompress,      NULL, NULL },
+    { "misa77_safe", "misa77 0.3.0 safe",      0,   1,    0,  BENCH_POOL_MT, lzbench_misa77_compress,     lzbench_misa77_safe_decompress, NULL, NULL },
     { "nvcomp_lz4", "nvcomp_lz4 2.2.0",        0,   7,    0,  BENCH_POOL_MT, lzbench_nvcomp_compress,     lzbench_nvcomp_decompress,     lzbench_nvcomp_init,     lzbench_nvcomp_deinit },
     { "openzl_u8",  "openzl 0.2.0 -p u8",       0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(uint8_t),  lzbench_openzl_deinit },
     { "openzl_i8",  "openzl 0.2.0 -p i8",       0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(int8_t),  lzbench_openzl_deinit },

--- a/lz/misa77/LICENSE
+++ b/lz/misa77/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lz/misa77/README.md
+++ b/lz/misa77/README.md
@@ -1,0 +1,228 @@
+# misa77 (0.3.0)
+
+misa77 is an LZ-based codec that targets the write-once, read-many niche. In particular, it aims to satisfy the following criteria:
+
+- Extremely high decompression throughput (single-threaded).
+- Modest compression ratios (LZ4 at high effort levels is a good reference point).
+- Constant memory use, regardless of input size (<= 5 MB across all compression modes, and 0 MB for decompression).
+
+Slow compression is the obvious tradeoff that one makes to achieve the above.
+
+In addition, misa77 has a somewhat synergizing tendency to decompress highly compressed files faster. This makes high-effort compression particularly attractive for misa77, and inspires some experimental compression modes (refer to [src/experimental/](src/experimental/)) that aim to spend more effort at compression time to produce a compressed stream that is friendlier to the microarchitectures of most CPUs when decompressing said streams.
+
+misa77 has two compression effort levels as of v0.3.0:
+
+- level 0: offers better decode throughput, slightly worse ratio, similar encode throughput
+- level 1 (default): offers slightly worse decode throughput, better ratio, similar encode throughput
+
+There are two decompressor modes:
+
+- unsafe: passing invalid input to this mode is UB.
+- safe: guaranteed to exit gracefully (ie. provably terminate, and not access out-of-bounds memory or engage in any other UB) in the case of corrupt/malicious input, is 2-4% slower than unsafe.
+
+## Benchmarks
+
+Detailed results are listed ahead, but here's a terse summary:
+
+- misa77 lies on the pareto frontier for decompression throughput vs compression ratio on most shapes of data.
+- It very frequently decompresses faster even when competitors have a significantly worse ratio.
+- It is quite slow at compression.
+- Performance is a bit sensitive to codegen, but even with the worst possible codegen I saw in my testing, misa77 was significantly faster than other codecs.
+
+Let's first see some cross-platform results for the [Silesia Corpus](https://sun.aei.polsl.pl//~sdeor/corpus/silesia.zip).
+
+Note:
+
+1. "Ratio" ahead is equal to `((compressed size)/(original)) * 100` (so lower is better).
+2. The benchmarking harness is a public fork of lzbench, and can be accessed [here](https://github.com/welcome-to-the-sunny-side/lzbench/tree/add-misa77-0.3.0).
+3. In the tables ahead, rows are sorted by decompression speed.
+
+---
+
+### Intel x86-64
+
+Details:
+
+- CPU: Intel(R) Core(TM) i7-14650HX (@2.2 GHz) (Intel Turbo disabled).
+- Single threaded, pinned to a single performance core.
+- CPU governor set to `performance`.
+
+| Compressor name       | Compression | Decompress. |  Ratio | Filename    |
+| --------------------- | ----------- | ----------- | ------ | ----------- |
+| misa77 0.3.0 -0       |   54.1 MB/s |   5363 MB/s |  42.64 | silesia.tar |
+| misa77 0.3.0 safe -0  |   54.1 MB/s |   5205 MB/s |  42.64 | silesia.tar |
+| misa77 0.3.0 -1       |   51.2 MB/s |   4372 MB/s |  39.65 | silesia.tar |
+| misa77 0.3.0 safe -1  |   51.2 MB/s |   4235 MB/s |  39.65 | silesia.tar |
+| zxc 0.13.1 -3         |    116 MB/s |   2830 MB/s |  45.46 | silesia.tar |
+| zxc 0.13.1 -4         |   81.0 MB/s |   2721 MB/s |  42.63 | silesia.tar |
+| lzsse8fast 2019-04-18 |    183 MB/s |   2668 MB/s |  44.80 | silesia.tar |
+| zxc 0.13.1 -5         |   48.4 MB/s |   2599 MB/s |  40.25 | silesia.tar |
+| lzsse4fast 2019-04-18 |    187 MB/s |   2538 MB/s |  45.26 | silesia.tar |
+| lz4hc 1.10.0 -12      |   7.31 MB/s |   2533 MB/s |  36.45 | silesia.tar |
+| lz4 1.10.0            |    371 MB/s |   2510 MB/s |  47.59 | silesia.tar |
+| lzav 5.11 -1          |    297 MB/s |   1725 MB/s |  39.94 | silesia.tar |
+| zstd 1.5.7 -1         |    296 MB/s |    903 MB/s |  34.54 | silesia.tar |
+| snappy 1.2.2          |    375 MB/s |    858 MB/s |  47.89 | silesia.tar |
+
+---
+
+### ARM64 (Apple Silicon)
+
+Details: 
+
+- CPU: Apple M3
+
+| Compressor name       | Compression | Decompress. |  Ratio | Filename    |
+| --------------------- | ----------- | ----------- | ------ | ----------- |
+| misa77 0.3.0 safe -0  |    133 MB/s |  12561 MB/s |  42.64 | silesia.tar |
+| misa77 0.3.0 -0       |    134 MB/s |  12537 MB/s |  42.64 | silesia.tar |
+| misa77 0.3.0 -1       |    122 MB/s |  10225 MB/s |  39.65 | silesia.tar |
+| misa77 0.3.0 safe -1  |    125 MB/s |  10057 MB/s |  39.65 | silesia.tar |
+| zxc 0.13.1 -3         |    271 MB/s |   8011 MB/s |  45.77 | silesia.tar |
+| zxc 0.13.1 -4         |    182 MB/s |   7640 MB/s |  43.20 | silesia.tar |
+| zxc 0.13.1 -5         |    111 MB/s |   7137 MB/s |  40.30 | silesia.tar |
+| lz4 1.10.0            |    919 MB/s |   5311 MB/s |  47.59 | silesia.tar |
+| lz4hc 1.10.0 -12      |   16.7 MB/s |   4892 MB/s |  36.45 | silesia.tar |
+| lzav 5.11 -1          |    740 MB/s |   4358 MB/s |  39.93 | silesia.tar |
+| snappy 1.2.2          |    969 MB/s |   3445 MB/s |  47.91 | silesia.tar |
+| zstd 1.5.7 -1         |    717 MB/s |   1619 MB/s |  34.54 | silesia.tar |
+
+---
+
+As misa77's performance is quite "spiky" (depending on the shape of the data being compressed), a file-level breakdown for the silesia corpus yields some interesting insights into its performance. 
+
+Note: 
+
+- The visuals that follow are derived from the benchmark results at [misc/lzbench-results-archive/0.3.0/intel.txt](misc/lzbench-results-archive/0.3.0/intel.txt)
+- These results are with the same x86-64 (Intel) setup mentioned previously.
+
+### Decode speed relative to lz4
+
+At level 0, misa77 decodes faster than lz4 on all 12 files (some by huge margins). Level 1 decodes faster on 11/12 files. The exception is `x-ray`, which is highly incompressible (lz4 has a ratio of nearly 1.0 on this file and essentially devolves to a `memcpy`).
+
+![misa77 per-file decode speed vs lz4, levels 0 and 1, Silesia (Intel)](misc/lzbench-results-archive/0.3.0/speedup_vs_lz4.png)
+
+### Throughput vs ratio, against popular fast-decode codecs
+
+On the compressible files, misa77 sits on the decode-throughput/ratio Pareto frontier: it decodes fastest while ~matching or beating the ratio of the other fast-LZ codecs. `x-ray` is an exception once again.
+
+To spot misa77 in these graphs, just look for the circles near the top :)
+
+![misa77 vs other codecs: per-file decode throughput vs ratio, Silesia (Intel)](misc/lzbench-results-archive/0.3.0/pareto_silesia.png)
+
+## Requirements
+
+For the library:
+
+- A C++20 compiler (both GCC and Clang are fine).
+- CMake >= 3.20.
+- A little-endian 64-bit system.
+
+For the CLI:
+
+- The `misa` CLI needs POSIX (Linux, macOS).
+
+Note: On x86-64, AVX2/SSE2 are selected at runtime. ARM has a NEON path.
+
+## Building
+
+```sh
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+```
+
+This produces the `misa` CLI at `build/misa`. For a binary tuned to the exact machine you'll run it on, add `-DMISA77_MARCH=native` (I recommend this). To run the round-trip test:
+
+```sh
+ctest --test-dir build
+```
+
+## Library Usage
+
+The build produces a static library (CMake target `misa77`) with a small C++ API in `misa77/misa77.h`. The easiest integration is a git submodule (or CMake `FetchContent`) plus:
+
+```cmake
+add_subdirectory(misa77)
+target_link_libraries(your_app PRIVATE misa77)
+```
+
+Sample usage:
+
+```cpp
+#include <misa77/misa77.h>
+#include <vector>
+
+// compress (pick a level with misa77::config(0/1); default is 1), returns 0 on failure
+std::vector<uint8_t> compressed(misa77::compress_bound(input_size));
+uint64_t csize = misa77::compress(input, input_size, compressed.data(), compressed.size());
+compressed.resize(csize);
+
+// decompress, returns original_size on success
+uint64_t original_size = misa77::decompressed_size(compressed.data());
+std::vector<uint8_t> output(misa77::decompressed_buffer_bound(original_size));
+// decompress uses the unsafe decompressor by default, pass dconfig(true) to use the safe decompressor
+uint64_t written = misa77::decompress(compressed.data(), csize, output.data(), output.size(), misa77::dconfig(true));
+```
+
+Two things to keep in mind:
+
+- You must size the destination buffers with `compress_bound` / `decompressed_buffer_bound`.
+- You must pass `misa77::dconfig(true)` to `misa77::decompress` if you want the decompressor to exit gracefully on invalid input.
+
+The experimental modes are declared in `misa77/experimental.h`, with usage documented in comments (these keep changing frequently so I don't wanna "formally" document them here just yet).
+
+## CLI Usage
+
+`misa` is a single, dependency-free binary with three file-based subcommands. It operates on single files only (there's no directory or pipe support, so `tar` first if you need those).
+
+```sh
+misa compress   FILE          # -> FILE.misa77
+misa decompress FILE.misa77   # -> FILE
+misa suggest    FILE          # -> FILE.misap  (tuned params)
+```
+
+`misa compress` takes `-l N` / `--level N` to pick the compression level (default is 1).
+
+There are also some experimental compression modes (at most one at a time, not combinable with `--level`):
+
+| Flag | Effect |
+| ---- | ------ |
+| `--adaptive` | autotune the compressor based on the input for decode speed (only use this with homogeneous data) |
+| `--params F.misap` | compress with a vector from `misa suggest` |
+| `--yolo` | high-effort, decode-optimized |
+
+`--adaptive` and `suggest` also take `--tune loose` / `--tune tight` (similar tradeoffs as `level 0/1`, and the default is loose) and `--sample MB` (how much input to sample when picking params, default is 2 MB). Everywhere, `-o PATH` sets the output path and `-f` overwrites without asking.
+
+```sh
+misa compress -l 0 enwik8                # enwik8 -> enwik8.misa77, fastest-decode level
+misa decompress enwik8.misa77            # back to enwik8
+
+# tune on a sample, then reuse the params:
+misa suggest --tune tight data.bin       # -> data.misap
+misa compress --params data.misap data.bin
+```
+
+## Documentation
+
+The underlying stream format (used by the library functions) and the container format for `.misa77` files (produced by the CLI) can be found in [`docs/`](docs/).
+
+## Status
+
+1. misa77's format may change unexpectedly as it's still v0.x.y. 
+2. It's been through local fuzzing with ASan/UBSan, broader hardening is ongoing.
+
+Note: misa77 has evolved out of a less polished endeavour to learn performance engineering, and its history can be found [in this archived repository](https://github.com/welcome-to-the-sunny-side/misa77-archive).
+
+## Acknowledgement
+
+Inspiration has been taken from:
+
+- [LZ4](http://github.com/lz4/lz4/)
+- [zxc](https://github.com/hellobertrand/zxc)
+- [lizard](https://github.com/inikep/lizard)
+
+Lastly, Claude Opus 4.8 and Fable 5 helped a lot with scripting, tooling, and building the CLI.
+
+## License
+
+MIT (see [LICENSE](LICENSE)).

--- a/lz/misa77/include/misa77/misa77.h
+++ b/lz/misa77/include/misa77/misa77.h
@@ -1,0 +1,84 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include <cstdint>
+
+// Library version
+#define MISA77_VERSION_MAJOR 0
+#define MISA77_VERSION_MINOR 3
+#define MISA77_VERSION_PATCH 0
+#define MISA77_VERSION_NUMBER                                                                      \
+    (MISA77_VERSION_MAJOR * 10000 + MISA77_VERSION_MINOR * 100 + MISA77_VERSION_PATCH)
+#define MISA77_STR_HELPER(x) #x
+#define MISA77_STR(x) MISA77_STR_HELPER(x)
+#define MISA77_VERSION_STR                                                                         \
+    MISA77_STR(MISA77_VERSION_MAJOR)                                                               \
+    "." MISA77_STR(MISA77_VERSION_MINOR) "." MISA77_STR(MISA77_VERSION_PATCH)
+
+namespace misa77
+{
+    // `1e17`
+    inline constexpr uint64_t max_src_size = 100'000'000'000'000'000;
+
+    // compressor config
+    class config
+    {
+    public:
+        // Only integers in [0, max_level] are valid levels
+        static constexpr uint8_t max_level = 1;
+        static constexpr uint8_t default_level = 1;
+        static_assert(default_level <= max_level);
+
+        uint8_t level;
+        config() : level(default_level) {}
+        explicit config(uint8_t l) : level(l) {}
+    };
+
+    // decompressor config
+    class dconfig
+    {
+    public:
+        static constexpr uint8_t default_safety = false;
+
+        bool safe;
+        dconfig() : safe(default_safety) {}
+        explicit dconfig(bool s) : safe(s) {}
+    };
+
+    // Upper-bound on compressed size (in bytes) for any input of size `src_size` bytes.
+    // Use to size destination buffer.
+    // PRECONDITION: `src_size <= max_src_size`
+    uint64_t compress_bound(uint64_t src_size);
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // `cfg.level` selects the compressor to be used (all levels conform to the same format).
+    // PRECONDITION: `src_size <= max_src_size` and `0 <= cfg.level <= config::max_level`
+    uint64_t compress(const uint8_t* __restrict src,
+                      uint64_t src_size,
+                      uint8_t* __restrict dst,
+                      uint64_t dst_cap,
+                      config cfg = config());
+
+    // Returns the exact size (in bytes) of the file that the given compressed file will be
+    // decompressed to.
+    // Only call this on buffers that were compressed in the misa77 format, as it
+    // requires the size of the buffer to be >= 8.
+    uint64_t decompressed_size(const uint8_t* src);
+
+    // Minimum size of buffer required to decompress a compressed file that corresponds to an
+    // original file of `src_size` bytes.
+    // Usage: decompressed_buffer_bound(decompressed_size(src))
+    uint64_t decompressed_buffer_bound(uint64_t src_size);
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // PRECONDITION: (dcfg.safe = true) OR (`src` and `src_size` must correspond to a valid misa77
+    // stream) Passing (dcfg.safe = false) and an invalid misa77 stream is UB!
+    uint64_t decompress(const uint8_t* __restrict src,
+                        uint64_t src_size,
+                        uint8_t* __restrict dst,
+                        uint64_t dst_cap,
+                        dconfig dcfg = dconfig());
+} // namespace misa77

--- a/lz/misa77/src/compress.cpp
+++ b/lz/misa77/src/compress.cpp
@@ -1,0 +1,43 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#include "compress_dispatch.h"
+#include "misa77/misa77.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    // Upper-bound on compressed size (in bytes) for any input of size `src_size` bytes.
+    // Use to size destination buffer.
+    // PRECONDITION: `src_size <= max_src_size`
+    uint64_t compress_bound(uint64_t src_size)
+    {
+        return uint64_t(8)   // uncompressed size
+               + uint64_t(8) // number of trailing raw literals (>= `literal_suffix`)
+               + src_size + (src_size / uint64_t(255)) +
+               uint64_t(16); // compressed data length upper-bound
+    }
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // Resolves the best finder path once per call, depending on the ISA.
+    // PRECONDITION: `src_size <= max_src_size`
+    uint64_t compress(const uint8_t* __restrict src,
+                      uint64_t src_size,
+                      uint8_t* __restrict dst,
+                      uint64_t dst_cap,
+                      config cfg)
+    {
+#if defined(__x86_64__)
+        if (__builtin_cpu_supports("avx2"))
+            return compress_avx2(src, src_size, dst, dst_cap, cfg);
+        return compress_sse2(src, src_size, dst, dst_cap, cfg);
+#elif defined(__aarch64__)
+        // NEON is guaranteed on Aarch64
+        return compress_neon(src, src_size, dst, dst_cap, cfg);
+#else
+        return compress_portable(src, src_size, dst, dst_cap, cfg);
+#endif
+    }
+} // namespace misa77

--- a/lz/misa77/src/compress_dispatch.h
+++ b/lz/misa77/src/compress_dispatch.h
@@ -1,0 +1,37 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "misa77/misa77.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    // ISA-specialized compress entry points. Each is defined in a per-target TU in src/isa/,
+    // compiled with that ISA's flags (target_avx2.cpp with -mavx2, target_sse2.cpp /
+    // target_portable.cpp at baseline, target_neon.cpp at armv8-a), and selected at runtime
+    // by compress() (see compress.cpp).
+    uint64_t compress_avx2(const uint8_t* __restrict src,
+                           uint64_t src_size,
+                           uint8_t* __restrict dst,
+                           uint64_t dst_cap,
+                           config cfg);
+    uint64_t compress_sse2(const uint8_t* __restrict src,
+                           uint64_t src_size,
+                           uint8_t* __restrict dst,
+                           uint64_t dst_cap,
+                           config cfg);
+    uint64_t compress_neon(const uint8_t* __restrict src,
+                           uint64_t src_size,
+                           uint8_t* __restrict dst,
+                           uint64_t dst_cap,
+                           config cfg);
+    uint64_t compress_portable(const uint8_t* __restrict src,
+                               uint64_t src_size,
+                               uint8_t* __restrict dst,
+                               uint64_t dst_cap,
+                               config cfg);
+} // namespace misa77

--- a/lz/misa77/src/compressor_zoo/default_compress_impl.h
+++ b/lz/misa77/src/compressor_zoo/default_compress_impl.h
@@ -1,0 +1,261 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "format.h"
+#include "misa77/misa77.h"
+#include "util.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace misa77
+{
+    static_assert(max_match_len >= 32);
+
+    namespace default_detail
+    {
+        constexpr uint32_t hash_top = 16;
+        constexpr uint32_t hash_siz = 1 << hash_top;
+        constexpr uint32_t hash_mul = 2654435761;
+
+        // Size of ring buffer per hash in the hashtable.
+        inline constexpr uint64_t hashtab_wid = 16;
+
+        // Hash 4 bytes to an integer in `[0, 1 << (hash_top))`.
+        [[gnu::always_inline]]
+        inline uint32_t hash4(const uint32_t val)
+        {
+            return (val * hash_mul) >> (32 - hash_top);
+        }
+
+        // Assuming that rem contains top 3 bits of the token, emits bytes specifying `n`.
+        [[gnu::always_inline]]
+        inline void emit_length_extras(uint8_t* dst, uint64_t& dlpos, uint64_t n, uint8_t rem)
+        {
+            if (rem != uint8_t(7)) [[likely]]
+                return;
+
+            // Write this unconditionally first, if it's wrong we'll just overwrite
+            dst[dlpos] = static_cast<uint8_t>(n);
+
+            constexpr uint64_t block = 255;
+            if (n >= block) [[unlikely]]
+            {
+                while (n >= block) [[unlikely]]
+                    dst[dlpos] = block, ++dlpos, n -= block;
+                dst[dlpos] = static_cast<uint8_t>(n);
+            }
+
+            ++dlpos;
+        }
+
+        // Don't look further ahead once you have a match `>= la_gate`
+        constexpr uint64_t la_gate = 16;
+
+        // Once you have match `>= la_pate`, only keep looking if you get gains
+        constexpr uint64_t la_pate = 8;
+
+        // When you've gone `p` hashtab searches without a match, advance the pointer by `p >>
+        // skip_shift`
+        constexpr uint64_t skip_shift = 6;
+    } // namespace default_detail
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // `isa_lib` is ISA-dependent.
+    template <class isa_lib>
+    uint64_t default_compress_impl(const uint8_t* __restrict src,
+                                   uint64_t src_size,
+                                   uint8_t* __restrict dst,
+                                   uint64_t dst_cap)
+    {
+        using namespace default_detail;
+
+        if (compress_bound(src_size) > dst_cap)
+            return 0;
+
+        // Left pointer in the destination buffer (metadata and control bytes)
+        uint64_t dlpos = 0;
+
+        // Right pointer in the destination buffer (literal bytes)
+        // We've written to `[drpos, dst_cap)` at any given point of time
+        uint64_t drpos = dst_cap;
+
+        storeu8(dst, src_size);
+        dlpos += 8;
+
+        // Small source
+        if (src_size <= small_lim)
+        {
+            if (src_size != 0)
+                memcpy(dst + dlpos, src, src_size);
+            dlpos += src_size;
+            return dlpos;
+        }
+
+        uint64_t literal_suffix_pos = dlpos;
+        dlpos += 8;
+
+        // Ensure that the last `literal_suffix` bytes will be literals
+        uint64_t match_end_limit = (src_size < literal_suffix ? 0 : src_size - literal_suffix);
+
+        // Beginning of the pending literal window
+        uint64_t lit = 0;
+
+        // `[lit, pos]` corresponds to the new range from the src buffer we're going to be
+        // turning into a lit + match pair
+        uint64_t pos = 0;
+
+        // `[0, hpos)` represents the range we've written into the hashtable
+        uint64_t hpos = 0;
+
+        uint64_t miss_run = 0;
+
+        std::vector<std::array<uint16_t, hashtab_wid>> hashtab(hash_siz);
+        std::vector<uint8_t> hashtab_idx(hash_siz);
+        while (pos + max_match_len <= match_end_limit)
+        {
+            // Reduce branch misses, `batch = 8` performs well empirically
+            constexpr uint64_t batch = 8;
+            while (pos >= hpos + hashtab_lag + batch) [[unlikely]]
+            {
+#pragma GCC unroll batch
+                for (uint64_t i = 0; i < batch; i++)
+                {
+                    uint32_t hsh = hash4(loadu4(src + hpos + i));
+                    hashtab[hsh][hashtab_idx[hsh]] =
+                        uint16_t(hpos + i); // We just store the lowest 2 bytes
+                    hashtab_idx[hsh] =
+                        (hashtab_idx[hsh] == hashtab_wid - 1
+                             ? uint8_t(0)
+                             : hashtab_idx[hsh] + 1); // Just cycle the pointer in the ring buffer
+                }
+                hpos += batch;
+            }
+
+            uint32_t val = loadu4(src + pos);
+            uint32_t hsh = hash4(val);
+
+            uint64_t lst = 0;
+            uint64_t match_len = 0;
+
+            typename isa_lib::vec reg = isa_lib::loadvec(src + pos);
+
+            if (pos > hashtab_lag) [[likely]]
+            {
+// MLP
+#pragma GCC unroll hashtab_wid
+                for (uint8_t i = 0; i < hashtab_wid; i++)
+                {
+                    uint16_t d = uint16_t(pos - hashtab[hsh][i] - hashtab_lag - 1);
+
+                    // Guaranteed to lie within `[pos - 2^16 - hashtab_lag, pos - hashtab_lag)`
+                    uint64_t ilst = (pos - max_match_len - 1 - d);
+
+                    typename isa_lib::vec ireg = isa_lib::loadvec(src + ilst);
+                    uint32_t imatch_len = isa_lib::lcp(reg, ireg);
+                    lst = (imatch_len > match_len ? ilst : lst);
+                    match_len = (imatch_len > match_len ? imatch_len : match_len);
+                }
+            }
+
+            if (match_len >= min_match_len)
+            {
+                for (uint64_t npos = pos + 1;
+                     npos <= pos + lookahead and npos + max_match_len <= match_end_limit and
+                     match_len < la_gate;
+                     npos++)
+                {
+                    uint64_t nlst = 0;
+                    uint64_t nmatch_len = 0;
+
+                    uint32_t val = loadu4(src + npos);
+                    uint32_t hsh = hash4(val);
+                    typename isa_lib::vec reg = isa_lib::loadvec(src + npos);
+#pragma GCC unroll hashtab_wid
+                    for (uint8_t i = 0; i < hashtab_wid; i++)
+                    {
+                        uint16_t d = uint16_t(npos - hashtab[hsh][i] - hashtab_lag - 1);
+
+                        // Guaranteed to lie within `[npos - 2^16 - hashtab_lag, npos -
+                        // hashtab_lag)`
+                        uint64_t ilst = (npos - max_match_len - 1 - d);
+
+                        typename isa_lib::vec ireg = isa_lib::loadvec(src + ilst);
+                        uint32_t imatch_len = isa_lib::lcp(reg, ireg);
+
+                        nlst = (imatch_len > nmatch_len ? ilst : nlst);
+                        nmatch_len = (imatch_len > nmatch_len ? imatch_len : nmatch_len);
+                    }
+
+                    bool improved = (nmatch_len > match_len);
+                    pos = (improved ? npos : pos);
+                    lst = (improved ? nlst : lst);
+                    match_len = (improved ? nmatch_len : match_len);
+
+                    if (!improved and match_len >= la_pate)
+                        break;
+                }
+
+                uint64_t norm_match_len = match_len - min_match_len + 1;
+
+                // `src[lit, pos)` are the literals
+                uint64_t lit_len = pos - lit;
+
+                // Token Byte
+                uint8_t lrem = std::min(uint64_t(7), lit_len);
+                dst[dlpos] = static_cast<uint8_t>((lrem << 5) | (norm_match_len));
+                lit_len -= lrem;
+                ++dlpos;
+
+                // 2 Distance bytes
+                uint64_t dis = pos - lst;
+                uint16_t dbytes = dis - hashtab_lag - 1;
+                storeu2(dst + dlpos, dbytes);
+                dlpos += 2;
+
+                // Extra literal length bytes
+                emit_length_extras(dst, dlpos, lit_len, lrem);
+
+                // Literal bytes
+                if (lit < pos)
+                {
+                    uint64_t lit_cnt = pos - lit;
+                    drpos -= lit_cnt;
+                    memcpy(dst + drpos, src + lit, lit_cnt);
+                }
+
+                pos += match_len;
+                lit = pos;
+                miss_run = 0;
+            }
+            else
+            {
+                pos += 1 + (miss_run >> skip_shift);
+                ++miss_run;
+            }
+        }
+
+        // Close the gap between the two streams by moving the literal stream to the left
+        if (drpos < dst_cap)
+        {
+            memmove(dst + dlpos, dst + drpos, dst_cap - drpos);
+            dlpos += dst_cap - drpos;
+        }
+
+        // Just deal with the last few literals (guaranteed to be `>= literal_suffix >=
+        // vector_width` bytes)
+        uint64_t literal_suffix_cnt = src_size - lit;
+        storeu8(dst + literal_suffix_pos, literal_suffix_cnt);
+        memcpy(dst + dlpos, src + lit, literal_suffix_cnt);
+        dlpos += literal_suffix_cnt;
+
+        return dlpos;
+    }
+
+} // namespace misa77

--- a/lz/misa77/src/compressor_zoo/loose_compress_impl.h
+++ b/lz/misa77/src/compressor_zoo/loose_compress_impl.h
@@ -1,0 +1,294 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "format.h"
+#include "misa77/misa77.h"
+#include "util.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace misa77
+{
+    static_assert(max_match_len >= 32);
+
+    namespace loose_detail
+    {
+        constexpr uint32_t hash_top = 16;
+        constexpr uint32_t hash_siz = 1 << hash_top;
+        constexpr uint32_t hash_mul = 2654435761;
+
+        // Size of ring buffer per hash in the hashtable.
+        inline constexpr uint64_t hashtab_wid = 16;
+
+        // Hash 4 bytes to an integer in `[0, 1 << (hash_top))`.
+        [[gnu::always_inline]]
+        inline uint32_t hash4(const uint32_t val)
+        {
+            return (val * hash_mul) >> (32 - hash_top);
+        }
+
+        // Assuming that rem contains top 3 bits of the token, emits bytes specifying `n`.
+        [[gnu::always_inline]]
+        inline void emit_length_extras(uint8_t* dst, uint64_t& dlpos, uint64_t n, uint8_t rem)
+        {
+            if (rem != uint8_t(7)) [[likely]]
+                return;
+
+            // Write this unconditionally first, if it's wrong we'll just overwrite
+            dst[dlpos] = static_cast<uint8_t>(n);
+
+            constexpr uint64_t block = 255;
+            if (n >= block) [[unlikely]]
+            {
+                while (n >= block) [[unlikely]]
+                    dst[dlpos] = block, ++dlpos, n -= block;
+                dst[dlpos] = static_cast<uint8_t>(n);
+            }
+
+            ++dlpos;
+        }
+
+        // Preferable lowerbound for match length (derived from the YOLO vector for now)
+        constexpr uint64_t accept_len = 7;
+        static_assert(accept_len >= min_match_len);
+
+        // We ideally want to keep literal length `<= fire_at`
+        constexpr uint64_t fire_at = 6;
+
+        // When you've gone `p` hashtab searches without a match, advance the pointer by `p >>
+        // skip_shift`
+        constexpr uint64_t skip_shift = 6;
+
+        // Regime counter: an adaptive value in `[0, regime_cap]`
+        // Runs with literal length in `[7, 32]` have a vote of `+2`, others `-1`
+        inline constexpr int64_t regime_cap = 64;
+        inline constexpr int64_t regime_threshold = 32;
+
+    } // namespace loose_detail
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // `isa_lib` is ISA-dependent.
+    template <class isa_lib>
+    uint64_t loose_compress_impl(const uint8_t* __restrict src,
+                                 uint64_t src_size,
+                                 uint8_t* __restrict dst,
+                                 uint64_t dst_cap)
+    {
+        using namespace loose_detail;
+
+        if (compress_bound(src_size) > dst_cap)
+            return 0;
+
+        // Left pointer in the destination buffer (metadata and control bytes)
+        uint64_t dlpos = 0;
+
+        // Right pointer in the destination buffer (literal bytes)
+        // We've written to `[drpos, dst_cap)` at any given point of time
+        uint64_t drpos = dst_cap;
+
+        storeu8(dst, src_size);
+        dlpos += 8;
+
+        // Small source
+        if (src_size <= small_lim)
+        {
+            if (src_size != 0)
+                memcpy(dst + dlpos, src, src_size);
+            dlpos += src_size;
+            return dlpos;
+        }
+
+        uint64_t literal_suffix_pos = dlpos;
+        dlpos += 8;
+
+        // Ensure that the last `literal_suffix` bytes will be literals
+        uint64_t match_end_limit = (src_size < literal_suffix ? 0 : src_size - literal_suffix);
+
+        // Beginning of the pending literal window
+        uint64_t lit = 0;
+
+        // `[lit, pos]` corresponds to the new range from the src buffer we're going to be
+        // turning into a lit + match pair
+        uint64_t pos = 0;
+
+        // `[0, hpos)` represents the range we've written into the hashtable
+        uint64_t hpos = 0;
+
+        uint64_t miss_run = 0;
+
+        std::vector<std::array<uint16_t, hashtab_wid>> hashtab(hash_siz);
+        std::vector<uint8_t> hashtab_idx(hash_siz);
+
+        // Last remembered match
+        uint64_t cand_pos = 0, cand_len = 0, cand_lst = 0;
+
+        // Adaptive variable that reflects values of lit_len we've been getting for recent blocks
+        int64_t regime = 0;
+
+        while (pos + max_match_len <= match_end_limit)
+        {
+            // Reduce branch misses, `batch = 8` performs well empirically
+            constexpr uint64_t batch = 8;
+            while (pos >= hpos + hashtab_lag + batch) [[unlikely]]
+            {
+#pragma GCC unroll batch
+                for (uint64_t i = 0; i < batch; i++)
+                {
+                    uint32_t hsh = hash4(loadu4(src + hpos + i));
+                    hashtab[hsh][hashtab_idx[hsh]] =
+                        uint16_t(hpos + i); // We just store the lowest 2 bytes
+                    hashtab_idx[hsh] =
+                        (hashtab_idx[hsh] == hashtab_wid - 1
+                             ? uint8_t(0)
+                             : hashtab_idx[hsh] + 1); // Just cycle the pointer in the ring buffer
+                }
+                hpos += batch;
+            }
+
+            uint32_t val = loadu4(src + pos);
+            uint32_t hsh = hash4(val);
+
+            uint64_t lst = 0;
+            uint64_t match_len = 0;
+
+            typename isa_lib::vec reg = isa_lib::loadvec(src + pos);
+
+            if (pos > hashtab_lag) [[likely]]
+            {
+// MLP
+#pragma GCC unroll hashtab_wid
+                for (uint8_t i = 0; i < hashtab_wid; i++)
+                {
+                    uint16_t d = uint16_t(pos - hashtab[hsh][i] - hashtab_lag - 1);
+
+                    // Guaranteed to lie within `[pos - 2^16 - hashtab_lag, pos - hashtab_lag)`
+                    uint64_t ilst = (pos - max_match_len - 1 - d);
+                    typename isa_lib::vec ireg = isa_lib::loadvec(src + ilst);
+                    uint32_t imatch_len = isa_lib::lcp(reg, ireg);
+                    lst = (imatch_len > match_len ? ilst : lst);
+                    match_len = (imatch_len > match_len ? imatch_len : match_len);
+                }
+            }
+
+            // We've inserted stuff into the hashtable assuming this value of `pos`, so we cannot
+            // probe the hashtable for any starting position behind this one going forward. This is
+            // important as `pos` is regressed ahead.
+            uint64_t pos_safe_bound = pos;
+
+            bool accept = (match_len >= accept_len);
+
+            uint64_t pend = pos - lit;
+            bool fire = (regime >= regime_threshold ? pend >= fire_at : pend == fire_at);
+
+            // We don't have an ideal match
+            if (!accept)
+            {
+                if (fire)
+                {
+                    // Prefer the one ending later between this position and the last remembered one
+                    if (cand_len != 0 and
+                        (match_len < min_match_len or cand_pos + cand_len >= pos + match_len))
+                    {
+                        pos = cand_pos;
+                        lst = cand_lst;
+                        match_len = cand_len;
+                    }
+
+                    // Note that if `accept` becomes false here, pos isn't pushed back by the above
+                    // branch
+                    accept = (match_len >= min_match_len);
+                }
+                else if (match_len >= min_match_len and
+                         (cand_len == 0 or pos + match_len >= cand_pos + cand_len))
+                {
+                    // This position becomes the new candidate
+                    cand_pos = pos;
+                    cand_len = match_len;
+                    cand_lst = lst;
+                }
+            }
+
+            if (accept)
+            {
+                // Extend the match backwards (note that `dis` in `(hashtab_lag, 2^16 +
+                // hashtab_lag]` holds).
+                // Extending `pos` backwards here is safe because we're not looking into the
+                // hashtable.
+                while (pos > lit and lst > 0 and match_len < max_match_len and
+                       src[pos - 1] == src[lst - 1])
+                {
+                    --pos;
+                    --lst;
+                    ++match_len;
+                }
+
+                uint64_t norm_match_len = match_len - min_match_len + 1;
+
+                // `src[lit, pos)` are the literals
+                uint64_t lit_len = pos - lit;
+
+                // regime vote
+                regime += (7 <= lit_len and lit_len <= 32 ? 2 : -1);
+                regime = std::clamp<int64_t>(regime, 0, regime_cap);
+
+                // Token Byte
+                uint8_t lrem = std::min(uint64_t(7), lit_len);
+                dst[dlpos] = static_cast<uint8_t>((lrem << 5) | (norm_match_len));
+                lit_len -= lrem;
+                ++dlpos;
+
+                // 2 Distance bytes
+                uint64_t dis = pos - lst;
+                uint16_t dbytes = dis - hashtab_lag - 1;
+                storeu2(dst + dlpos, dbytes);
+                dlpos += 2;
+
+                // Extra literal length bytes
+                emit_length_extras(dst, dlpos, lit_len, lrem);
+
+                // Literal bytes
+                if (lit < pos)
+                {
+                    uint64_t lit_cnt = pos - lit;
+                    drpos -= lit_cnt;
+                    memcpy(dst + drpos, src + lit, lit_cnt);
+                }
+
+                pos += match_len;
+                lit = pos;
+                pos = std::max(pos, pos_safe_bound);
+                cand_len = 0;
+                miss_run = 0;
+            }
+            else
+            {
+                pos += 1 + (miss_run >> skip_shift);
+                ++miss_run;
+            }
+        }
+
+        // Close the gap between the two streams by moving the literal stream to the left
+        if (drpos < dst_cap)
+        {
+            memmove(dst + dlpos, dst + drpos, dst_cap - drpos);
+            dlpos += dst_cap - drpos;
+        }
+
+        // Just deal with the last few literals (guaranteed to be `>= literal_suffix >=
+        // vector_width` bytes)
+        uint64_t literal_suffix_cnt = src_size - lit;
+        storeu8(dst + literal_suffix_pos, literal_suffix_cnt);
+        memcpy(dst + dlpos, src + lit, literal_suffix_cnt);
+        dlpos += literal_suffix_cnt;
+
+        return dlpos;
+    }
+
+} // namespace misa77

--- a/lz/misa77/src/decompress.cpp
+++ b/lz/misa77/src/decompress.cpp
@@ -1,0 +1,58 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#include "decompress_dispatch.h"
+#include "format.h"
+#include "misa77/misa77.h"
+#include "util.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    static_assert(vector_width == 32);
+    static_assert(hashtab_lag >= vector_width);
+    static_assert(vector_width >= max_match_len);
+    static_assert(literal_suffix >= dec_literal_copy);
+
+    // Returns the exact size (in bytes) of the file that the given compressed file will be
+    // decompressed to.
+    // Only call this on buffers that were compressed in the misa77 format, as it
+    // requires the size of the buffer to be >= 8.
+    uint64_t decompressed_size(const uint8_t* src)
+    {
+        return loadu8(src);
+    }
+
+    // Minimum size of buffer required to decompress a compressed file that corresponds to an
+    // original file of `src_size` bytes.
+    // Usage: decompressed_buffer_bound(decompressed_size(src))
+    uint64_t decompressed_buffer_bound(uint64_t src_size)
+    {
+        return src_size;
+    }
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // Resolves the best decode path once per call, depending on the ISA.
+    // PRECONDITION: `src` and `src_size` must correspond to a valid misa77 stream.
+    // `decompress` does not validate input, and malformed/malicious data can lead to UB or worse.
+    uint64_t decompress(const uint8_t* __restrict src,
+                        uint64_t src_size,
+                        uint8_t* __restrict dst,
+                        uint64_t dst_cap,
+                        dconfig dcfg)
+    {
+#if defined(__x86_64__)
+        if (__builtin_cpu_supports("avx2"))
+            return decompress_avx2(src, src_size, dst, dst_cap, dcfg);
+        return decompress_sse2(src, src_size, dst, dst_cap, dcfg);
+#elif defined(__aarch64__)
+        // NEON is guaranteed on Aarch64
+        return decompress_neon(src, src_size, dst, dst_cap, dcfg);
+#else
+        return decompress_portable(src, src_size, dst, dst_cap, dcfg);
+#endif
+    }
+
+} // namespace misa77

--- a/lz/misa77/src/decompress_dispatch.h
+++ b/lz/misa77/src/decompress_dispatch.h
@@ -1,0 +1,37 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "misa77/misa77.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    // ISA-specialized decompress entry points. Each is defined in a per-target TU in src/isa/,
+    // compiled with that ISA's flags (target_avx2.cpp with -mavx2, target_sse2.cpp /
+    // target_portable.cpp at baseline, target_neon.cpp at armv8-a), and selected at runtime
+    // by decompress() (see decompress.cpp).
+    uint64_t decompress_avx2(const uint8_t* __restrict src,
+                             uint64_t src_size,
+                             uint8_t* __restrict dst,
+                             uint64_t dst_cap,
+                             dconfig dcfg);
+    uint64_t decompress_sse2(const uint8_t* __restrict src,
+                             uint64_t src_size,
+                             uint8_t* __restrict dst,
+                             uint64_t dst_cap,
+                             dconfig dcfg);
+    uint64_t decompress_neon(const uint8_t* __restrict src,
+                             uint64_t src_size,
+                             uint8_t* __restrict dst,
+                             uint64_t dst_cap,
+                             dconfig dcfg);
+    uint64_t decompress_portable(const uint8_t* __restrict src,
+                                 uint64_t src_size,
+                                 uint8_t* __restrict dst,
+                                 uint64_t dst_cap,
+                                 dconfig dcfg);
+} // namespace misa77

--- a/lz/misa77/src/decompressor_zoo/safe_decompress_impl.h
+++ b/lz/misa77/src/decompressor_zoo/safe_decompress_impl.h
@@ -1,0 +1,226 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "format.h"
+#include "util.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+
+namespace misa77
+{
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // `isa_lib` is ISA-dependent.
+    template <class isa_lib>
+    uint64_t safe_decompress_impl(const uint8_t* __restrict src,
+                                  uint64_t src_size,
+                                  uint8_t* __restrict dst,
+                                  uint64_t dst_cap)
+    {
+        // Header fields must exist
+        if (src_size < 8) [[unlikely]]
+            return 0;
+
+        const uint64_t original_size = loadu8(src);
+
+        if (dst_cap < original_size)
+            return 0;
+
+        // Small source
+        if (original_size <= small_lim)
+        {
+            // Must not over-read here
+            if (src_size < 8 + original_size) [[unlikely]]
+                return 0;
+            if (original_size > 0)
+                memcpy(dst, src + uint64_t(8), original_size);
+            return original_size;
+        }
+
+        // Extra headers for non-small source
+        if (src_size < 16) [[unlikely]]
+            return 0;
+
+        const uint64_t literal_suffix_cnt = loadu8(src + 8);
+
+        // The raw suffix must fit in both buffers (for our unconditional over-reads and writes to
+        // be safe), and must be >= literal_suffix
+        if (literal_suffix_cnt < literal_suffix or literal_suffix_cnt > src_size - 16 or
+            literal_suffix_cnt > original_size) [[unlikely]]
+            return 0;
+
+        const uint8_t* control = src + 16;
+        const uint8_t* literals = src + src_size - literal_suffix_cnt;
+        uint8_t* out = dst;
+
+        // The loop may produce at most this much output (we put the raw suffix after this)
+        const uint64_t loop_limit = original_size - literal_suffix_cnt;
+        uint8_t* const out_limit = dst + loop_limit;
+
+        constexpr uint64_t dis_ceil = dis_lim + hashtab_lag; // max representable dis
+
+        uint8_t* const prefix_end = dst + std::min(dis_ceil, loop_limit);
+
+        // Fully guarded step for an initial small prefix (match distance is dangerous here), and
+        // the tail
+        auto guarded_step = [&]() -> bool
+        {
+            uint8_t token = control[0];
+            uint64_t lit_len = token >> 5;
+            uint64_t match_len = (token & uint8_t(0x1F)) + min_match_len - 1;
+
+            uint16_t dis_small = loadu2(control + 1);
+            uint32_t dis = dis_small + hashtab_lag + 1;
+
+            control += 3;
+
+            if (lit_len == 7) [[unlikely]]
+            {
+                uint64_t pot_add = *control;
+                lit_len += pot_add;
+                ++control;
+
+                constexpr uint64_t block = 255;
+                if (pot_add == block) [[unlikely]]
+                {
+                    // Bounded, shouldn't just keep reading ahead as it finds 255s
+                    while (*control == block) [[unlikely]]
+                    {
+                        lit_len += block, ++control;
+                        if (control >= literals) [[unlikely]]
+                            return false;
+                    }
+                    lit_len += *control, ++control;
+                }
+            }
+
+            // no src underflow.
+            if (lit_len > uint64_t(literals - src)) [[unlikely]]
+                return false;
+
+            // bound this token's dst writes
+            if (uint64_t(out - dst) + lit_len + min_match_len > loop_limit) [[unlikely]]
+                return false;
+
+            literals -= lit_len;
+            if (lit_len > dec_literal_copy) [[unlikely]]
+            {
+                isa_lib::copy32(out, literals);
+
+                if (lit_len > vector_width) [[unlikely]]
+                {
+                    memcpy(out + vector_width, literals + vector_width, lit_len - vector_width);
+                }
+            }
+            else
+            {
+                memcpy(out, literals, dec_literal_copy);
+            }
+            out += lit_len;
+
+            // match source must not start before dst[0].
+            if (dis > uint64_t(out - dst)) [[unlikely]]
+                return false;
+
+            isa_lib::cyccpy(out - dis, dis);
+            out += match_len;
+            return true;
+        };
+
+        // Prefix: first dis_ceil output bytes.
+        while (control < literals and out < prefix_end)
+            if (!guarded_step()) [[unlikely]]
+                return 0;
+
+        // The fast loop below must never begin a token within red_slack bytes of
+        // out_limit.
+        constexpr uint64_t red_slack = 8;
+
+        // A non-extras token has lit_len <= 6 and starts at out <= out_limit - red_slack
+        // cyccpy write must stay inside the suffix slack past out_limit
+        static_assert(6 + vector_width - (red_slack + 1) <= literal_suffix);
+        // a match code 31 must not advance `out` past one-past-the-end of a dst buffer
+        static_assert(6 + (31 + min_match_len - 1) - (red_slack + 1) <= literal_suffix);
+
+        uint8_t* const red = dst + (loop_limit > red_slack ? loop_limit - red_slack : uint64_t(0));
+
+        // Fast main loop: no per-token guards outside the extras branch.
+        while (control < literals and out < red)
+        {
+            uint8_t token = control[0];
+            uint64_t lit_len = token >> 5;
+            uint64_t match_len = (token & uint8_t(0x1F)) + min_match_len - 1;
+
+            uint16_t dis_small = loadu2(control + 1);
+            uint32_t dis = dis_small + hashtab_lag + 1;
+
+            control += 3;
+
+            if (lit_len == 7) [[unlikely]]
+            {
+                uint64_t pot_add = *control;
+                lit_len += pot_add;
+                ++control;
+
+                constexpr uint64_t block = 255;
+                if (pot_add == block) [[unlikely]]
+                {
+                    // Bounded, shouldn't just keep reading ahead as it finds 255s
+                    while (*control == block) [[unlikely]]
+                    {
+                        lit_len += block, ++control;
+                        if (control >= literals) [[unlikely]]
+                            return 0;
+                    }
+                    lit_len += *control, ++control;
+                }
+
+                if (lit_len > uint64_t(literals - src)) [[unlikely]]
+                    return 0;
+#if defined(__clang__)
+                // Equivalent to the check below, rewritten in terms of `red`
+                if (lit_len - (red_slack - min_match_len) > uint64_t(red - out)) [[unlikely]]
+                    return 0;
+#else
+                if (lit_len + min_match_len > uint64_t(out_limit - out)) [[unlikely]]
+                    return 0;
+#endif
+            }
+
+            literals -= lit_len;
+            if (lit_len > dec_literal_copy) [[unlikely]]
+            {
+                isa_lib::copy32(out, literals);
+
+                if (lit_len > vector_width) [[unlikely]]
+                {
+                    memcpy(out + vector_width, literals + vector_width, lit_len - vector_width);
+                }
+            }
+            else
+            {
+                memcpy(out, literals, dec_literal_copy);
+            }
+            out += lit_len;
+
+            isa_lib::cyccpy(out - dis, dis);
+            out += match_len;
+        }
+
+        // The last few tokens
+        while (control < literals)
+            if (!guarded_step()) [[unlikely]]
+                return 0;
+
+        if (out != out_limit)
+            return 0;
+
+        // Literal suffix at the end
+        memcpy(out, src + src_size - literal_suffix_cnt, literal_suffix_cnt);
+        return loop_limit + literal_suffix_cnt;
+    }
+} // namespace misa77

--- a/lz/misa77/src/decompressor_zoo/unsafe_decompress_impl.h
+++ b/lz/misa77/src/decompressor_zoo/unsafe_decompress_impl.h
@@ -1,0 +1,104 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "format.h"
+#include "misa77/misa77.h"
+#include "util.h"
+
+#include <cstdint>
+#include <cstring>
+
+namespace misa77
+{
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // `isa_lib` is ISA-dependent.
+    template <class isa_lib>
+    uint64_t unsafe_decompress_impl(const uint8_t* __restrict src,
+                                    uint64_t src_size,
+                                    uint8_t* __restrict dst,
+                                    uint64_t dst_cap)
+    {
+        const uint64_t original_size = loadu8(src);
+
+        if (dst_cap < original_size)
+            return 0;
+
+        // Small source
+        if (original_size <= small_lim)
+        {
+            if (original_size > 0)
+                memcpy(dst, src + uint64_t(8), original_size);
+            return original_size;
+        }
+
+        const uint64_t literal_suffix_cnt = loadu8(src + 8);
+        const uint8_t* control = src + 16;
+        const uint8_t* literals = src + src_size - literal_suffix_cnt;
+        uint8_t* out = dst;
+
+        // Token loop with safe overwrites in the destination buffer and safe overreads from source.
+        while (control < literals)
+        {
+            // Overread is safe here
+            uint8_t token = control[0];
+            uint64_t lit_len = token >> 5;
+            uint64_t match_len = (token & uint8_t(0x1F)) + min_match_len - 1;
+
+            uint16_t dis_small = loadu2(control + 1);
+            uint32_t dis = dis_small + hashtab_lag + 1;
+
+            control += 3;
+
+            if (lit_len == 7) [[unlikely]]
+            {
+                uint64_t pot_add = *control;
+                lit_len += pot_add;
+                ++control;
+
+                constexpr uint64_t block = 255;
+                if (pot_add == block) [[unlikely]]
+                {
+                    while (*control == block) [[unlikely]]
+                        lit_len += block, ++control;
+                    lit_len += *control, ++control;
+                }
+            }
+
+            literals -= lit_len;
+            if (lit_len > dec_literal_copy) [[unlikely]]
+            {
+                isa_lib::copy32(out, literals);
+
+                if (lit_len > vector_width) [[unlikely]]
+                {
+                    memcpy(out + vector_width, literals + vector_width, lit_len - vector_width);
+                }
+            }
+            else
+            {
+                // Unconditional copy, safe because we have `dec_literal_copy` bytes of
+                // breathing room at the end in src and dst due to `literal_suffix`
+                memcpy(out, literals, dec_literal_copy);
+            }
+            out += lit_len;
+
+            // When we enter cyccpy, we're guaranteed to have `literal_suffix` >= vector_width
+            // bytes of breathing room in the destination buffer as the last `literal_suffix`
+            // bytes are literals
+            isa_lib::cyccpy(out - dis, dis);
+            out += match_len;
+        }
+
+        if (uint64_t(out - dst) != original_size - literal_suffix_cnt)
+            return 0;
+
+        // Literal suffix at the end
+        memcpy(out, src + src_size - literal_suffix_cnt, literal_suffix_cnt);
+        out += literal_suffix_cnt;
+
+        return uint64_t(out - dst);
+    }
+} // namespace misa77

--- a/lz/misa77/src/format.h
+++ b/lz/misa77/src/format.h
@@ -1,0 +1,58 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include <cstdint>
+
+namespace misa77
+{
+    // Width in bytes of several unconditional operations we perform.
+    inline constexpr uint64_t vector_width = 32;
+
+    // (`raw file size <= small_lim`) => small mode, we just write the raw bytes.
+    inline constexpr uint32_t small_lim = 32;
+
+    // When we find a match, we check `lookahead` positions ahead for a potentially better match.
+    inline constexpr uint64_t lookahead = 2;
+
+    // The distance in bytes by which the start of the active hashtable window lags the pointer.
+    // Don't set this too high, as there were a lot of matches for dis in [32, 512].
+    inline constexpr uint64_t hashtab_lag = 32;
+    static_assert(hashtab_lag >= vector_width);
+
+    // If we're asked to copy a match after having processed `c` bytes of raw data, then the match
+    // will begin in `[c - dis_lim - hashtab_lag, c - hashtab_lag)`.
+    inline constexpr uint64_t dis_lim = (uint32_t(1) << 16);
+
+    // We have exactly 2 bytes to indicate distance.
+    static_assert(dis_lim <= (1 << 16));
+
+    inline constexpr uint32_t min_match_len = 4;
+
+    // `min_match_len >= 4` is needed for the compression bound to hold.
+    static_assert(min_match_len >= 4);
+
+    inline constexpr uint32_t max_match_len = 32;
+
+    // One `cyccpy` call should deal with the entire match.
+    static_assert(max_match_len <= vector_width);
+
+    // Lowerbound for the number of literals in the final raw suffix.
+    // This MUST be >= `vector_width` because:
+    // 1. During decompression, `cyccpy` performs unconditional writes in the destination buffer,
+    // and we're using this suffix as padding that we can safely overwrite!!!
+    // 2. During decompression, we perform unconditional reads from the source buffer, and this
+    // literal suffix acts as padding that we can safely "over-read" into!!!
+    inline constexpr uint32_t literal_suffix = 32;
+    static_assert(literal_suffix >= vector_width);
+
+    // Need enough source bytes to be able to guarantee that we can produce the appropriate raw
+    // literal suffix.
+    static_assert(literal_suffix <= small_lim + 1);
+
+    // Unconditionally copied number of literal bytes in decompressor.
+    inline constexpr uint64_t dec_literal_copy = 16;
+    static_assert(literal_suffix >= dec_literal_copy);
+} // namespace misa77

--- a/lz/misa77/src/isa/lib_avx2.h
+++ b/lz/misa77/src/isa/lib_avx2.h
@@ -1,0 +1,64 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+// AVX2 copy/finder policy (256-bit).
+//
+// CONTRACT: the intrinsics below are AVX2, so this header MUST only be included
+// from a TU compiled with -mavx2.
+
+#include <cstdint>
+#include <immintrin.h>
+
+namespace misa77
+{
+    class lib_avx2
+    {
+    public:
+        // Copies `src[0, vector_width)` to `src[dis, dis + vector_width)`.
+        // It's guaranteed that `dis >= vector_width`, so there's no aliasing.
+        [[gnu::always_inline]]
+        static inline void cyccpy(uint8_t* src, uint64_t dis)
+        {
+            __m256i reg = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
+            _mm256_storeu_si256(reinterpret_cast<__m256i*>(src + dis), reg);
+        }
+
+        // Copies `src[0, vector_width)` to `dst[0, vector_width)`.
+        // It's guaranteed that the two ranges don't alias.
+        [[gnu::always_inline]]
+        static inline void copy32(uint8_t* __restrict dst, const uint8_t* __restrict src)
+        {
+            __m256i reg = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
+            _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst), reg);
+        }
+
+        using vec = __m256i;
+
+        // Return internal representation of `src[0, vector_width)`.
+        [[gnu::always_inline]]
+        static inline vec loadvec(const uint8_t* src)
+        {
+            return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
+        }
+
+        // First differing byte index (0-indexed) between `reg1` and `reg2`.
+        // If there's no such index, return `vector_width`.
+        [[gnu::always_inline]]
+        static inline uint64_t lcp(const vec& reg1, const vec& reg2)
+        {
+            const __m256i eq = _mm256_cmpeq_epi8(reg1, reg2);
+            const uint32_t mask = static_cast<uint32_t>(_mm256_movemask_epi8(eq));
+            const uint32_t diff = ~mask;
+
+// __builtin_ctz(0) is UB, but tzcnt is defined for 0 and conveniently returns 32
+#if defined(__BMI__)
+            return static_cast<uint64_t>(_tzcnt_u32(diff));
+#else
+            return diff ? static_cast<uint64_t>(__builtin_ctz(diff)) : 32;
+#endif
+        }
+    };
+} // namespace misa77

--- a/lz/misa77/src/isa/lib_neon.h
+++ b/lz/misa77/src/isa/lib_neon.h
@@ -1,0 +1,78 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+// ARM NEON (2x128-bit) copy/finder policy.
+//
+// CONTRACT: NEON (AdvSIMD) is guaranteed by the AArch64 ISA, so this header only
+// requires the including TU to be an AArch64 baseline build (-march=armv8-a).
+
+#include "format.h" // vector_width
+
+#include <arm_neon.h>
+#include <cstdint>
+
+namespace misa77
+{
+    class lib_neon
+    {
+    public:
+        // Copies `src[0, vector_width)` to `src[dis, dis + vector_width)`.
+        // It's guaranteed that `dis >= vector_width`, so there's no aliasing.
+        [[gnu::always_inline]]
+        static inline void cyccpy(uint8_t* src, uint64_t dis)
+        {
+            uint8x16_t reg1 = vld1q_u8(src);
+            uint8x16_t reg2 = vld1q_u8(src + vector_width / 2);
+            vst1q_u8(src + dis, reg1);
+            vst1q_u8(src + dis + vector_width / 2, reg2);
+        }
+
+        // Copies `src[0, vector_width)` to `dst[0, vector_width)`.
+        // It's guaranteed that the two ranges don't alias.
+        [[gnu::always_inline]]
+        static inline void copy32(uint8_t* __restrict dst, const uint8_t* __restrict src)
+        {
+            uint8x16_t reg1 = vld1q_u8(src);
+            uint8x16_t reg2 = vld1q_u8(src + vector_width / 2);
+            vst1q_u8(dst, reg1);
+            vst1q_u8(dst + vector_width / 2, reg2);
+        }
+
+        struct vec
+        {
+            uint8x16_t lo, hi;
+        };
+
+        // Return internal representation of `src[0, vector_width)`.
+        [[gnu::always_inline]]
+        static inline vec loadvec(const uint8_t* src)
+        {
+            return vec{vld1q_u8(src), vld1q_u8(src + vector_width / 2)};
+        }
+
+        // First differing byte index (0-indexed) between `reg1` and `reg2`.
+        // If there's no such index, return `vector_width`.
+        [[gnu::always_inline]]
+        static inline uint64_t lcp(const vec& reg1, const vec& reg2)
+        {
+            // thanks to danlark1 on HN: https://news.ycombinator.com/item?id=48925428
+            const uint8x16_t eq0 = vceqq_u8(reg1.lo, reg2.lo);
+            const uint8x16_t eq1 = vceqq_u8(reg1.hi, reg2.hi);
+            const uint64_t mask0 =
+                vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(eq0), 4)), 0);
+            const uint64_t mask1 =
+                vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(eq1), 4)), 0);
+            // __builtin_ctzll(0) is UB, so the all-equal halves must be tested explicitly
+            const uint64_t diff0 = ~mask0;
+            if (diff0)
+                return static_cast<uint64_t>(__builtin_ctzll(diff0)) >> 2;
+            const uint64_t diff1 = ~mask1;
+            if (diff1)
+                return (vector_width / 2) + (static_cast<uint64_t>(__builtin_ctzll(diff1)) >> 2);
+            return vector_width;
+        }
+    };
+} // namespace misa77

--- a/lz/misa77/src/isa/lib_portable.h
+++ b/lz/misa77/src/isa/lib_portable.h
@@ -1,0 +1,69 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+// Portable copy/finder policy.
+//
+// CONTRACT: no ISA requirement, safe to include from any TU.
+
+#include "format.h" // vector_width
+#include "util.h"   // loadu8
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+
+namespace misa77
+{
+    // The compiler should auto-vectorize the `memcpy` calls in here w.r.t. the target architecture,
+    // whenever possible.
+    class lib_portable
+    {
+    public:
+        // Copies `src[0, vector_width)` to `src[dis, dis + vector_width)`
+        // It's guaranteed that `dis >= vector_width`, so there's no aliasing.
+        [[gnu::always_inline]]
+        static inline void cyccpy(uint8_t* src, uint64_t dis)
+        {
+            memcpy(src + dis, src, vector_width);
+        }
+
+        // Copies `src[0, vector_width)` to `dst[0, vector_width)`.
+        // It's guaranteed that the two ranges don't alias.
+        [[gnu::always_inline]]
+        static inline void copy32(uint8_t* __restrict dst, const uint8_t* __restrict src)
+        {
+            memcpy(dst, src, vector_width);
+        }
+
+        // Any internal representation of 32 bytes of contiguous data is fine.
+        using vec = std::array<uint8_t, vector_width>;
+
+        // Return internal representation of `src[0, vector_width)`.
+        [[gnu::always_inline]]
+        static inline vec loadvec(const uint8_t* src)
+        {
+            vec ret;
+            std::memcpy(ret.data(), src, vector_width);
+            return ret;
+        }
+
+        // First differing byte index (0-indexed) between `reg1` and `reg2`.
+        // If there's no such index, return `vector_width`.
+        // Little-endian assumed:
+        // ctz of the XOR points at the lowest differing bit, hence the lowest byte.
+        [[gnu::always_inline]]
+        static inline uint64_t lcp(const vec& reg1, const vec& reg2)
+        {
+            for (uint64_t off = 0; off < vector_width; off += 8)
+            {
+                const uint64_t x = loadu8(reg1.data() + off) ^ loadu8(reg2.data() + off);
+                if (x)
+                    return off + (static_cast<uint64_t>(__builtin_ctzll(x)) >> 3);
+            }
+            return vector_width;
+        }
+    };
+} // namespace misa77

--- a/lz/misa77/src/isa/lib_sse2.h
+++ b/lz/misa77/src/isa/lib_sse2.h
@@ -1,0 +1,77 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+// SSE2 (2x128-bit) copy/finder policy.
+//
+// CONTRACT: SSE2 is guaranteed by the x86-64 ISA, so this header only requires
+// the including TU to be a genuine x86-64 baseline build (-march=x86-64).
+
+#include "format.h" // vector_width
+
+#include <cstdint>
+#include <immintrin.h>
+
+namespace misa77
+{
+    class lib_sse2
+    {
+    public:
+        // Copies `src[0, vector_width)` to `src[dis, dis + vector_width)`.
+        // It's guaranteed that `dis >= vector_width`, so there's no aliasing.
+        [[gnu::always_inline]]
+        static inline void cyccpy(uint8_t* src, uint64_t dis)
+        {
+            __m128i reg1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(src));
+            __m128i reg2 =
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + vector_width / 2));
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(src + dis), reg1);
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(src + dis + vector_width / 2), reg2);
+        }
+
+        // Copies `src[0, vector_width)` to `dst[0, vector_width)`.
+        // It's guaranteed that the two ranges don't alias.
+        [[gnu::always_inline]]
+        static inline void copy32(uint8_t* __restrict dst, const uint8_t* __restrict src)
+        {
+            __m128i reg1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(src));
+            __m128i reg2 =
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + vector_width / 2));
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(dst), reg1);
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(dst + vector_width / 2), reg2);
+        }
+
+        struct vec
+        {
+            __m128i lo, hi;
+        };
+
+        // Return internal representation of `src[0, vector_width)`.
+        [[gnu::always_inline]]
+        static inline vec loadvec(const uint8_t* src)
+        {
+            return vec{_mm_loadu_si128(reinterpret_cast<const __m128i*>(src)),
+                       _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + vector_width / 2))};
+        }
+
+        // First differing byte index (0-indexed) between `reg1` and `reg2`.
+        // If there's no such index, return `vector_width`.
+        [[gnu::always_inline]]
+        static inline uint64_t lcp(const vec& reg1, const vec& reg2)
+        {
+            const __m128i eq0 = _mm_cmpeq_epi8(reg1.lo, reg2.lo);
+            const __m128i eq1 = _mm_cmpeq_epi8(reg1.hi, reg2.hi);
+            const uint32_t mask0 = static_cast<uint32_t>(_mm_movemask_epi8(eq0));
+            const uint32_t mask1 = static_cast<uint32_t>(_mm_movemask_epi8(eq1));
+            const uint32_t diff = ~(mask0 | (mask1 << 16));
+// __builtin_ctz(0) is UB, but tzcnt is defined for 0 and conveniently returns 32
+#if defined(__BMI__)
+            return static_cast<uint64_t>(_tzcnt_u32(diff));
+#else
+            return diff ? static_cast<uint64_t>(__builtin_ctz(diff)) : 32;
+#endif
+        }
+    };
+} // namespace misa77

--- a/lz/misa77/src/isa/target_avx2.cpp
+++ b/lz/misa77/src/isa/target_avx2.cpp
@@ -1,0 +1,44 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+// AVX2 TU.
+// Built only on x86 targets and the implementations herein are chosen at dispatch iff the cpu has
+// AVX2 support.
+
+#include "compress_dispatch.h"
+#include "compressor_zoo/default_compress_impl.h"
+#include "compressor_zoo/loose_compress_impl.h"
+#include "decompress_dispatch.h"
+#include "decompressor_zoo/safe_decompress_impl.h"
+#include "decompressor_zoo/unsafe_decompress_impl.h"
+#include "isa/lib_avx2.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    uint64_t compress_avx2(const uint8_t* __restrict src,
+                           uint64_t src_size,
+                           uint8_t* __restrict dst,
+                           uint64_t dst_cap,
+                           config cfg)
+    {
+        if (cfg.level == 0)
+            return loose_compress_impl<lib_avx2>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 1)
+            return default_compress_impl<lib_avx2>(src, src_size, dst, dst_cap);
+        return 0;
+    }
+
+    uint64_t decompress_avx2(const uint8_t* __restrict src,
+                             uint64_t src_size,
+                             uint8_t* __restrict dst,
+                             uint64_t dst_cap,
+                             dconfig dcfg)
+    {
+        if (dcfg.safe)
+            return safe_decompress_impl<lib_avx2>(src, src_size, dst, dst_cap);
+        return unsafe_decompress_impl<lib_avx2>(src, src_size, dst, dst_cap);
+    }
+} // namespace misa77

--- a/lz/misa77/src/isa/target_neon.cpp
+++ b/lz/misa77/src/isa/target_neon.cpp
@@ -1,0 +1,42 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+// Baseline for AArch64 (NEON/AdvSIMD support is guaranteed in the ISA).
+
+#include "compress_dispatch.h"
+#include "compressor_zoo/default_compress_impl.h"
+#include "compressor_zoo/loose_compress_impl.h"
+#include "decompress_dispatch.h"
+#include "decompressor_zoo/safe_decompress_impl.h"
+#include "decompressor_zoo/unsafe_decompress_impl.h"
+#include "isa/lib_neon.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    uint64_t compress_neon(const uint8_t* __restrict src,
+                           uint64_t src_size,
+                           uint8_t* __restrict dst,
+                           uint64_t dst_cap,
+                           config cfg)
+    {
+        if (cfg.level == 0)
+            return loose_compress_impl<lib_neon>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 1)
+            return default_compress_impl<lib_neon>(src, src_size, dst, dst_cap);
+        return 0;
+    }
+
+    uint64_t decompress_neon(const uint8_t* __restrict src,
+                             uint64_t src_size,
+                             uint8_t* __restrict dst,
+                             uint64_t dst_cap,
+                             dconfig dcfg)
+    {
+        if (dcfg.safe)
+            return safe_decompress_impl<lib_neon>(src, src_size, dst, dst_cap);
+        return unsafe_decompress_impl<lib_neon>(src, src_size, dst, dst_cap);
+    }
+} // namespace misa77

--- a/lz/misa77/src/isa/target_portable.cpp
+++ b/lz/misa77/src/isa/target_portable.cpp
@@ -1,0 +1,42 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+// Built on every target.
+
+#include "compress_dispatch.h"
+#include "compressor_zoo/default_compress_impl.h"
+#include "compressor_zoo/loose_compress_impl.h"
+#include "decompress_dispatch.h"
+#include "decompressor_zoo/safe_decompress_impl.h"
+#include "decompressor_zoo/unsafe_decompress_impl.h"
+#include "isa/lib_portable.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    uint64_t compress_portable(const uint8_t* __restrict src,
+                               uint64_t src_size,
+                               uint8_t* __restrict dst,
+                               uint64_t dst_cap,
+                               config cfg)
+    {
+        if (cfg.level == 0)
+            return loose_compress_impl<lib_portable>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 1)
+            return default_compress_impl<lib_portable>(src, src_size, dst, dst_cap);
+        return 0;
+    }
+
+    uint64_t decompress_portable(const uint8_t* __restrict src,
+                                 uint64_t src_size,
+                                 uint8_t* __restrict dst,
+                                 uint64_t dst_cap,
+                                 dconfig dcfg)
+    {
+        if (dcfg.safe)
+            return safe_decompress_impl<lib_portable>(src, src_size, dst, dst_cap);
+        return unsafe_decompress_impl<lib_portable>(src, src_size, dst, dst_cap);
+    }
+} // namespace misa77

--- a/lz/misa77/src/isa/target_sse2.cpp
+++ b/lz/misa77/src/isa/target_sse2.cpp
@@ -1,0 +1,43 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+// Baseline for x86-64 (SSE2 support is guaranteed in the ISA).
+
+#include "compress_dispatch.h"
+#include "compressor_zoo/default_compress_impl.h"
+#include "compressor_zoo/loose_compress_impl.h"
+#include "decompress_dispatch.h"
+#include "decompressor_zoo/safe_decompress_impl.h"
+#include "decompressor_zoo/unsafe_decompress_impl.h"
+#include "isa/lib_sse2.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    uint64_t compress_sse2(const uint8_t* __restrict src,
+                           uint64_t src_size,
+                           uint8_t* __restrict dst,
+                           uint64_t dst_cap,
+                           config cfg)
+    {
+        if (cfg.level == 0)
+            return loose_compress_impl<lib_sse2>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 1)
+            return default_compress_impl<lib_sse2>(src, src_size, dst, dst_cap);
+        return 0;
+    }
+
+    uint64_t decompress_sse2(const uint8_t* __restrict src,
+                             uint64_t src_size,
+                             uint8_t* __restrict dst,
+                             uint64_t dst_cap,
+                             dconfig dcfg)
+    {
+        if (dcfg.safe)
+            return safe_decompress_impl<lib_sse2>(src, src_size, dst, dst_cap);
+        return unsafe_decompress_impl<lib_sse2>(src, src_size, dst, dst_cap);
+    }
+
+} // namespace misa77

--- a/lz/misa77/src/util.h
+++ b/lz/misa77/src/util.h
@@ -1,0 +1,56 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+
+// ISA-agnostic helpers.
+// See src/isa for ISA-specialized helpers
+
+namespace misa77
+{
+    [[gnu::always_inline]]
+    inline uint16_t loadu2(const uint8_t* ptr)
+    {
+        uint16_t v;
+        memcpy(&v, ptr, 2);
+        return v;
+    }
+
+    [[gnu::always_inline]]
+    inline void storeu2(uint8_t* ptr, const uint16_t val)
+    {
+        memcpy(ptr, &val, 2);
+    }
+
+    [[gnu::always_inline]]
+    inline uint32_t loadu4(const uint8_t* ptr)
+    {
+        uint32_t v;
+        memcpy(&v, ptr, 4);
+        return v;
+    }
+
+    [[gnu::always_inline]]
+    inline void storeu4(uint8_t* ptr, const uint32_t val)
+    {
+        memcpy(ptr, &val, 4);
+    }
+
+    [[gnu::always_inline]]
+    inline uint64_t loadu8(const uint8_t* ptr)
+    {
+        uint64_t v;
+        memcpy(&v, ptr, 8);
+        return v;
+    }
+
+    [[gnu::always_inline]]
+    inline void storeu8(uint8_t* ptr, const uint64_t val)
+    {
+        memcpy(ptr, &val, 8);
+    }
+} // namespace misa77


### PR DESCRIPTION
misa77 is an LZ77 codec for the "write once, read many" niche. It trades compression speed for very high decompression throughput and decent ratios. It decodes much faster than most codecs in its ratio class on most data types and architectures.

- **License**: MIT
- **Repository**: https://github.com/welcome-to-the-sunny-side/misa77 (this PR vendors [v0.3.0](https://github.com/welcome-to-the-sunny-side/misa77/releases/tag/v0.3.0))

### Registered variants

- `misa77` (levels 0-1): level 0 decodes fastest, level 1 (the library default) trades a little decode speed for ratio.
- `misa77_safe` (levels 0-1): same compressor, but decompression runs with full input validation (guaranteed to terminate and stay in-bounds on corrupt/malicious input).

All levels emit the same bitstream format, so the two variants share compressed streams and differ only in the decoder.

Detailed benchmark results can be found [here](https://github.com/welcome-to-the-sunny-side/misa77/blob/main/README.md). A small portion is attached below.

### Results (silesia.tar, Intel i7-14650HX (@2.2 GHz), single core, turbo disabled)

| Compressor name          | Compression | Decompress. |  Ratio |
| ------------------------ | ----------- | ----------- | ------ |
| misa77 0.3.0 -0          |   54.1 MB/s |   5363 MB/s |  42.64 |
| misa77 0.3.0 safe -0     |   54.1 MB/s |   5205 MB/s |  42.64 |
| misa77 0.3.0 -1          |   51.2 MB/s |   4372 MB/s |  39.65 |
| misa77 0.3.0 safe -1     |   51.2 MB/s |   4235 MB/s |  39.65 |
| zxc 0.13.1 -3            |    116 MB/s |   2830 MB/s |  45.46 |
| zxc 0.13.1 -4            |   81.0 MB/s |   2721 MB/s |  42.63 |
| lzsse8fast 2019-04-18    |    183 MB/s |   2668 MB/s |  44.80 |
| zxc 0.13.1 -5            |   48.4 MB/s |   2599 MB/s |  40.25 |
| lzsse4fast 2019-04-18    |    187 MB/s |   2538 MB/s |  45.26 |
| lz4hc 1.10.0 -12         |   7.31 MB/s |   2533 MB/s |  36.45 |
| lz4 1.10.0               |    371 MB/s |   2510 MB/s |  47.59 |
| lzav 5.11 -1             |    297 MB/s |   1725 MB/s |  39.94 |
| zstd 1.5.7 -1            |    296 MB/s |    903 MB/s |  34.54 |
| snappy 1.2.2             |    375 MB/s |    858 MB/s |  47.89 |

(misa77 rows first, then competitors sorted by decompression speed)

On ARM64 (Apple M3, Apple clang) the gap is larger: level 0 decodes silesia.tar at ~12.5 GB/s vs lz4's ~5.3 GB/s, with the safe decoder at parity with the unsafe one. Refer to the README for more details.

### Requirements

- C++20
- A 64-bit little-endian system.

### Integration

- Added the codec source under `lz/misa77/` (MIT licensed), byte-identical to the misa77 repository at tag v0.3.0.
- Registered in `bench/codecs.h`, `bench/lz_codecs.cpp`, and `bench/lzbench.h`; listed in `README.md` + `CHANGELOG`.
- The Makefile requires C++20 and a 64-bit little-endian system. Unsupported systems get `BENCH_REMOVE_MISA77` automatically, and `DONT_BUILD_MISA77=1` is available as a manual override.

### Verification

Benchmarked across the Silesia corpus on x86-64 (Intel, GCC) and ARM64 (Apple M3, Apple clang). lzbench's built-in decompression check passed on all runs. The safe decoder has additionally been mutation-fuzzed under ASan/UBSan.
