### PR TITLE
Add misa77 0.5.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 v2.x.y
 - added OpenZL v0.2.0 (thanks to @fwyzard)
 - updated zxc to 0.13.1 (thanks to @hellobertrand)
+- added misa77 0.5.0 (by @welcome-to-the-sunny-side)
 
 v2.3 (Jun 15, 2026)
 - improvement: Reorganized compressor alias groups by type — ALL is now a composite of LZ /

--- a/Makefile
+++ b/Makefile
@@ -888,6 +888,42 @@ else
     $(ZXC_DIR)/%_neon.o: $(ZXC_DIR)/%.c ; $(CMD_BUILD_ZXC)
 endif
 
+
+# misa77 targets 64-bit little-endian systems and needs C++20.
+MISA77_OK := $(shell printf 'int main(){static_assert(__BYTE_ORDER__==__ORDER_LITTLE_ENDIAN__);static_assert(sizeof(void*)==8);return 0;}' | $(CXX) $(CODE_FLAGS) -std=c++20 -fsyntax-only -x c++ - 2>/dev/null && echo ok)
+ifneq ($(MISA77_OK),ok)
+    DONT_BUILD_MISA77 ?= 1
+endif
+
+ifeq "$(DONT_BUILD_MISA77)" "1"
+    DEFINES += -DBENCH_REMOVE_MISA77
+else
+    MISA77_DIR = lz/misa77
+    MISA77_INC = -I$(MISA77_DIR)/include -I$(MISA77_DIR)/src
+    # always built:
+    MISA77_FILES  = $(MISA77_DIR)/src/compress.o $(MISA77_DIR)/src/decompress.o
+    MISA77_FILES += $(MISA77_DIR)/src/isa/target_portable.o
+    MISA77_ISA := $(shell echo | $(CXX) $(CODE_FLAGS) -dM -E -x c++ - 2>/dev/null | grep -oE '__(x86_64|aarch64)__' | head -n1)
+    # 64-bit x86 only:
+    ifeq ($(MISA77_ISA),__x86_64__)
+        MISA77_FILES += $(MISA77_DIR)/src/isa/target_sse2.o $(MISA77_DIR)/src/isa/target_avx2.o
+    endif
+    # 64-bit ARM only
+    ifeq ($(MISA77_ISA),__aarch64__)
+        MISA77_FILES += $(MISA77_DIR)/src/isa/target_neon.o
+    endif
+
+    CMD_BUILD_MISA77 = @$(MKDIR) $(dir $@) && $(CXX) $(CXXFLAGS) -std=c++20 $(MISA77_INC) $(MISA77_FLAGS) $< -c -o $@
+
+    $(MISA77_DIR)/%_avx2.o: MISA77_FLAGS = -mavx2
+    $(MISA77_DIR)/%_avx2.o: $(MISA77_DIR)/%.cpp ; $(CMD_BUILD_MISA77)
+
+    $(MISA77_DIR)/%_sse2.o: MISA77_FLAGS = -msse2
+    $(MISA77_DIR)/%_sse2.o: $(MISA77_DIR)/%.cpp ; $(CMD_BUILD_MISA77)
+
+    $(MISA77_DIR)/%.o: $(MISA77_DIR)/%.cpp ; $(CMD_BUILD_MISA77)
+endif
+
 # Symmetric codecs
 ifeq "$(DONT_BUILD_BSC)" "1"
     DEFINES += -DBENCH_REMOVE_BSC
@@ -1051,7 +1087,7 @@ endif # ifeq "$(ENABLE_CUDA)"
 
 MKDIR = mkdir -p
 
-lzbench: $(BUGGY_C_FILES) $(BUGGY_CC_FILES) $(BUGGY_CXX_FILES) $(ACEAPEX_FILES) $(BSC_C_FILES) $(BSC_CXX_FILES) $(BSC_CUDA_FILES) $(ACEAPEX_CUDA_FILES) $(BZIP2_FILES) $(BZIP3_FILES) $(CSC_FILES) $(KANZI_FILES) $(FASTLZMA2_OBJ) $(ZSTD_FILES) $(LZSSE_FILES) $(LZFSE_FILES) $(XZ_FILES) $(LIBLZG_FILES) $(BRIEFLZ_FILES) $(LZF_FILES) $(BROTLI_FILES) $(LZMA_FILES) $(ZLING_FILES) $(QUICKLZ_FILES) $(OPENZL_C_FILES) $(OPENZL_S_FILES) $(SNAPPY_FILES) $(ZLIB_FILES) $(ZLIB_NG_FILES) $(LZHAM_FILES) $(LZO_FILES) $(UCL_FILES) $(LZ4_FILES) $(LIZARD_FILES) $(LIBDEFLATE_FILES) $(ZXC_FILES) $(MISC_FILES) $(NVCOMP_FILES) $(PPMD_FILES) $(BENCH_FILES) $(SKIM_FILE)
+lzbench: $(BUGGY_C_FILES) $(BUGGY_CC_FILES) $(BUGGY_CXX_FILES) $(ACEAPEX_FILES) $(BSC_C_FILES) $(BSC_CXX_FILES) $(BSC_CUDA_FILES) $(ACEAPEX_CUDA_FILES) $(BZIP2_FILES) $(BZIP3_FILES) $(CSC_FILES) $(KANZI_FILES) $(FASTLZMA2_OBJ) $(ZSTD_FILES) $(LZSSE_FILES) $(LZFSE_FILES) $(XZ_FILES) $(LIBLZG_FILES) $(BRIEFLZ_FILES) $(LZF_FILES) $(BROTLI_FILES) $(LZMA_FILES) $(ZLING_FILES) $(QUICKLZ_FILES) $(OPENZL_C_FILES) $(OPENZL_S_FILES) $(SNAPPY_FILES) $(ZLIB_FILES) $(ZLIB_NG_FILES) $(LZHAM_FILES) $(LZO_FILES) $(UCL_FILES) $(LZ4_FILES) $(LIZARD_FILES) $(LIBDEFLATE_FILES) $(ZXC_FILES) $(MISA77_FILES) $(MISC_FILES) $(NVCOMP_FILES) $(PPMD_FILES) $(BENCH_FILES) $(SKIM_FILE)
 	$(CXX) $^ -o $@ $(LDFLAGS)
 	@echo Linked GCC_VERSION=$(GCC_VERSION) CLANG_VERSION=$(CLANG_VERSION) COMPILER=$(COMPILER)
 
@@ -1123,7 +1159,7 @@ $(LIZARD_FILES): %.o : %.c
 
 $(LZ_CODECS): %.o : %.cpp
 	@$(MKDIR) $(dir $@)
-	$(CXX) $(CXXFLAGS) -Ilz -Ilz/brotli/include -Ilz/openzl/include -Ilz/zxc/src/lib/vendors $< -c -o $@
+	$(CXX) $(CXXFLAGS) -Ilz -Ilz/brotli/include -Ilz/openzl/include -Ilz/zxc/src/lib/vendors -Ilz/misa77/include $< -c -o $@
 
 $(LZHAM_FILES): %.o : %.cpp
 	@$(MKDIR) $(dir $@)

--- a/Makefile
+++ b/Makefile
@@ -890,9 +890,15 @@ endif
 
 
 # misa77 targets 64-bit little-endian systems and needs C++20.
-MISA77_OK := $(shell printf 'int main(){static_assert(__BYTE_ORDER__==__ORDER_LITTLE_ENDIAN__);static_assert(sizeof(void*)==8);return 0;}' | $(CXX) $(CODE_FLAGS) -std=c++20 -fsyntax-only -x c++ - 2>/dev/null && echo ok)
-ifneq ($(MISA77_OK),ok)
-    DONT_BUILD_MISA77 ?= 1
+# The probe is skipped when misa77 is already disabled with DONT_BUILD_MISA77=1.
+ifneq ($(DONT_BUILD_MISA77),1)
+    MISA77_OK := $(shell printf 'int main(){static_assert(__BYTE_ORDER__==__ORDER_LITTLE_ENDIAN__);static_assert(sizeof(void*)==8);return 0;}' | $(CXX) $(CODE_FLAGS) -std=c++20 -fsyntax-only -x c++ - 2>/dev/null && echo ok)
+    ifneq ($(MISA77_OK),ok)
+        DONT_BUILD_MISA77 ?= 1
+        ifeq "$(DONT_BUILD_MISA77)" "1"
+            $(info C++20 and a 64-bit little-endian target required – skipping misa77 build)
+        endif
+    endif
 endif
 
 ifeq "$(DONT_BUILD_MISA77)" "1"
@@ -903,23 +909,25 @@ else
     # always built:
     MISA77_FILES  = $(MISA77_DIR)/src/compress.o $(MISA77_DIR)/src/decompress.o
     MISA77_FILES += $(MISA77_DIR)/src/isa/target_portable.o
-    MISA77_ISA := $(shell echo | $(CXX) $(CODE_FLAGS) -dM -E -x c++ - 2>/dev/null | grep -oE '__(x86_64|aarch64)__' | head -n1)
-    # 64-bit x86 only:
-    ifeq ($(MISA77_ISA),__x86_64__)
+
+    # 64-bit x86 only (the probe above already rejected 32-bit and big-endian targets):
+    ifneq (,$(filter x86_64% amd64%,$(TARGET_ARCH)))
         MISA77_FILES += $(MISA77_DIR)/src/isa/target_sse2.o $(MISA77_DIR)/src/isa/target_avx2.o
     endif
-    # 64-bit ARM only
-    ifeq ($(MISA77_ISA),__aarch64__)
+    # 64-bit ARM only:
+    ifneq (,$(filter arm64% aarch64%,$(TARGET_ARCH)))
         MISA77_FILES += $(MISA77_DIR)/src/isa/target_neon.o
     endif
 
     CMD_BUILD_MISA77 = @$(MKDIR) $(dir $@) && $(CXX) $(CXXFLAGS) -std=c++20 $(MISA77_INC) $(MISA77_FLAGS) $< -c -o $@
 
+    # target_avx2.cpp is the only TU needing extra ISA flags: SSE2 and NEON are baseline on
+    # 64-bit x86 and ARM, and the probe above already disabled misa77 on 32-bit targets. A
+    # 32-bit x86 port would have to add -msse2 back for target_sse2.cpp, as i686 has neither
+    # __SSE__ nor __SSE2__ by default.
+    # A pattern-specific variable applies to every target matching the pattern, so -mavx2
+    # reaches target_avx2.o through the generic rule below.
     $(MISA77_DIR)/%_avx2.o: MISA77_FLAGS = -mavx2
-    $(MISA77_DIR)/%_avx2.o: $(MISA77_DIR)/%.cpp ; $(CMD_BUILD_MISA77)
-
-    $(MISA77_DIR)/%_sse2.o: MISA77_FLAGS = -msse2
-    $(MISA77_DIR)/%_sse2.o: $(MISA77_DIR)/%.cpp ; $(CMD_BUILD_MISA77)
 
     $(MISA77_DIR)/%.o: $(MISA77_DIR)/%.cpp ; $(CMD_BUILD_MISA77)
 endif

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Notes column says otherwise.
 | [lzo 2.10](http://www.oberhumer.com/opensource/lzo) | 2017-03-01 | |
 | [lzsse 2019-04-18 (1847c3e827)](https://github.com/ConorStokes/LZSSE) | 2019-04-18 | 64-bit x86 only — requires SSE4.1 (Windows: MinGW-w64 only); lzsse8fast has a [bug](https://github.com/ConorStokes/LZSSE/issues/14) |
 | [memlz 0.2 beta](https://github.com/rrrlasse/memlz) | 2025-11-03 | Disabled on 32-bit ARM — unaligned access faults (SIGBUS) |
-| [misa77 0.5.0](https://github.com/welcome-to-the-sunny-side/misa77) | 2026-07-27 | Little-endian 64-bit only |
+| [misa77 0.5.0](https://github.com/welcome-to-the-sunny-side/misa77) | 2026-07-27 | Little-endian 64-bit only — needs a C++20 compiler (GCC 10+, Clang 12+); skipped automatically |
 | [nvcomp 2.2.0](https://github.com/NVIDIA/nvcomp) | 2022-02-07 | CUDA only — built with `make ENABLE_CUDA=1`; not in the default CI matrix |
 | [openzl 0.2.0](https://openzl.org/) | 2026-05-07 | 64-bit only — upstream does not support 32-bit builds |
 | [ppmd8 26.01](http://7-zip.org) | 2026-04-27 | |

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Notes column says otherwise.
 | [lzo 2.10](http://www.oberhumer.com/opensource/lzo) | 2017-03-01 | |
 | [lzsse 2019-04-18 (1847c3e827)](https://github.com/ConorStokes/LZSSE) | 2019-04-18 | 64-bit x86 only — requires SSE4.1 (Windows: MinGW-w64 only); lzsse8fast has a [bug](https://github.com/ConorStokes/LZSSE/issues/14) |
 | [memlz 0.2 beta](https://github.com/rrrlasse/memlz) | 2025-11-03 | Disabled on 32-bit ARM — unaligned access faults (SIGBUS) |
+| [misa77 0.5.0](https://github.com/welcome-to-the-sunny-side/misa77) | 2026-07-27 | Little-endian 64-bit only |
 | [nvcomp 2.2.0](https://github.com/NVIDIA/nvcomp) | 2022-02-07 | CUDA only — built with `make ENABLE_CUDA=1`; not in the default CI matrix |
 | [openzl 0.2.0](https://openzl.org/) | 2026-05-07 | 64-bit only — upstream does not support 32-bit builds |
 | [ppmd8 26.01](http://7-zip.org) | 2026-04-27 | |

--- a/bench/codecs.h
+++ b/bench/codecs.h
@@ -416,6 +416,17 @@ int64_t lzbench_memcpy(char *inbuf, size_t insize, char *outbuf, size_t outsize,
 #endif
 
 
+#ifndef BENCH_REMOVE_MISA77
+    int64_t lzbench_misa77_compress(char* inbuf, size_t insize, char* outbuf, size_t outsize, codec_options_t* codec_options);
+    int64_t lzbench_misa77_decompress(char* inbuf, size_t insize, char* outbuf, size_t outsize, codec_options_t* codec_options);
+    int64_t lzbench_misa77_safe_decompress(char* inbuf, size_t insize, char* outbuf, size_t outsize, codec_options_t* codec_options);
+#else
+    #define lzbench_misa77_compress NULL
+    #define lzbench_misa77_decompress NULL
+    #define lzbench_misa77_safe_decompress NULL
+#endif
+
+
 #ifndef BENCH_REMOVE_OPENZL
     char* lzbench_openzl_init_serial(size_t insize, size_t level, size_t);
     template <typename TInteger>

--- a/bench/lz_codecs.cpp
+++ b/bench/lz_codecs.cpp
@@ -57,6 +57,32 @@ int64_t lzbench_memlz_decompress(char* inbuf, size_t insize, char* outbuf, size_
 
 
 
+#ifndef BENCH_REMOVE_MISA77
+#include "misa77/misa77.h"
+
+int64_t lzbench_misa77_compress(char* inbuf, size_t insize, char* outbuf, size_t outsize, codec_options_t* codec_options)
+{
+    // level 0 = fastest decompression, level 1 = best ratio (the library default),
+    // level 2 = "heavy" format (better ratio still, slow compression)
+    return (int64_t)misa77::compress((const uint8_t*)inbuf, insize, (uint8_t*)outbuf, outsize, misa77::config((uint8_t)codec_options->level));
+}
+
+// The decompressor detects the format (light for levels 0-1, heavy for level 2) from the
+// stream itself. misa77_safe stops at level 1 because the heavy format has no safe decoder
+// yet (misa77::decompress with dconfig(true) rejects heavy streams by returning 0).
+int64_t lzbench_misa77_decompress(char* inbuf, size_t insize, char* outbuf, size_t outsize, codec_options_t* codec_options)
+{
+    return (int64_t)misa77::decompress((const uint8_t*)inbuf, insize, (uint8_t*)outbuf, outsize);
+}
+
+int64_t lzbench_misa77_safe_decompress(char* inbuf, size_t insize, char* outbuf, size_t outsize, codec_options_t* codec_options)
+{
+    return (int64_t)misa77::decompress((const uint8_t*)inbuf, insize, (uint8_t*)outbuf, outsize, misa77::dconfig(true));
+}
+#endif // BENCH_REMOVE_MISA77
+
+
+
 #ifndef BENCH_REMOVE_BRIEFLZ
 #include "lz/brieflz/brieflz.h"
 

--- a/bench/lzbench.h
+++ b/bench/lzbench.h
@@ -236,6 +236,8 @@ static const compressor_desc_t comp_desc[] =
     { "lzsse8fast", "lzsse8fast 2019-04-18",   0,   0,    0,  BENCH_POOL_MT, lzbench_lzsse8fast_compress, lzbench_lzsse8_decompress,     lzbench_lzsse8fast_init, lzbench_lzsse8fast_deinit },
     { "lzvn",       "lzvn 2017-03-08",         0,   0,    0,  BENCH_POOL_MT, lzbench_lzvn_compress,       lzbench_lzvn_decompress,       lzbench_lzvn_init,       lzbench_lzvn_deinit },
     { "memlz",      "memlz 0.2 beta",          0,   0,    0,  BENCH_POOL_MT, lzbench_memlz_compress,      lzbench_memlz_decompress,      lzbench_memlz_init,      lzbench_memlz_deinit },
+    { "misa77",      "misa77 0.5.0",           0,   2,    0,  BENCH_POOL_MT, lzbench_misa77_compress,     lzbench_misa77_decompress,      NULL, NULL },
+    { "misa77_safe", "misa77 0.5.0 safe",      0,   1,    0,  BENCH_POOL_MT, lzbench_misa77_compress,     lzbench_misa77_safe_decompress, NULL, NULL },
     { "nvcomp_lz4", "nvcomp_lz4 2.2.0",        0,   7,    0,  BENCH_POOL_MT, lzbench_nvcomp_compress,     lzbench_nvcomp_decompress,     lzbench_nvcomp_init,     lzbench_nvcomp_deinit },
     { "openzl_u8",  "openzl 0.2.0 -p u8",       0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(uint8_t),  lzbench_openzl_deinit },
     { "openzl_i8",  "openzl 0.2.0 -p i8",       0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(int8_t),  lzbench_openzl_deinit },
@@ -294,7 +296,7 @@ static const alias_desc_t alias_desc[] =
               "lizard,10,12,15,19,20,22,25,29,30,32,35,39,40,42,45,49/lz4fast,17,9,3/lz4/lz4hc,1,4,9,12/lzav/" \
               "lzf,0,1/lzfse/lzg,1,4,6,8/lzham,0,1/lzlib,0,3,6,9/lzma,0,2,4,6,9/" \
               "lzo1/lzo1a/lzo1b,1,3,6,9,99,999/lzo1c,1,3,6,9,99,999/lzo1f/lzo1x/lzo1y/lzo1z/lzo2a/" \
-              "lzsse2,1,6,12,16/lzsse4fast/lzsse4,1,6,12,16/lzsse8,1,6,12,16/lzvn/memlz/quicklz,1,2,3/" \
+              "lzsse2,1,6,12,16/lzsse4fast/lzsse4,1,6,12,16/lzsse8,1,6,12,16/lzvn/memlz/misa77,0,1,2/misa77_safe,0,1/quicklz,1,2,3/" \
               "slz_gzip/snappy/ucl_nrv2b,1,6,9/ucl_nrv2d,1,6,9/ucl_nrv2e,1,6,9/" \
               "xz,1,3,5,7,9/yalz77,1,6,12/zlib,1,6,9/zlib-ng,1,6,9/zstd_fast,-5,-3,-1/zstd,1,2,5,8,11,15,18,22/zxc,1,3,6" },
     { "SYMMETRIC", "Includes compressors with similar compression and decompression speeds.",
@@ -307,7 +309,7 @@ static const alias_desc_t alias_desc[] =
     { "FASTEST", "All LZ/SYMMETRIC/MISC compressors, each at only its fastest level.",
      /* LZ */ "memcpy/aceapex-DISABLED,1/brieflz,1/brotli,0/fastlz,1/fastlzma2,1/kanzi,1/libdeflate,1/lizard,10/lz4fast,99/lz4/lz4hc,1/lzav,1/" \
               "lzf,0/lzfse/lzham,0/lzlib,0/lzma,0/lzo1,1/lzo1a,1/lzo1b,1/lzo1c,1/lzo1f,1/lzo1x,1/lzo1y,1/lzo1z/lzo2a/lzsse2,1/" \
-              "lzsse4fast/lzsse4,1/lzsse8,1/lzvn/memlz/quicklz,1/slz_gzip,1/snappy/ucl_nrv2b,1/ucl_nrv2d,1/ucl_nrv2e,1/xz,0/yalz77,1/" \
+              "lzsse4fast/lzsse4,1/lzsse8,1/lzvn/memlz/misa77,0/misa77_safe,0/quicklz,1/slz_gzip,1/snappy/ucl_nrv2b,1/ucl_nrv2d,1/ucl_nrv2e,1/xz,0/yalz77,1/" \
               "zlib,1/zlib-ng,1/zstd_fast,-5/zstd,1/zxc,1/" /* aceapex is disabled as it has issues with tiny inputs */ \
 /* SYMMETR */ "bsc1/bzip2,1/bzip3,1/density,1/ppmd8,1/zpaq,1/" \
    /* MISC */ "crush,0/lzjb/skim/tamp,8/tornado-DISABLED,1/zling,0" }, /* Tornado is disabled as it has issues with incompressible data */

--- a/lz/misa77/LICENSE
+++ b/lz/misa77/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lz/misa77/README.md
+++ b/lz/misa77/README.md
@@ -1,0 +1,239 @@
+# misa77 (0.5.0)
+
+misa77 is an LZ-based codec that targets the write-once, read-many niche. In particular, it aims to satisfy the following criteria:
+
+- Extremely high decompression throughput (single-threaded).
+- Modest compression ratios (LZ4 at high effort levels is a good reference point).
+- Constant memory use during compression, regardless of input size (5-16 MB for levels 0-1, ~160 MB for level 2). Decompression uses no extra memory.
+
+Slow compression is the obvious tradeoff that one makes to achieve the above.
+
+In addition, misa77 has a somewhat synergizing tendency to decompress highly compressed files faster. This makes high-effort compression particularly attractive for misa77, and inspires some experimental compression modes (refer to [src/experimental/](src/experimental/)) that aim to spend more effort at compression time to produce a compressed stream that is friendlier to the microarchitectures of most CPUs when decompressing said streams.
+
+misa77 has three compression effort levels as of v0.5.0:
+
+- level 0: offers better decode throughput, slightly worse ratio, similar encode throughput
+- level 1 (default): offers slightly worse decode throughput, better ratio, similar encode throughput
+- level 2: offers similar decode throughput to level 1, the best ratio (slightly better than `lz4hc -12`), very low encode throughput
+
+There are two decompressor modes:
+
+- unsafe: passing invalid input to this mode is UB.
+- safe: guaranteed to exit gracefully (ie. provably terminate, and not access out-of-bounds memory or engage in any other UB) in the case of corrupt/malicious input, is 2-4% slower than unsafe.
+
+Note: as of now, level 2 doesn't have a safe decompressor. It will be added soon.
+
+## Benchmarks
+
+Detailed results are listed ahead, but here's a terse summary:
+
+- misa77 lies on the pareto frontier for decompression throughput vs compression ratio on most shapes of data.
+- It very frequently decompresses faster even when competitors have a significantly worse ratio.
+- It is quite slow at compression.
+- Performance is a bit sensitive to codegen, but even with the worst possible codegen I saw in my testing, misa77 was significantly faster than other codecs.
+
+Let's first see some cross-platform results for the [Silesia Corpus](https://sun.aei.polsl.pl//~sdeor/corpus/silesia.zip).
+
+Note:
+
+1. "Ratio" ahead is equal to `((compressed size)/(original)) * 100` (so lower is better).
+2. The benchmarking harness is a public fork of lzbench, and can be accessed [here](https://github.com/welcome-to-the-sunny-side/lzbench/tree/add-misa77-0.4.0).
+3. In the tables ahead, rows are sorted by decompression speed.
+
+---
+
+### Intel x86-64
+
+Details:
+
+- CPU: Intel(R) Core(TM) i7-14650HX (@2.2 GHz) (Intel Turbo disabled).
+- Single threaded, pinned to a single performance core.
+- CPU governor set to `performance`.
+
+| Compressor name       | Compression | Decompress. |  Ratio | Filename    |
+| --------------------- | ----------- | ----------- | ------ | ----------- |
+| misa77 0.5.0 -0       |   54.3 MB/s |   5359 MB/s |  42.64 | silesia.tar |
+| misa77 0.5.0 safe -0  |   54.1 MB/s |   5216 MB/s |  42.64 | silesia.tar |
+| misa77 0.5.0 -2       |   7.01 MB/s |   4470 MB/s |  35.51 | silesia.tar |
+| misa77 0.5.0 -1       |   51.2 MB/s |   4378 MB/s |  39.65 | silesia.tar |
+| misa77 0.5.0 safe -1  |   51.2 MB/s |   4252 MB/s |  39.65 | silesia.tar |
+| zxc 0.13.1 -3         |    116 MB/s |   2838 MB/s |  45.46 | silesia.tar |
+| zxc 0.13.1 -4         |   81.2 MB/s |   2726 MB/s |  42.63 | silesia.tar |
+| lzsse8fast 2019-04-18 |    183 MB/s |   2663 MB/s |  44.80 | silesia.tar |
+| zxc 0.13.1 -5         |   48.4 MB/s |   2602 MB/s |  40.25 | silesia.tar |
+| lz4hc 1.10.0 -12      |   7.31 MB/s |   2531 MB/s |  36.45 | silesia.tar |
+| lzsse4fast 2019-04-18 |    187 MB/s |   2525 MB/s |  45.26 | silesia.tar |
+| lz4 1.10.0            |    371 MB/s |   2506 MB/s |  47.59 | silesia.tar |
+| lz4hc 1.10.0 -9       |   22.0 MB/s |   2454 MB/s |  36.75 | silesia.tar |
+| lzav 5.11 -2          |   58.4 MB/s |   1729 MB/s |  34.97 | silesia.tar |
+| zxc 0.13.1 -7         |   4.27 MB/s |   1645 MB/s |  33.00 | silesia.tar |
+| zstd 1.5.7 -1         |    297 MB/s |    903 MB/s |  34.54 | silesia.tar |
+| snappy 1.2.2          |    376 MB/s |    858 MB/s |  47.89 | silesia.tar |
+
+---
+
+### ARM64 (Apple Silicon)
+
+Details: 
+
+- CPU: Apple M3
+
+| Compressor name      | Compression | Decompress. |  Ratio | Filename    |
+| -------------------- | ----------- | ----------- | ------ | ----------- |
+| misa77 0.5.0 -0      |    134 MB/s |  12660 MB/s |  42.64 | silesia.tar |
+| misa77 0.5.0 safe -0 |    134 MB/s |  12484 MB/s |  42.64 | silesia.tar |
+| misa77 0.5.0 -1      |    127 MB/s |  10270 MB/s |  39.65 | silesia.tar |
+| misa77 0.5.0 safe -1 |    127 MB/s |  10100 MB/s |  39.65 | silesia.tar |
+| misa77 0.5.0 -2      |   13.6 MB/s |   9935 MB/s |  35.51 | silesia.tar |
+| zxc 0.13.1 -3        |    279 MB/s |   8030 MB/s |  45.77 | silesia.tar |
+| zxc 0.13.1 -4        |    193 MB/s |   7663 MB/s |  43.20 | silesia.tar |
+| zxc 0.13.1 -5        |    115 MB/s |   7166 MB/s |  40.30 | silesia.tar |
+| lz4 1.10.0           |    882 MB/s |   5166 MB/s |  47.59 | silesia.tar |
+| lz4hc 1.10.0 -9      |   53.2 MB/s |   4885 MB/s |  36.74 | silesia.tar |
+| lz4hc 1.10.0 -12     |   17.0 MB/s |   4883 MB/s |  36.45 | silesia.tar |
+| zxc 0.13.1 -7        |   9.78 MB/s |   4310 MB/s |  33.01 | silesia.tar |
+| lzav 5.11 -2         |    175 MB/s |   4261 MB/s |  34.97 | silesia.tar |
+| snappy 1.2.2         |    967 MB/s |   3438 MB/s |  47.91 | silesia.tar |
+| zstd 1.5.7 -1        |    722 MB/s |   1615 MB/s |  34.54 | silesia.tar |
+
+---
+
+As misa77's performance is quite "spiky" (depending on the shape of the data being compressed), a file-level breakdown for the silesia corpus yields some interesting insights into its performance. 
+
+Note: 
+
+- The visuals that follow are derived from the benchmark results at [misc/lzbench-results-archive/0.5.0/intel.txt](misc/lzbench-results-archive/0.5.0/intel.txt)
+- These results are with the same x86-64 (Intel) setup mentioned previously.
+
+### Decode speed relative to lz4
+
+At level 0, misa77 decodes faster than lz4 on all 12 files (some by huge margins). Levels 1 and 2 decode faster on 11/12 files each, while compressing substantially better than lz4 everywhere. The exception is `x-ray`, which is highly incompressible (lz4 has a ratio of nearly 1.0 on this file and essentially devolves to a `memcpy`).
+
+![misa77 per-file decode speed vs lz4, levels 0-2, Silesia (Intel)](misc/lzbench-results-archive/0.5.0/speedup_vs_lz4.png)
+
+### Throughput vs ratio, against popular fast-decode codecs
+
+On the compressible files, misa77 sits on the decode-throughput/ratio Pareto frontier: it decodes fastest while ~matching or beating the ratio of the other fast-LZ codecs. `x-ray` is an exception once again.
+
+To spot misa77 in these graphs, just look for the circles near the top :)
+
+![misa77 vs other codecs: per-file decode throughput vs ratio, Silesia (Intel), levels 0-2](misc/lzbench-results-archive/0.5.0/pareto_silesia.png)
+
+## Requirements
+
+For the library:
+
+- A C++20 compiler (both GCC and Clang are fine).
+- CMake >= 3.20.
+- A little-endian 64-bit system.
+
+For the CLI:
+
+- The `misa` CLI needs POSIX (Linux, macOS).
+
+Note: On x86-64, AVX2/SSE2 are selected at runtime. ARM has a NEON path.
+
+## Building
+
+```sh
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+```
+
+This produces the `misa` CLI at `build/misa`. For a binary tuned to the exact machine you'll run it on, add `-DMISA77_MARCH=native` (I recommend this). To run the round-trip test:
+
+```sh
+ctest --test-dir build
+```
+
+## Library Usage
+
+The build produces a static library (CMake target `misa77`) with a small C++ API in `misa77/misa77.h`. The easiest integration is a git submodule (or CMake `FetchContent`) plus:
+
+```cmake
+add_subdirectory(misa77)
+target_link_libraries(your_app PRIVATE misa77)
+```
+
+Sample usage:
+
+```cpp
+#include <misa77/misa77.h>
+#include <vector>
+
+// compress (pick a level with misa77::config(0/1/2); default is 1), returns 0 on failure
+misa77::config cfg;
+std::vector<uint8_t> compressed(misa77::compress_bound(input_size, cfg));
+uint64_t csize = misa77::compress(input, input_size, compressed.data(), compressed.size(), cfg);
+compressed.resize(csize);
+
+// decompress, returns original_size on success
+uint64_t original_size = misa77::decompressed_size(compressed.data());
+std::vector<uint8_t> output(misa77::decompressed_buffer_bound(original_size));
+// decompress uses the unsafe decompressor by default, pass dconfig(true) to use the safe decompressor
+uint64_t written = misa77::decompress(compressed.data(), csize, output.data(), output.size(), misa77::dconfig(true));
+```
+
+Three things to keep in mind:
+
+- You must size the destination buffers with `compress_bound` / `decompressed_buffer_bound`, passing `compress_bound` the same `config` you compress with (the bound depends on the level's format).
+- You must pass `misa77::dconfig(true)` to `misa77::decompress` if you want the decompressor to exit gracefully on invalid input.
+- Safe decompression does not support level-2 streams yet: `decompress` with `dconfig(true)` returns 0 for them (the unsafe path decodes them fine).
+
+The experimental modes are declared in `misa77/experimental.h`, with usage documented in comments (these keep changing frequently so I don't wanna "formally" document them here just yet).
+
+## CLI Usage
+
+`misa` is a single, dependency-free binary with three file-based subcommands. It operates on single files only (there's no directory or pipe support, so `tar` first if you need those).
+
+```sh
+misa compress   FILE          # -> FILE.misa77
+misa decompress FILE.misa77   # -> FILE
+misa suggest    FILE          # -> FILE.misap  (tuned params)
+```
+
+`misa compress` takes `-l N` / `--level N` to pick the compression level (default is 1).
+
+There are also some experimental compression modes (at most one at a time, not combinable with `--level`):
+
+| Flag | Effect |
+| ---- | ------ |
+| `--adaptive` | autotune the compressor based on the input for decode speed (only use this with homogeneous data) |
+| `--params F.misap` | compress with a vector from `misa suggest` |
+| `--yolo` | high-effort, decode-optimized |
+
+`--adaptive` and `suggest` also take `--tune loose` / `--tune tight` (similar tradeoffs as `level 0/1`, and the default is loose) and `--sample MB` (how much input to sample when picking params, default is 2 MB). Everywhere, `-o PATH` sets the output path and `-f` overwrites without asking.
+
+```sh
+misa compress -l 0 enwik8                # enwik8 -> enwik8.misa77, fastest-decode level
+misa decompress enwik8.misa77            # back to enwik8
+
+# tune on a sample, then reuse the params:
+misa suggest --tune tight data.bin       # -> data.misap
+misa compress --params data.misap data.bin
+```
+
+## Documentation
+
+The underlying stream format (used by the library functions) and the container format for `.misa77` files (produced by the CLI) can be found in [`docs/`](docs/).
+
+## Status
+
+1. misa77's format may change unexpectedly as it's still v0.x.y. 
+2. It's been through local fuzzing with ASan/UBSan, broader hardening is ongoing.
+
+Note: misa77 has evolved out of a less polished endeavour to learn performance engineering, and its history can be found [in this archived repository](https://github.com/welcome-to-the-sunny-side/misa77-archive).
+
+## Acknowledgement
+
+Inspiration has been taken from:
+
+- [LZ4](http://github.com/lz4/lz4/)
+- [zxc](https://github.com/hellobertrand/zxc)
+- [lizard](https://github.com/inikep/lizard)
+
+Lastly, Claude Fable 5 and Opus 4.8 helped a *lot* with orchestrating experiments, scripting, tooling, and building the CLI. Without their assistance, development would have been far slower, and I would likely not have explored all the paths that I did end up exploring (some of which were productive and some of which weren't).
+
+## License
+
+MIT (see [LICENSE](LICENSE)).

--- a/lz/misa77/include/misa77/misa77.h
+++ b/lz/misa77/include/misa77/misa77.h
@@ -1,0 +1,91 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include <cstdint>
+
+// Library version
+#define MISA77_VERSION_MAJOR 0
+#define MISA77_VERSION_MINOR 5
+#define MISA77_VERSION_PATCH 0
+#define MISA77_VERSION_NUMBER                                                                      \
+    (MISA77_VERSION_MAJOR * 10000 + MISA77_VERSION_MINOR * 100 + MISA77_VERSION_PATCH)
+#define MISA77_STR_HELPER(x) #x
+#define MISA77_STR(x) MISA77_STR_HELPER(x)
+#define MISA77_VERSION_STR                                                                         \
+    MISA77_STR(MISA77_VERSION_MAJOR)                                                               \
+    "." MISA77_STR(MISA77_VERSION_MINOR) "." MISA77_STR(MISA77_VERSION_PATCH)
+
+namespace misa77
+{
+    // `1e15`
+    inline constexpr uint64_t max_src_size = 1'000'000'000'000'000;
+
+    // compressor config
+    class config
+    {
+    public:
+        // Only integers in [0, max_level] are valid levels
+        static constexpr uint8_t max_level = 2;
+        static constexpr uint8_t default_level = 1;
+        static_assert(default_level <= max_level);
+
+        // Light levels in [0, heavy_lb), heavy levels in [heavy_lb, max_level]
+        static constexpr uint8_t heavy_lb = 2;
+
+        uint8_t level;
+        config() : level(default_level) {}
+        explicit config(uint8_t l) : level(l) {}
+    };
+
+    // decompressor config
+    class dconfig
+    {
+    public:
+        static constexpr uint8_t default_safety = false;
+
+        bool safe;
+        dconfig() : safe(default_safety) {}
+        explicit dconfig(bool s) : safe(s) {}
+    };
+
+    // Upper-bound on compressed size (in bytes) for any input of size `src_size` bytes.
+    // Use to size destination buffer. The bound depends on the format `cfg.level` emits, so
+    // pass the same `cfg` you will pass to `compress`.
+    // PRECONDITION: `src_size <= max_src_size`
+    uint64_t compress_bound(uint64_t src_size, config cfg);
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // `cfg.level` selects the compressor to be used. Levels below `config::heavy_lb` emit the
+    // light format, levels at or above it emit the heavy format.
+    // PRECONDITION: `src_size <= max_src_size` and `0 <= cfg.level <= config::max_level`
+    uint64_t compress(const uint8_t* __restrict src,
+                      uint64_t src_size,
+                      uint8_t* __restrict dst,
+                      uint64_t dst_cap,
+                      config cfg = config());
+
+    // Returns the exact size (in bytes) of the file that the given compressed file will be
+    // decompressed to.
+    // Only call this on buffers that were compressed in the misa77 format, as it
+    // requires the size of the buffer to be >= 8.
+    uint64_t decompressed_size(const uint8_t* src);
+
+    // Minimum size of buffer required to decompress a compressed file that corresponds to an
+    // original file of `src_size` bytes.
+    // Usage: decompressed_buffer_bound(decompressed_size(src))
+    uint64_t decompressed_buffer_bound(uint64_t src_size);
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // PRECONDITION: (dcfg.safe = true) OR (`src` and `src_size` must correspond to a valid misa77
+    // stream) Passing (dcfg.safe = false) and an invalid misa77 stream is UB!
+    // NOTE: safe decompression of the heavy format (streams from levels >= config::heavy_lb) is
+    // not supported yet; safe mode returns 0 for such streams without writing to `dst`.
+    uint64_t decompress(const uint8_t* __restrict src,
+                        uint64_t src_size,
+                        uint8_t* __restrict dst,
+                        uint64_t dst_cap,
+                        dconfig dcfg = dconfig());
+} // namespace misa77

--- a/lz/misa77/src/compress.cpp
+++ b/lz/misa77/src/compress.cpp
@@ -1,0 +1,49 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#include "compress_dispatch.h"
+#include "misa77/misa77.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    // Upper-bound on compressed size (in bytes) for any input of size `src_size` bytes.
+    // Use to size destination buffer.
+    // PRECONDITION: `src_size <= max_src_size`
+    uint64_t compress_bound(uint64_t src_size, config cfg)
+    {
+        if (cfg.level < cfg.heavy_lb)
+            return uint64_t(8)   // uncompressed size
+                   + uint64_t(8) // number of trailing raw literals (>= `literal_suffix`)
+                   + src_size + (src_size / uint64_t(255)) +
+                   uint64_t(16); // compressed data length upper-bound
+        else
+            return uint64_t(8) + uint64_t(8) + src_size + (src_size / uint64_t(32)) + uint64_t(64);
+    }
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // Resolves the best finder path once per call, depending on the ISA.
+    // PRECONDITION: `src_size <= max_src_size`
+    uint64_t compress(const uint8_t* __restrict src,
+                      uint64_t src_size,
+                      uint8_t* __restrict dst,
+                      uint64_t dst_cap,
+                      config cfg)
+    {
+        if (src_size > max_src_size)
+            return 0;
+
+#if defined(__x86_64__)
+        if (__builtin_cpu_supports("avx2"))
+            return compress_avx2(src, src_size, dst, dst_cap, cfg);
+        return compress_sse2(src, src_size, dst, dst_cap, cfg);
+#elif defined(__aarch64__)
+        // NEON is guaranteed on Aarch64
+        return compress_neon(src, src_size, dst, dst_cap, cfg);
+#else
+        return compress_portable(src, src_size, dst, dst_cap, cfg);
+#endif
+    }
+} // namespace misa77

--- a/lz/misa77/src/compress_dispatch.h
+++ b/lz/misa77/src/compress_dispatch.h
@@ -1,0 +1,37 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "misa77/misa77.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    // ISA-specialized compress entry points. Each is defined in a per-target TU in src/isa/,
+    // compiled with that ISA's flags (target_avx2.cpp with -mavx2, target_sse2.cpp /
+    // target_portable.cpp at baseline, target_neon.cpp at armv8-a), and selected at runtime
+    // by compress() (see compress.cpp).
+    uint64_t compress_avx2(const uint8_t* __restrict src,
+                           uint64_t src_size,
+                           uint8_t* __restrict dst,
+                           uint64_t dst_cap,
+                           config cfg);
+    uint64_t compress_sse2(const uint8_t* __restrict src,
+                           uint64_t src_size,
+                           uint8_t* __restrict dst,
+                           uint64_t dst_cap,
+                           config cfg);
+    uint64_t compress_neon(const uint8_t* __restrict src,
+                           uint64_t src_size,
+                           uint8_t* __restrict dst,
+                           uint64_t dst_cap,
+                           config cfg);
+    uint64_t compress_portable(const uint8_t* __restrict src,
+                               uint64_t src_size,
+                               uint8_t* __restrict dst,
+                               uint64_t dst_cap,
+                               config cfg);
+} // namespace misa77

--- a/lz/misa77/src/compressor_zoo/default_compress_impl.h
+++ b/lz/misa77/src/compressor_zoo/default_compress_impl.h
@@ -1,0 +1,264 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "format.h"
+#include "misa77/misa77.h"
+#include "util.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace misa77
+{
+    namespace default_detail
+    {
+        using namespace light;
+
+        constexpr uint32_t hash_top = 16;
+        constexpr uint32_t hash_siz = 1 << hash_top;
+        constexpr uint32_t hash_mul = 2654435761;
+
+        // Size of ring buffer per hash in the hashtable.
+        inline constexpr uint64_t hashtab_wid = 16;
+
+        // Hash 4 bytes to an integer in `[0, 1 << (hash_top))`.
+        [[gnu::always_inline]]
+        inline uint32_t hash4(const uint32_t val)
+        {
+            return (val * hash_mul) >> (32 - hash_top);
+        }
+
+        // Assuming that rem contains top 3 bits of the token, emits bytes specifying `n`.
+        [[gnu::always_inline]]
+        inline void emit_length_extras(uint8_t* dst, uint64_t& dlpos, uint64_t n, uint8_t rem)
+        {
+            if (rem != uint8_t(7)) [[likely]]
+                return;
+
+            // Write this unconditionally first, if it's wrong we'll just overwrite
+            dst[dlpos] = static_cast<uint8_t>(n);
+
+            constexpr uint64_t block = 255;
+            if (n >= block) [[unlikely]]
+            {
+                while (n >= block) [[unlikely]]
+                    dst[dlpos] = block, ++dlpos, n -= block;
+                dst[dlpos] = static_cast<uint8_t>(n);
+            }
+
+            ++dlpos;
+        }
+
+        // Don't look further ahead once you have a match `>= la_gate`
+        constexpr uint64_t la_gate = 16;
+
+        // Once you have match `>= la_pate`, only keep looking if you get gains
+        constexpr uint64_t la_pate = 8;
+
+        // When you've gone `p` hashtab searches without a match, advance the pointer by `p >>
+        // skip_shift`
+        constexpr uint64_t skip_shift = 6;
+    } // namespace default_detail
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // `isa_lib` is ISA-dependent.
+    template <class isa_lib>
+    uint64_t default_compress_impl(const uint8_t* __restrict src,
+                                   uint64_t src_size,
+                                   uint8_t* __restrict dst,
+                                   uint64_t dst_cap)
+    {
+        using namespace light;
+        using namespace default_detail;
+
+        static_assert(max_match_len >= 32);
+
+        if (compress_bound(src_size, config()) > dst_cap)
+            return 0;
+
+        // Left pointer in the destination buffer (metadata and control bytes)
+        uint64_t dlpos = 0;
+
+        // Right pointer in the destination buffer (literal bytes)
+        // We've written to `[drpos, dst_cap)` at any given point of time
+        uint64_t drpos = dst_cap;
+
+        storeu8(dst, src_size);
+        dlpos += 8;
+
+        // Small source
+        if (src_size <= small_lim)
+        {
+            if (src_size != 0)
+                memcpy(dst + dlpos, src, src_size);
+            dlpos += src_size;
+            return dlpos;
+        }
+
+        uint64_t literal_suffix_pos = dlpos;
+        dlpos += 8;
+
+        // Ensure that the last `literal_suffix` bytes will be literals
+        uint64_t match_end_limit = (src_size < literal_suffix ? 0 : src_size - literal_suffix);
+
+        // Beginning of the pending literal window
+        uint64_t lit = 0;
+
+        // `[lit, pos]` corresponds to the new range from the src buffer we're going to be
+        // turning into a lit + match pair
+        uint64_t pos = 0;
+
+        // `[0, hpos)` represents the range we've written into the hashtable
+        uint64_t hpos = 0;
+
+        uint64_t miss_run = 0;
+
+        std::vector<std::array<uint16_t, hashtab_wid>> hashtab(hash_siz);
+        std::vector<uint8_t> hashtab_idx(hash_siz);
+        while (pos + max_match_len <= match_end_limit)
+        {
+            // Reduce branch misses, `batch = 8` performs well empirically
+            constexpr uint64_t batch = 8;
+            while (pos >= hpos + hashtab_lag + batch) [[unlikely]]
+            {
+#pragma GCC unroll batch
+                for (uint64_t i = 0; i < batch; i++)
+                {
+                    uint32_t hsh = hash4(loadu4(src + hpos + i));
+                    hashtab[hsh][hashtab_idx[hsh]] =
+                        uint16_t(hpos + i); // We just store the lowest 2 bytes
+                    hashtab_idx[hsh] =
+                        (hashtab_idx[hsh] == hashtab_wid - 1
+                             ? uint8_t(0)
+                             : hashtab_idx[hsh] + 1); // Just cycle the pointer in the ring buffer
+                }
+                hpos += batch;
+            }
+
+            uint32_t val = loadu4(src + pos);
+            uint32_t hsh = hash4(val);
+
+            uint64_t lst = 0;
+            uint64_t match_len = 0;
+
+            typename isa_lib::vec reg = isa_lib::loadvec(src + pos);
+
+            if (pos > hashtab_lag) [[likely]]
+            {
+// MLP
+#pragma GCC unroll hashtab_wid
+                for (uint8_t i = 0; i < hashtab_wid; i++)
+                {
+                    uint16_t d = uint16_t(pos - hashtab[hsh][i] - hashtab_lag - 1);
+
+                    // Guaranteed to lie within `[pos - 2^16 - hashtab_lag, pos - hashtab_lag)`
+                    uint64_t ilst = (pos - max_match_len - 1 - d);
+
+                    typename isa_lib::vec ireg = isa_lib::loadvec(src + ilst);
+                    uint32_t imatch_len = isa_lib::lcp(reg, ireg);
+                    lst = (imatch_len > match_len ? ilst : lst);
+                    match_len = (imatch_len > match_len ? imatch_len : match_len);
+                }
+            }
+
+            if (match_len >= min_match_len)
+            {
+                for (uint64_t npos = pos + 1;
+                     npos <= pos + lookahead and npos + max_match_len <= match_end_limit and
+                     match_len < la_gate;
+                     npos++)
+                {
+                    uint64_t nlst = 0;
+                    uint64_t nmatch_len = 0;
+
+                    uint32_t val = loadu4(src + npos);
+                    uint32_t hsh = hash4(val);
+                    typename isa_lib::vec reg = isa_lib::loadvec(src + npos);
+#pragma GCC unroll hashtab_wid
+                    for (uint8_t i = 0; i < hashtab_wid; i++)
+                    {
+                        uint16_t d = uint16_t(npos - hashtab[hsh][i] - hashtab_lag - 1);
+
+                        // Guaranteed to lie within `[npos - 2^16 - hashtab_lag, npos -
+                        // hashtab_lag)`
+                        uint64_t ilst = (npos - max_match_len - 1 - d);
+
+                        typename isa_lib::vec ireg = isa_lib::loadvec(src + ilst);
+                        uint32_t imatch_len = isa_lib::lcp(reg, ireg);
+
+                        nlst = (imatch_len > nmatch_len ? ilst : nlst);
+                        nmatch_len = (imatch_len > nmatch_len ? imatch_len : nmatch_len);
+                    }
+
+                    bool improved = (nmatch_len > match_len);
+                    pos = (improved ? npos : pos);
+                    lst = (improved ? nlst : lst);
+                    match_len = (improved ? nmatch_len : match_len);
+
+                    if (!improved and match_len >= la_pate)
+                        break;
+                }
+
+                uint64_t norm_match_len = match_len - min_match_len + 1;
+
+                // `src[lit, pos)` are the literals
+                uint64_t lit_len = pos - lit;
+
+                // Token Byte
+                uint8_t lrem = std::min(uint64_t(7), lit_len);
+                dst[dlpos] = static_cast<uint8_t>((lrem << 5) | (norm_match_len));
+                lit_len -= lrem;
+                ++dlpos;
+
+                // 2 Distance bytes
+                uint64_t dis = pos - lst;
+                uint16_t dbytes = dis - hashtab_lag - 1;
+                storeu2(dst + dlpos, dbytes);
+                dlpos += 2;
+
+                // Extra literal length bytes
+                emit_length_extras(dst, dlpos, lit_len, lrem);
+
+                // Literal bytes
+                if (lit < pos)
+                {
+                    uint64_t lit_cnt = pos - lit;
+                    drpos -= lit_cnt;
+                    memcpy(dst + drpos, src + lit, lit_cnt);
+                }
+
+                pos += match_len;
+                lit = pos;
+                miss_run = 0;
+            }
+            else
+            {
+                pos += 1 + (miss_run >> skip_shift);
+                ++miss_run;
+            }
+        }
+
+        // Close the gap between the two streams by moving the literal stream to the left
+        if (drpos < dst_cap)
+        {
+            memmove(dst + dlpos, dst + drpos, dst_cap - drpos);
+            dlpos += dst_cap - drpos;
+        }
+
+        // Just deal with the last few literals (guaranteed to be `>= literal_suffix >=
+        // vector_width` bytes)
+        uint64_t literal_suffix_cnt = src_size - lit;
+        storeu8(dst + literal_suffix_pos, literal_suffix_cnt);
+        memcpy(dst + dlpos, src + lit, literal_suffix_cnt);
+        dlpos += literal_suffix_cnt;
+
+        return dlpos;
+    }
+
+} // namespace misa77

--- a/lz/misa77/src/compressor_zoo/heavy_compress_impl.h
+++ b/lz/misa77/src/compressor_zoo/heavy_compress_impl.h
@@ -1,0 +1,456 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "format.h"
+#include "misa77/misa77.h"
+#include "suffix/sais.h"
+#include "util.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <vector>
+
+namespace misa77
+{
+    namespace heavy_detail
+    {
+        using namespace heavy;
+
+        // 2 MB blocks
+        constexpr uint64_t block_size = uint64_t(1) << 21;
+
+        // segments can extend past block boundaries
+        constexpr uint64_t pad_len = max_match_len + 1;
+
+        constexpr float cond_flag_thresh = 0.14f;
+
+        constexpr uint64_t dp_inf = std::numeric_limits<uint64_t>::max();
+
+        [[gnu::always_inline]]
+        inline uint64_t lit_extras(uint64_t run)
+        {
+            return run < lit_lim ? 0 : 1 + (run - lit_lim) / 255;
+        }
+
+        // 3-level bitset that maintains the positions of the alive suffixes inside the match window
+        struct liveset
+        {
+            std::vector<uint64_t> l0, l1, l2;
+
+            // live iff sa[r] < lim
+            void build(const int32_t* sa, uint64_t m, uint32_t lim)
+            {
+                l0.assign((m + 63) / 64, 0);
+                l1.assign((l0.size() + 63) / 64, 0);
+                l2.assign((l1.size() + 63) / 64, 0);
+                for (uint64_t w = 0; w < l0.size(); ++w)
+                {
+                    const uint64_t base = w << 6;
+                    const uint64_t top = std::min<uint64_t>(64, m - base);
+                    uint64_t bits = 0;
+                    for (uint64_t j = 0; j < top; ++j)
+                        bits |= uint64_t(uint32_t(sa[base + j]) < lim) << j;
+                    l0[w] = bits;
+                }
+                for (uint64_t w = 0; w < l0.size(); ++w)
+                    if (l0[w])
+                        l1[w >> 6] |= uint64_t(1) << (w & 63);
+                for (uint64_t w = 0; w < l1.size(); ++w)
+                    if (l1[w])
+                        l2[w >> 6] |= uint64_t(1) << (w & 63);
+            }
+
+            void set(uint64_t i)
+            {
+                l0[i >> 6] |= uint64_t(1) << (i & 63);
+                l1[i >> 12] |= uint64_t(1) << ((i >> 6) & 63);
+                l2[i >> 18] |= uint64_t(1) << ((i >> 12) & 63);
+            }
+
+            void clear(uint64_t i)
+            {
+                if ((l0[i >> 6] &= ~(uint64_t(1) << (i & 63))) == 0)
+                    if ((l1[i >> 12] &= ~(uint64_t(1) << ((i >> 6) & 63))) == 0)
+                        l2[i >> 18] &= ~(uint64_t(1) << ((i >> 12) & 63));
+            }
+
+            // largest live index < i, or -1
+            int64_t prev(uint64_t i) const
+            {
+                uint64_t w = i >> 6;
+                uint64_t mask = (i & 63) ? (uint64_t(1) << (i & 63)) - 1 : 0;
+                if (uint64_t v = l0[w] & mask)
+                    return int64_t((w << 6) + 63 - uint64_t(__builtin_clzll(v)));
+                uint64_t w1 = w >> 6;
+                uint64_t m1 = (w & 63) ? (uint64_t(1) << (w & 63)) - 1 : 0;
+                if (uint64_t v = l1[w1] & m1)
+                {
+                    w = (w1 << 6) + 63 - uint64_t(__builtin_clzll(v));
+                    return int64_t((w << 6) + 63 - uint64_t(__builtin_clzll(l0[w])));
+                }
+                uint64_t w2 = w1 >> 6;
+                uint64_t m2 = (w1 & 63) ? (uint64_t(1) << (w1 & 63)) - 1 : 0;
+                for (int64_t t = int64_t(w2); t >= 0; --t)
+                {
+                    uint64_t v2 = l2[t] & (t == int64_t(w2) ? m2 : ~uint64_t(0));
+                    if (!v2)
+                        continue;
+                    uint64_t a = (uint64_t(t) << 6) + 63 - uint64_t(__builtin_clzll(v2));
+                    uint64_t b = (a << 6) + 63 - uint64_t(__builtin_clzll(l1[a]));
+                    return int64_t((b << 6) + 63 - uint64_t(__builtin_clzll(l0[b])));
+                }
+                return -1;
+            }
+
+            // smallest live index > i, or -1
+            int64_t next(uint64_t i) const
+            {
+                uint64_t w = i >> 6;
+                uint64_t mask = (i & 63) == 63 ? 0 : ~((uint64_t(2) << (i & 63)) - 1);
+                if (uint64_t v = l0[w] & mask)
+                    return int64_t((w << 6) + uint64_t(__builtin_ctzll(v)));
+                uint64_t w1 = w >> 6;
+                uint64_t m1 = (w & 63) == 63 ? 0 : ~((uint64_t(2) << (w & 63)) - 1);
+                if (uint64_t v = l1[w1] & m1)
+                {
+                    w = (w1 << 6) + uint64_t(__builtin_ctzll(v));
+                    return int64_t((w << 6) + uint64_t(__builtin_ctzll(l0[w])));
+                }
+                uint64_t w2 = w1 >> 6;
+                uint64_t m2 = (w1 & 63) == 63 ? 0 : ~((uint64_t(2) << (w1 & 63)) - 1);
+                for (uint64_t t = w2; t < l2.size(); ++t)
+                {
+                    uint64_t v2 = l2[t] & (t == w2 ? m2 : ~uint64_t(0));
+                    if (!v2)
+                        continue;
+                    uint64_t a = (t << 6) + uint64_t(__builtin_ctzll(v2));
+                    uint64_t b = (a << 6) + uint64_t(__builtin_ctzll(l1[a]));
+                    return int64_t((b << 6) + uint64_t(__builtin_ctzll(l0[b])));
+                }
+                return -1;
+            }
+        };
+    } // namespace heavy_detail
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // `isa_lib` is ISA-dependent.
+    template <class isa_lib>
+    uint64_t heavy_compress_impl(const uint8_t* __restrict src,
+                                 uint64_t src_size,
+                                 uint8_t* __restrict dst,
+                                 uint64_t dst_cap)
+    {
+        using namespace heavy;
+        using namespace heavy_detail;
+
+        if (compress_bound(src_size, config(config::heavy_lb)) > dst_cap)
+            return 0;
+
+        auto lcp_long = [&](const uint8_t* a, const uint8_t* b, uint32_t max_len) -> uint32_t
+        {
+            uint32_t i = 0;
+            while (i + vector_width <= max_len)
+            {
+                uint32_t len = isa_lib::lcp(isa_lib::loadvec(a + i), isa_lib::loadvec(b + i));
+                i += len;
+                if (len < vector_width)
+                    return i;
+            }
+            while (i < max_len and a[i] == b[i])
+                ++i;
+            return i;
+        };
+
+        // Left pointer in the destination buffer (metadata and control bytes)
+        uint64_t dlpos = 0;
+
+        // Right pointer in the destination buffer (literal bytes)
+        // We've written to `[drpos, dst_cap)` at any given point of time
+        uint64_t drpos = dst_cap;
+
+        storeu8(dst, src_size | (uint64_t(1) << (format_bit + 56)));
+        dlpos += 8;
+
+        if (src_size <= small_lim)
+        {
+            if (src_size != 0)
+                memcpy(dst + dlpos, src, src_size);
+            dlpos += src_size;
+            return dlpos;
+        }
+
+        uint64_t literal_suffix_pos = dlpos;
+        dlpos += 8;
+
+        // Ensure that the last `literal_suffix` bytes will be literals
+        uint64_t match_end_limit = (src_size < literal_suffix ? 0 : src_size - literal_suffix);
+
+        // Beginning of the pending literal window
+        uint64_t lit = 0;
+
+        // Token stats for the conditional-decode bit
+        uint64_t tokens = 0;
+        uint64_t long_matches = 0;
+
+        // `match_len` is always an exact codebook length here (the DP relaxes only those)
+        auto emit_token = [&](uint64_t match_start, uint32_t match_len, uint32_t match_dis)
+        {
+            uint64_t lit_len = match_start - lit;
+            uint32_t lrem = lit_len < lit_lim ? uint32_t(lit_len) : uint32_t(lit_lim);
+            uint32_t code = LUT.code_floor[match_len];
+            uint32_t tok = uint32_t((match_dis - min_dis) & dis_mask) | (code << 20) | (lrem << 26);
+            storeu4(dst + dlpos, tok);
+            dlpos += 4;
+            if (lrem == lit_lim)
+            {
+                uint64_t e = lit_len - lit_lim;
+                while (e >= 255)
+                {
+                    dst[dlpos++] = 255;
+                    e -= 255;
+                }
+                dst[dlpos++] = uint8_t(e);
+            }
+            if (lit_len)
+            {
+                drpos -= lit_len;
+                memcpy(dst + drpos, src + lit, lit_len);
+            }
+            ++tokens;
+            long_matches += uint64_t(match_len > vector_width);
+            lit = match_start + match_len;
+        };
+
+        // Per-block state, reused across blocks
+        sais_chan sorter_chan;
+        std::vector<int32_t> sa, rank;
+        liveset live;
+        std::vector<uint8_t> max_len;    // longest in-window match at each block position
+        std::vector<uint32_t> match_dis; // its distance
+        std::vector<uint64_t> dp;        // exact cost of the cheapest parse ending at boundary i
+
+        struct arrival
+        {
+            uint32_t dis;
+            uint32_t len;
+            uint64_t lit_run; // literals immediately before the match
+        };
+        std::vector<arrival> arr;
+
+        struct token_rec
+        {
+            uint64_t match_start;
+            uint32_t len;
+            uint32_t dis;
+        };
+        std::vector<token_rec> block_tokens;
+
+        // Last committed parse boundary and its exact total cost
+        uint64_t qstar = 0;
+        uint64_t qstar_cost = 16; // header
+
+        for (uint64_t bs = 0; bs < src_size; bs += block_size)
+        {
+            const uint64_t be = std::min(bs + block_size, src_size);
+            const uint64_t blen = be - bs;
+
+            // Suffix array and rank over [history | block | pad]
+            const uint64_t seg0 = bs > max_dis ? bs - max_dis : 0;
+            const uint64_t seg_end = std::min(src_size, be + pad_len);
+            const uint32_t m = uint32_t(seg_end - seg0);
+            sa.resize(m);
+            rank.resize(m);
+            sorter_chan.sa(src + seg0, m, sa.data(), rank.data());
+
+            // Longest in-window match per position, clipped at the block end
+            max_len.assign(blen, 0);
+            match_dis.assign(blen, 0);
+
+            // Matches must end within the block AND BEFORE the raw suffix
+            const uint64_t hard = std::min(be, match_end_limit);
+            const uint32_t init_lim =
+                bs >= min_dis and bs - min_dis >= seg0 ? uint32_t(bs - min_dis - seg0 + 1) : 0;
+            live.build(sa.data(), m, init_lim);
+
+            uint64_t carry_len = 0;
+            uint32_t carry_dis = 0;
+            for (uint64_t p = bs; p < be; ++p)
+            {
+                // Slide the source window [p - max_dis, p - min_dis]
+                if (p >= min_dis and p - min_dis >= seg0)
+                    live.set(uint64_t(rank[p - min_dis - seg0]));
+                if (p > max_dis and p - max_dis - 1 >= seg0)
+                    live.clear(uint64_t(rank[p - max_dis - 1 - seg0]));
+
+                if (p + min_match_len > hard)
+                    continue;
+                const uint32_t limit = uint32_t(std::min<uint64_t>(max_match_len, hard - p));
+
+                // Skip the queries, make use of carry
+                if (carry_len >= limit)
+                {
+                    max_len[p - bs] = uint8_t(limit);
+                    match_dis[p - bs] = carry_dis;
+                    --carry_len;
+                    continue;
+                }
+
+                const uint64_t r = uint64_t(rank[p - seg0]);
+                uint32_t best = 0;
+                uint32_t best_dis = 0;
+                auto consider = [&](int64_t q)
+                {
+                    if (q < 0)
+                        return;
+                    const uint64_t s = seg0 + uint64_t(sa[q]);
+                    const uint32_t l = lcp_long(src + p, src + s, limit);
+                    if (l > best)
+                    {
+                        best = l;
+                        best_dis = uint32_t(p - s);
+                    }
+                };
+                consider(live.prev(r));
+                consider(live.next(r));
+
+                if (best >= min_match_len)
+                {
+                    max_len[p - bs] = uint8_t(best);
+                    match_dis[p - bs] = best_dis;
+                    if (best >= limit)
+                    {
+                        // Extend past the clamp to seed the carry for upcoming positions
+                        const uint64_t room = src_size - (p + limit);
+                        const uint32_t ext = lcp_long(src + p + limit,
+                                                      src + (p - best_dis) + limit,
+                                                      uint32_t(std::min<uint64_t>(room, ndis)));
+                        carry_len = uint64_t(limit) + ext - 1;
+                        carry_dis = best_dis;
+                    }
+                    else
+                    {
+                        carry_len = best - 1;
+                        carry_dis = best_dis;
+                    }
+                }
+                else
+                    carry_len -= uint64_t(carry_len > 0);
+            }
+
+            // Exact DP over boundaries [bs, be]
+            dp.assign(blen + 1, dp_inf);
+            arr.resize(blen + 1);
+
+            // G-state = cheapest known "boundary + all literals since" arrival
+            uint64_t g_run = bs - qstar;
+            uint64_t g_cost = qstar_cost + g_run + lit_extras(g_run);
+
+            // Next run length at which the extras byte count grows
+            uint64_t g_next = g_run < lit_lim ? lit_lim : g_run + 255 - (g_run - lit_lim) % 255;
+            if (bs == 0)
+                dp[0] = qstar_cost;
+            for (uint64_t p = bs; p <= be; ++p)
+            {
+                const uint64_t i = p - bs;
+                if (p > bs)
+                {
+                    ++g_run;
+                    if (g_run >= g_next) [[unlikely]]
+                    {
+                        ++g_cost;
+                        g_next = g_run + 255;
+                    }
+                    ++g_cost;
+                    if (dp[i] <= g_cost)
+                    {
+                        g_cost = dp[i];
+                        g_run = 0;
+                        g_next = lit_lim;
+                    }
+                }
+                const uint32_t lmax = i < blen ? max_len[i] : 0;
+                if (lmax >= min_match_len)
+                {
+                    const uint64_t c = g_cost + 4;
+                    const uint32_t top_code = LUT.code_floor[lmax];
+                    for (uint32_t code = 1; code <= top_code; ++code)
+                    {
+                        const uint32_t len = LUT.len_of[code];
+                        const uint64_t q = i + len;
+                        if (c < dp[q])
+                        {
+                            dp[q] = c;
+                            arr[q] = {match_dis[i], len, g_run};
+                        }
+                    }
+                }
+            }
+
+            // Commit at the seam
+            uint64_t commit;
+            uint64_t commit_cost;
+            if (be < src_size)
+            {
+                commit = be - g_run;
+                commit_cost = g_cost - g_run - lit_extras(g_run);
+            }
+            else
+            {
+                // Final block, so minimize cost + terminal literals
+                // Raw suffix obviously doesn't contribute
+                uint64_t best_total = qstar_cost + (src_size - qstar);
+                commit = qstar;
+                commit_cost = qstar_cost;
+                for (uint64_t p = bs; p <= be; ++p)
+                    if (dp[p - bs] != dp_inf and dp[p - bs] + (src_size - p) < best_total)
+                    {
+                        best_total = dp[p - bs] + (src_size - p);
+                        commit = p;
+                        commit_cost = dp[p - bs];
+                    }
+            }
+
+            // backtrack commit, then emit forward...
+            block_tokens.clear();
+            for (uint64_t i = commit; i > qstar;)
+            {
+                const arrival& a = arr[i - bs];
+                const uint64_t next = i - a.len - a.lit_run;
+                if (a.len < min_match_len or (next < bs and next != qstar))
+                    return 0; // sommething went wrong
+                block_tokens.push_back({i - a.len, a.len, a.dis});
+                i = next;
+            }
+            for (uint64_t k = block_tokens.size(); k-- > 0;)
+                emit_token(block_tokens[k].match_start, block_tokens[k].len, block_tokens[k].dis);
+
+            qstar = commit;
+            qstar_cost = commit_cost;
+        }
+
+        // Close the gap between the two streams by moving the literal stream to the left
+        if (drpos < dst_cap)
+        {
+            memmove(dst + dlpos, dst + drpos, dst_cap - drpos);
+            dlpos += dst_cap - drpos;
+        }
+
+        // Just deal with the last few literals (guaranteed to be `>= literal_suffix >=
+        // vector_width` bytes)
+        uint64_t literal_suffix_cnt = src_size - lit;
+        storeu8(dst + literal_suffix_pos, literal_suffix_cnt);
+        memcpy(dst + dlpos, src + lit, literal_suffix_cnt);
+        dlpos += literal_suffix_cnt;
+
+        bool cond = float(long_matches) < cond_flag_thresh * float(tokens);
+        uint64_t flags = (uint64_t(1) << format_bit) | (uint64_t(cond) << cond_bit);
+        storeu8(dst, src_size | (flags << 56));
+
+        return dlpos;
+    }
+} // namespace misa77

--- a/lz/misa77/src/compressor_zoo/loose_compress_impl.h
+++ b/lz/misa77/src/compressor_zoo/loose_compress_impl.h
@@ -1,0 +1,297 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "format.h"
+#include "misa77/misa77.h"
+#include "util.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace misa77
+{
+    namespace loose_detail
+    {
+        using namespace light;
+
+        constexpr uint32_t hash_top = 16;
+        constexpr uint32_t hash_siz = 1 << hash_top;
+        constexpr uint32_t hash_mul = 2654435761;
+
+        // Size of ring buffer per hash in the hashtable.
+        inline constexpr uint64_t hashtab_wid = 16;
+
+        // Hash 4 bytes to an integer in `[0, 1 << (hash_top))`.
+        [[gnu::always_inline]]
+        inline uint32_t hash4(const uint32_t val)
+        {
+            return (val * hash_mul) >> (32 - hash_top);
+        }
+
+        // Assuming that rem contains top 3 bits of the token, emits bytes specifying `n`.
+        [[gnu::always_inline]]
+        inline void emit_length_extras(uint8_t* dst, uint64_t& dlpos, uint64_t n, uint8_t rem)
+        {
+            if (rem != uint8_t(7)) [[likely]]
+                return;
+
+            // Write this unconditionally first, if it's wrong we'll just overwrite
+            dst[dlpos] = static_cast<uint8_t>(n);
+
+            constexpr uint64_t block = 255;
+            if (n >= block) [[unlikely]]
+            {
+                while (n >= block) [[unlikely]]
+                    dst[dlpos] = block, ++dlpos, n -= block;
+                dst[dlpos] = static_cast<uint8_t>(n);
+            }
+
+            ++dlpos;
+        }
+
+        // Preferable lowerbound for match length (derived from the YOLO vector for now)
+        constexpr uint64_t accept_len = 7;
+        static_assert(accept_len >= min_match_len);
+
+        // We ideally want to keep literal length `<= fire_at`
+        constexpr uint64_t fire_at = 6;
+
+        // When you've gone `p` hashtab searches without a match, advance the pointer by `p >>
+        // skip_shift`
+        constexpr uint64_t skip_shift = 6;
+
+        // Regime counter: an adaptive value in `[0, regime_cap]`
+        // Runs with literal length in `[7, 32]` have a vote of `+2`, others `-1`
+        inline constexpr int64_t regime_cap = 64;
+        inline constexpr int64_t regime_threshold = 32;
+
+    } // namespace loose_detail
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // `isa_lib` is ISA-dependent.
+    template <class isa_lib>
+    uint64_t loose_compress_impl(const uint8_t* __restrict src,
+                                 uint64_t src_size,
+                                 uint8_t* __restrict dst,
+                                 uint64_t dst_cap)
+    {
+        using namespace light;
+        using namespace loose_detail;
+
+        static_assert(max_match_len >= 32);
+
+        if (compress_bound(src_size, config()) > dst_cap)
+            return 0;
+
+        // Left pointer in the destination buffer (metadata and control bytes)
+        uint64_t dlpos = 0;
+
+        // Right pointer in the destination buffer (literal bytes)
+        // We've written to `[drpos, dst_cap)` at any given point of time
+        uint64_t drpos = dst_cap;
+
+        storeu8(dst, src_size);
+        dlpos += 8;
+
+        // Small source
+        if (src_size <= small_lim)
+        {
+            if (src_size != 0)
+                memcpy(dst + dlpos, src, src_size);
+            dlpos += src_size;
+            return dlpos;
+        }
+
+        uint64_t literal_suffix_pos = dlpos;
+        dlpos += 8;
+
+        // Ensure that the last `literal_suffix` bytes will be literals
+        uint64_t match_end_limit = (src_size < literal_suffix ? 0 : src_size - literal_suffix);
+
+        // Beginning of the pending literal window
+        uint64_t lit = 0;
+
+        // `[lit, pos]` corresponds to the new range from the src buffer we're going to be
+        // turning into a lit + match pair
+        uint64_t pos = 0;
+
+        // `[0, hpos)` represents the range we've written into the hashtable
+        uint64_t hpos = 0;
+
+        uint64_t miss_run = 0;
+
+        std::vector<std::array<uint16_t, hashtab_wid>> hashtab(hash_siz);
+        std::vector<uint8_t> hashtab_idx(hash_siz);
+
+        // Last remembered match
+        uint64_t cand_pos = 0, cand_len = 0, cand_lst = 0;
+
+        // Adaptive variable that reflects values of lit_len we've been getting for recent blocks
+        int64_t regime = 0;
+
+        while (pos + max_match_len <= match_end_limit)
+        {
+            // Reduce branch misses, `batch = 8` performs well empirically
+            constexpr uint64_t batch = 8;
+            while (pos >= hpos + hashtab_lag + batch) [[unlikely]]
+            {
+#pragma GCC unroll batch
+                for (uint64_t i = 0; i < batch; i++)
+                {
+                    uint32_t hsh = hash4(loadu4(src + hpos + i));
+                    hashtab[hsh][hashtab_idx[hsh]] =
+                        uint16_t(hpos + i); // We just store the lowest 2 bytes
+                    hashtab_idx[hsh] =
+                        (hashtab_idx[hsh] == hashtab_wid - 1
+                             ? uint8_t(0)
+                             : hashtab_idx[hsh] + 1); // Just cycle the pointer in the ring buffer
+                }
+                hpos += batch;
+            }
+
+            uint32_t val = loadu4(src + pos);
+            uint32_t hsh = hash4(val);
+
+            uint64_t lst = 0;
+            uint64_t match_len = 0;
+
+            typename isa_lib::vec reg = isa_lib::loadvec(src + pos);
+
+            if (pos > hashtab_lag) [[likely]]
+            {
+// MLP
+#pragma GCC unroll hashtab_wid
+                for (uint8_t i = 0; i < hashtab_wid; i++)
+                {
+                    uint16_t d = uint16_t(pos - hashtab[hsh][i] - hashtab_lag - 1);
+
+                    // Guaranteed to lie within `[pos - 2^16 - hashtab_lag, pos - hashtab_lag)`
+                    uint64_t ilst = (pos - max_match_len - 1 - d);
+                    typename isa_lib::vec ireg = isa_lib::loadvec(src + ilst);
+                    uint32_t imatch_len = isa_lib::lcp(reg, ireg);
+                    lst = (imatch_len > match_len ? ilst : lst);
+                    match_len = (imatch_len > match_len ? imatch_len : match_len);
+                }
+            }
+
+            // We've inserted stuff into the hashtable assuming this value of `pos`, so we cannot
+            // probe the hashtable for any starting position behind this one going forward. This is
+            // important as `pos` is regressed ahead.
+            uint64_t pos_safe_bound = pos;
+
+            bool accept = (match_len >= accept_len);
+
+            uint64_t pend = pos - lit;
+            bool fire = (regime >= regime_threshold ? pend >= fire_at : pend == fire_at);
+
+            // We don't have an ideal match
+            if (!accept)
+            {
+                if (fire)
+                {
+                    // Prefer the one ending later between this position and the last remembered one
+                    if (cand_len != 0 and
+                        (match_len < min_match_len or cand_pos + cand_len >= pos + match_len))
+                    {
+                        pos = cand_pos;
+                        lst = cand_lst;
+                        match_len = cand_len;
+                    }
+
+                    // Note that if `accept` becomes false here, pos isn't pushed back by the above
+                    // branch
+                    accept = (match_len >= min_match_len);
+                }
+                else if (match_len >= min_match_len and
+                         (cand_len == 0 or pos + match_len >= cand_pos + cand_len))
+                {
+                    // This position becomes the new candidate
+                    cand_pos = pos;
+                    cand_len = match_len;
+                    cand_lst = lst;
+                }
+            }
+
+            if (accept)
+            {
+                // Extend the match backwards (note that `dis` in `(hashtab_lag, 2^16 +
+                // hashtab_lag]` holds).
+                // Extending `pos` backwards here is safe because we're not looking into the
+                // hashtable.
+                while (pos > lit and lst > 0 and match_len < max_match_len and
+                       src[pos - 1] == src[lst - 1])
+                {
+                    --pos;
+                    --lst;
+                    ++match_len;
+                }
+
+                uint64_t norm_match_len = match_len - min_match_len + 1;
+
+                // `src[lit, pos)` are the literals
+                uint64_t lit_len = pos - lit;
+
+                // regime vote
+                regime += (7 <= lit_len and lit_len <= 32 ? 2 : -1);
+                regime = std::clamp<int64_t>(regime, 0, regime_cap);
+
+                // Token Byte
+                uint8_t lrem = std::min(uint64_t(7), lit_len);
+                dst[dlpos] = static_cast<uint8_t>((lrem << 5) | (norm_match_len));
+                lit_len -= lrem;
+                ++dlpos;
+
+                // 2 Distance bytes
+                uint64_t dis = pos - lst;
+                uint16_t dbytes = dis - hashtab_lag - 1;
+                storeu2(dst + dlpos, dbytes);
+                dlpos += 2;
+
+                // Extra literal length bytes
+                emit_length_extras(dst, dlpos, lit_len, lrem);
+
+                // Literal bytes
+                if (lit < pos)
+                {
+                    uint64_t lit_cnt = pos - lit;
+                    drpos -= lit_cnt;
+                    memcpy(dst + drpos, src + lit, lit_cnt);
+                }
+
+                pos += match_len;
+                lit = pos;
+                pos = std::max(pos, pos_safe_bound);
+                cand_len = 0;
+                miss_run = 0;
+            }
+            else
+            {
+                pos += 1 + (miss_run >> skip_shift);
+                ++miss_run;
+            }
+        }
+
+        // Close the gap between the two streams by moving the literal stream to the left
+        if (drpos < dst_cap)
+        {
+            memmove(dst + dlpos, dst + drpos, dst_cap - drpos);
+            dlpos += dst_cap - drpos;
+        }
+
+        // Just deal with the last few literals (guaranteed to be `>= literal_suffix >=
+        // vector_width` bytes)
+        uint64_t literal_suffix_cnt = src_size - lit;
+        storeu8(dst + literal_suffix_pos, literal_suffix_cnt);
+        memcpy(dst + dlpos, src + lit, literal_suffix_cnt);
+        dlpos += literal_suffix_cnt;
+
+        return dlpos;
+    }
+
+} // namespace misa77

--- a/lz/misa77/src/decompress.cpp
+++ b/lz/misa77/src/decompress.cpp
@@ -1,0 +1,63 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#include "decompress_dispatch.h"
+#include "format.h"
+#include "misa77/misa77.h"
+#include "util.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    // sanity check
+    static_assert(vector_width == 32);
+    static_assert(light::hashtab_lag >= vector_width);
+    static_assert(vector_width >= light::max_match_len);
+    static_assert(light::literal_suffix >= light::dec_literal_copy);
+
+    // Returns the exact size (in bytes) of the file that the given compressed file will be
+    // decompressed to.
+    // Only call this on buffers that were compressed in the misa77 format, as it
+    // requires the size of the buffer to be >= 8.
+    uint64_t decompressed_size(const uint8_t* src)
+    {
+        return loadu8(src) & 0x00FF'FFFF'FFFF'FFFF;
+    }
+
+    // Minimum size of buffer required to decompress a compressed file that corresponds to an
+    // original file of `src_size` bytes.
+    // Usage: decompressed_buffer_bound(decompressed_size(src))
+    uint64_t decompressed_buffer_bound(uint64_t src_size)
+    {
+        return src_size;
+    }
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // Resolves the best decode path once per call, depending on the ISA.
+    // PRECONDITION: `src` and `src_size` must correspond to a valid misa77 stream.
+    // `decompress` does not validate input, and malformed/malicious data can lead to UB or worse.
+    uint64_t decompress(const uint8_t* __restrict src,
+                        uint64_t src_size,
+                        uint8_t* __restrict dst,
+                        uint64_t dst_cap,
+                        dconfig dcfg)
+    {
+        // no valid stream is shorter than 8 bytes (smallest is an empty file's bare header).
+        if (src_size < 8)
+            return 0;
+
+#if defined(__x86_64__)
+        if (__builtin_cpu_supports("avx2"))
+            return decompress_avx2(src, src_size, dst, dst_cap, dcfg);
+        return decompress_sse2(src, src_size, dst, dst_cap, dcfg);
+#elif defined(__aarch64__)
+        // NEON is guaranteed on Aarch64
+        return decompress_neon(src, src_size, dst, dst_cap, dcfg);
+#else
+        return decompress_portable(src, src_size, dst, dst_cap, dcfg);
+#endif
+    }
+
+} // namespace misa77

--- a/lz/misa77/src/decompress_dispatch.h
+++ b/lz/misa77/src/decompress_dispatch.h
@@ -1,0 +1,37 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "misa77/misa77.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    // ISA-specialized decompress entry points. Each is defined in a per-target TU in src/isa/,
+    // compiled with that ISA's flags (target_avx2.cpp with -mavx2, target_sse2.cpp /
+    // target_portable.cpp at baseline, target_neon.cpp at armv8-a), and selected at runtime
+    // by decompress() (see decompress.cpp).
+    uint64_t decompress_avx2(const uint8_t* __restrict src,
+                             uint64_t src_size,
+                             uint8_t* __restrict dst,
+                             uint64_t dst_cap,
+                             dconfig dcfg);
+    uint64_t decompress_sse2(const uint8_t* __restrict src,
+                             uint64_t src_size,
+                             uint8_t* __restrict dst,
+                             uint64_t dst_cap,
+                             dconfig dcfg);
+    uint64_t decompress_neon(const uint8_t* __restrict src,
+                             uint64_t src_size,
+                             uint8_t* __restrict dst,
+                             uint64_t dst_cap,
+                             dconfig dcfg);
+    uint64_t decompress_portable(const uint8_t* __restrict src,
+                                 uint64_t src_size,
+                                 uint8_t* __restrict dst,
+                                 uint64_t dst_cap,
+                                 dconfig dcfg);
+} // namespace misa77

--- a/lz/misa77/src/decompressor_zoo/heavy_safe_decompress_impl.h
+++ b/lz/misa77/src/decompressor_zoo/heavy_safe_decompress_impl.h
@@ -1,0 +1,30 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "format.h"
+#include "misa77/misa77.h"
+#include "util.h"
+
+#include <cstdint>
+#include <cstring>
+
+namespace misa77
+{
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // `isa_lib` is ISA-dependent.
+    template <class isa_lib>
+    uint64_t heavy_safe_decompress_impl(const uint8_t* __restrict src,
+                                        uint64_t src_size,
+                                        uint8_t* __restrict dst,
+                                        uint64_t dst_cap)
+    {
+        using namespace heavy;
+        // support will be added in the future
+        // for now, you must use the unsafe decompressor for the heavy mode
+        (void)src, (void)src_size, (void)dst, (void)dst_cap;
+        return 0;
+    }
+} // namespace misa77

--- a/lz/misa77/src/decompressor_zoo/heavy_unsafe_decompress_impl.h
+++ b/lz/misa77/src/decompressor_zoo/heavy_unsafe_decompress_impl.h
@@ -1,0 +1,140 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "format.h"
+#include "misa77/misa77.h"
+#include "util.h"
+
+#include <cstdint>
+#include <cstring>
+
+namespace misa77
+{
+    template <bool cond, class isa_lib>
+    uint64_t heavy_unsafe_decompress_inner(const uint8_t* __restrict src,
+                                           uint64_t src_size,
+                                           uint8_t* __restrict dst,
+                                           uint64_t dst_cap)
+    {
+        using namespace heavy;
+
+        const uint64_t original_size = decompressed_size(src);
+
+        if (dst_cap < original_size or src_size < 8)
+            return 0;
+
+        bool check = ((1 << format_bit) & src[7]);
+        if (!check)
+            return 0;
+
+        // Small source
+        if (original_size <= small_lim)
+        {
+            if (original_size > 0)
+                memcpy(dst, src + uint64_t(8), original_size);
+            return original_size;
+        }
+
+        const uint64_t literal_suffix_cnt = loadu8(src + 8);
+        const uint8_t* control = src + 16;
+        const uint8_t* literals = src + src_size - literal_suffix_cnt;
+        uint8_t* out = dst;
+
+        uint32_t token = loadu4(control);
+        while (control < literals)
+        {
+            uint64_t lit_len = token >> 26;
+            uint64_t match_len = LUT.len_of[(token >> 20) & 63];
+            uint64_t dis = (token & dis_mask) + min_dis;
+            control += 4;
+
+            // should almost never be taken with the heavy format :)
+            if (lit_len == lit_lim) [[unlikely]]
+            {
+                uint64_t pot_add = *control;
+                lit_len += pot_add;
+                ++control;
+                if (pot_add == 255) [[unlikely]]
+                {
+                    while (*control == 255) [[unlikely]]
+                        lit_len += 255, ++control;
+                    lit_len += *control, ++control;
+                }
+            }
+
+            literals -= lit_len;
+            if (lit_len > dec_literal_copy) [[unlikely]]
+            {
+                isa_lib::copy32(out, literals);
+                if (lit_len > vector_width) [[unlikely]]
+                    memcpy(out + vector_width, literals + vector_width, lit_len - vector_width);
+            }
+            else
+            {
+                // Unconditional copy, safe because we have `dec_literal_copy` bytes of
+                // breathing room at the end in src and dst due to `literal_suffix`
+                memcpy(out, literals, dec_literal_copy);
+            }
+            out += lit_len;
+
+            // load this early
+            token = loadu4(control);
+
+            uint8_t* match_at = out - dis;
+
+            isa_lib::cyccpy(match_at, dis);
+            if constexpr (cond)
+            {
+                if (match_len > vector_width) [[unlikely]] // ummmm
+                {
+                    isa_lib::cyccpy(match_at + vector_width, dis);
+                    if (match_len > vector_width + vector_width) [[unlikely]]
+                        for (uint64_t off = 64; off < match_len; off += 32)
+                            isa_lib::cyccpy(match_at + off, dis);
+                }
+            }
+            else
+            {
+                isa_lib::cyccpy(match_at + vector_width, dis);
+                if (match_len > vector_width + vector_width) [[unlikely]]
+                    for (uint64_t off = 64; off < match_len; off += 32)
+                        isa_lib::cyccpy(match_at + off, dis);
+            }
+            out += match_len;
+        }
+
+        if (uint64_t(out - dst) != original_size - literal_suffix_cnt)
+            return 0;
+        memcpy(out, src + src_size - literal_suffix_cnt, literal_suffix_cnt);
+        return original_size;
+    }
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // `isa_lib` is ISA-dependent.
+    template <class isa_lib>
+    uint64_t heavy_unsafe_decompress_impl(const uint8_t* __restrict src,
+                                          uint64_t src_size,
+                                          uint8_t* __restrict dst,
+                                          uint64_t dst_cap)
+    {
+        using namespace heavy;
+
+        const uint64_t original_size = decompressed_size(src);
+
+        if (dst_cap < original_size or src_size < 8)
+            return 0;
+
+        bool check = ((1 << format_bit) & src[7]);
+        if (!check)
+            return 0;
+
+        const bool check2 = ((1 << cond_bit) & src[7]);
+
+        if (check2)
+            return heavy_unsafe_decompress_inner<true, isa_lib>(src, src_size, dst, dst_cap);
+        return heavy_unsafe_decompress_inner<false, isa_lib>(src, src_size, dst, dst_cap);
+    }
+} // namespace misa77

--- a/lz/misa77/src/decompressor_zoo/safe_decompress_impl.h
+++ b/lz/misa77/src/decompressor_zoo/safe_decompress_impl.h
@@ -1,0 +1,228 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "format.h"
+#include "util.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+
+namespace misa77
+{
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // `isa_lib` is ISA-dependent.
+    template <class isa_lib>
+    uint64_t safe_decompress_impl(const uint8_t* __restrict src,
+                                  uint64_t src_size,
+                                  uint8_t* __restrict dst,
+                                  uint64_t dst_cap)
+    {
+        using namespace light;
+
+        // Header fields must exist
+        if (src_size < 8) [[unlikely]]
+            return 0;
+
+        const uint64_t original_size = loadu8(src);
+
+        if (dst_cap < original_size)
+            return 0;
+
+        // Small source
+        if (original_size <= small_lim)
+        {
+            // Must not over-read here
+            if (src_size < 8 + original_size) [[unlikely]]
+                return 0;
+            if (original_size > 0)
+                memcpy(dst, src + uint64_t(8), original_size);
+            return original_size;
+        }
+
+        // Extra headers for non-small source
+        if (src_size < 16) [[unlikely]]
+            return 0;
+
+        const uint64_t literal_suffix_cnt = loadu8(src + 8);
+
+        // The raw suffix must fit in both buffers (for our unconditional over-reads and writes to
+        // be safe), and must be >= literal_suffix
+        if (literal_suffix_cnt < literal_suffix or literal_suffix_cnt > src_size - 16 or
+            literal_suffix_cnt > original_size) [[unlikely]]
+            return 0;
+
+        const uint8_t* control = src + 16;
+        const uint8_t* literals = src + src_size - literal_suffix_cnt;
+        uint8_t* out = dst;
+
+        // The loop may produce at most this much output (we put the raw suffix after this)
+        const uint64_t loop_limit = original_size - literal_suffix_cnt;
+        uint8_t* const out_limit = dst + loop_limit;
+
+        constexpr uint64_t dis_ceil = dis_lim + hashtab_lag; // max representable dis
+
+        uint8_t* const prefix_end = dst + std::min(dis_ceil, loop_limit);
+
+        // Fully guarded step for an initial small prefix (match distance is dangerous here), and
+        // the tail
+        auto guarded_step = [&]() -> bool
+        {
+            uint8_t token = control[0];
+            uint64_t lit_len = token >> 5;
+            uint64_t match_len = (token & uint8_t(0x1F)) + min_match_len - 1;
+
+            uint16_t dis_small = loadu2(control + 1);
+            uint32_t dis = dis_small + hashtab_lag + 1;
+
+            control += 3;
+
+            if (lit_len == 7) [[unlikely]]
+            {
+                uint64_t pot_add = *control;
+                lit_len += pot_add;
+                ++control;
+
+                constexpr uint64_t block = 255;
+                if (pot_add == block) [[unlikely]]
+                {
+                    // Bounded, shouldn't just keep reading ahead as it finds 255s
+                    while (*control == block) [[unlikely]]
+                    {
+                        lit_len += block, ++control;
+                        if (control >= literals) [[unlikely]]
+                            return false;
+                    }
+                    lit_len += *control, ++control;
+                }
+            }
+
+            // no src underflow.
+            if (lit_len > uint64_t(literals - src)) [[unlikely]]
+                return false;
+
+            // bound this token's dst writes
+            if (uint64_t(out - dst) + lit_len + min_match_len > loop_limit) [[unlikely]]
+                return false;
+
+            literals -= lit_len;
+            if (lit_len > dec_literal_copy) [[unlikely]]
+            {
+                isa_lib::copy32(out, literals);
+
+                if (lit_len > vector_width) [[unlikely]]
+                {
+                    memcpy(out + vector_width, literals + vector_width, lit_len - vector_width);
+                }
+            }
+            else
+            {
+                memcpy(out, literals, dec_literal_copy);
+            }
+            out += lit_len;
+
+            // match source must not start before dst[0].
+            if (dis > uint64_t(out - dst)) [[unlikely]]
+                return false;
+
+            isa_lib::cyccpy(out - dis, dis);
+            out += match_len;
+            return true;
+        };
+
+        // Prefix: first dis_ceil output bytes.
+        while (control < literals and out < prefix_end)
+            if (!guarded_step()) [[unlikely]]
+                return 0;
+
+        // The fast loop below must never begin a token within red_slack bytes of
+        // out_limit.
+        constexpr uint64_t red_slack = 8;
+
+        // A non-extras token has lit_len <= 6 and starts at out <= out_limit - red_slack
+        // cyccpy write must stay inside the suffix slack past out_limit
+        static_assert(6 + vector_width - (red_slack + 1) <= literal_suffix);
+        // a match code 31 must not advance `out` past one-past-the-end of a dst buffer
+        static_assert(6 + (31 + min_match_len - 1) - (red_slack + 1) <= literal_suffix);
+
+        uint8_t* const red = dst + (loop_limit > red_slack ? loop_limit - red_slack : uint64_t(0));
+
+        // Fast main loop: no per-token guards outside the extras branch.
+        while (control < literals and out < red)
+        {
+            uint8_t token = control[0];
+            uint64_t lit_len = token >> 5;
+            uint64_t match_len = (token & uint8_t(0x1F)) + min_match_len - 1;
+
+            uint16_t dis_small = loadu2(control + 1);
+            uint32_t dis = dis_small + hashtab_lag + 1;
+
+            control += 3;
+
+            if (lit_len == 7) [[unlikely]]
+            {
+                uint64_t pot_add = *control;
+                lit_len += pot_add;
+                ++control;
+
+                constexpr uint64_t block = 255;
+                if (pot_add == block) [[unlikely]]
+                {
+                    // Bounded, shouldn't just keep reading ahead as it finds 255s
+                    while (*control == block) [[unlikely]]
+                    {
+                        lit_len += block, ++control;
+                        if (control >= literals) [[unlikely]]
+                            return 0;
+                    }
+                    lit_len += *control, ++control;
+                }
+
+                if (lit_len > uint64_t(literals - src)) [[unlikely]]
+                    return 0;
+#if defined(__clang__)
+                // Equivalent to the check below, rewritten in terms of `red`
+                if (lit_len - (red_slack - min_match_len) > uint64_t(red - out)) [[unlikely]]
+                    return 0;
+#else
+                if (lit_len + min_match_len > uint64_t(out_limit - out)) [[unlikely]]
+                    return 0;
+#endif
+            }
+
+            literals -= lit_len;
+            if (lit_len > dec_literal_copy) [[unlikely]]
+            {
+                isa_lib::copy32(out, literals);
+
+                if (lit_len > vector_width) [[unlikely]]
+                {
+                    memcpy(out + vector_width, literals + vector_width, lit_len - vector_width);
+                }
+            }
+            else
+            {
+                memcpy(out, literals, dec_literal_copy);
+            }
+            out += lit_len;
+
+            isa_lib::cyccpy(out - dis, dis);
+            out += match_len;
+        }
+
+        // The last few tokens
+        while (control < literals)
+            if (!guarded_step()) [[unlikely]]
+                return 0;
+
+        if (out != out_limit)
+            return 0;
+
+        // Literal suffix at the end
+        memcpy(out, src + src_size - literal_suffix_cnt, literal_suffix_cnt);
+        return loop_limit + literal_suffix_cnt;
+    }
+} // namespace misa77

--- a/lz/misa77/src/decompressor_zoo/unsafe_decompress_impl.h
+++ b/lz/misa77/src/decompressor_zoo/unsafe_decompress_impl.h
@@ -1,0 +1,106 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "format.h"
+#include "misa77/misa77.h"
+#include "util.h"
+
+#include <cstdint>
+#include <cstring>
+
+namespace misa77
+{
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // `isa_lib` is ISA-dependent.
+    template <class isa_lib>
+    uint64_t unsafe_decompress_impl(const uint8_t* __restrict src,
+                                    uint64_t src_size,
+                                    uint8_t* __restrict dst,
+                                    uint64_t dst_cap)
+    {
+        using namespace light;
+
+        const uint64_t original_size = loadu8(src);
+
+        if (dst_cap < original_size)
+            return 0;
+
+        // Small source
+        if (original_size <= small_lim)
+        {
+            if (original_size > 0)
+                memcpy(dst, src + uint64_t(8), original_size);
+            return original_size;
+        }
+
+        const uint64_t literal_suffix_cnt = loadu8(src + 8);
+        const uint8_t* control = src + 16;
+        const uint8_t* literals = src + src_size - literal_suffix_cnt;
+        uint8_t* out = dst;
+
+        // Token loop with safe overwrites in the destination buffer and safe overreads from source.
+        while (control < literals)
+        {
+            // Overread is safe here
+            uint8_t token = control[0];
+            uint64_t lit_len = token >> 5;
+            uint64_t match_len = (token & uint8_t(0x1F)) + min_match_len - 1;
+
+            uint16_t dis_small = loadu2(control + 1);
+            uint32_t dis = dis_small + hashtab_lag + 1;
+
+            control += 3;
+
+            if (lit_len == 7) [[unlikely]]
+            {
+                uint64_t pot_add = *control;
+                lit_len += pot_add;
+                ++control;
+
+                constexpr uint64_t block = 255;
+                if (pot_add == block) [[unlikely]]
+                {
+                    while (*control == block) [[unlikely]]
+                        lit_len += block, ++control;
+                    lit_len += *control, ++control;
+                }
+            }
+
+            literals -= lit_len;
+            if (lit_len > dec_literal_copy) [[unlikely]]
+            {
+                isa_lib::copy32(out, literals);
+
+                if (lit_len > vector_width) [[unlikely]]
+                {
+                    memcpy(out + vector_width, literals + vector_width, lit_len - vector_width);
+                }
+            }
+            else
+            {
+                // Unconditional copy, safe because we have `dec_literal_copy` bytes of
+                // breathing room at the end in src and dst due to `literal_suffix`
+                memcpy(out, literals, dec_literal_copy);
+            }
+            out += lit_len;
+
+            // When we enter cyccpy, we're guaranteed to have `literal_suffix` >= vector_width
+            // bytes of breathing room in the destination buffer as the last `literal_suffix`
+            // bytes are literals
+            isa_lib::cyccpy(out - dis, dis);
+            out += match_len;
+        }
+
+        if (uint64_t(out - dst) != original_size - literal_suffix_cnt)
+            return 0;
+
+        // Literal suffix at the end
+        memcpy(out, src + src_size - literal_suffix_cnt, literal_suffix_cnt);
+        out += literal_suffix_cnt;
+
+        return uint64_t(out - dst);
+    }
+} // namespace misa77

--- a/lz/misa77/src/format.h
+++ b/lz/misa77/src/format.h
@@ -1,0 +1,156 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include <cstdint>
+
+namespace misa77
+{
+    // (bit at this pos = 0) => light format, otherwise heavy
+    inline constexpr uint8_t format_bit = 0;
+
+    // Width in bytes of several unconditional operations we perform through isa libs in both
+    // formats.
+    inline constexpr uint64_t vector_width = 32;
+
+    // light format, used by levels in [0, config::heavy_lb)
+    namespace light
+    {
+        // (`raw file size <= small_lim`) => small mode, we just write the raw bytes.
+        inline constexpr uint32_t small_lim = 32;
+
+        // When we find a match, we check `lookahead` positions ahead for a potentially better
+        // match.
+        inline constexpr uint64_t lookahead = 2;
+
+        // The distance in bytes by which the start of the active hashtable window lags the pointer.
+        // Don't set this too high, as there were a lot of matches for dis in [32, 512].
+        inline constexpr uint64_t hashtab_lag = 32;
+        static_assert(hashtab_lag >= vector_width);
+
+        // If we're asked to copy a match after having processed `c` bytes of raw data, then the
+        // match will begin in `[c - dis_lim - hashtab_lag, c - hashtab_lag)`.
+        inline constexpr uint64_t dis_lim = (uint32_t(1) << 16);
+
+        // We have exactly 2 bytes to indicate distance.
+        static_assert(dis_lim <= (1 << 16));
+
+        inline constexpr uint32_t min_match_len = 4;
+
+        // `min_match_len >= 4` is needed for the compression bound to hold.
+        static_assert(min_match_len >= 4);
+
+        inline constexpr uint32_t max_match_len = 32;
+
+        // One `cyccpy` call should deal with the entire match.
+        static_assert(max_match_len <= vector_width);
+
+        // Lowerbound for the number of literals in the final raw suffix.
+        // This MUST be >= `vector_width` because:
+        // 1. During decompression, `cyccpy` performs unconditional writes in the destination
+        // buffer, and we're using this suffix as padding that we can safely overwrite!!!
+        // 2. During decompression, we perform unconditional reads from the source buffer, and this
+        // literal suffix acts as padding that we can safely "over-read" into!!!
+        inline constexpr uint32_t literal_suffix = 32;
+        static_assert(literal_suffix >= vector_width);
+
+        // Need enough source bytes to be able to guarantee that we can produce the appropriate raw
+        // literal suffix.
+        static_assert(literal_suffix <= small_lim + 1);
+
+        // Unconditionally copied number of literal bytes in decompressor.
+        inline constexpr uint64_t dec_literal_copy = 16;
+        static_assert(literal_suffix >= dec_literal_copy);
+    } // namespace light
+
+    // heavy format, used by levels in [config::heavy_lb, config::max_level]
+    namespace heavy
+    {
+        // a lot of things ahead have an analogue in the light format
+
+        inline constexpr uint32_t small_lim = 64;
+
+        // lut_t.len_of[64] contains a (match code) -> (match len) mapping that is clustered close
+        // for smaller values of match code/len, and gets increasingly diffuse as match code
+        // increases. The tables inside are constexpr evaluated.
+        struct lut_t
+        {
+            uint8_t len_of[64];      // code -> (length (0 for code 0))
+            uint8_t code_floor[256]; // length -> (code of largest codebook length <= it)
+            uint8_t len_floor[256];  // length -> (that codebook length itself)
+
+            // constexpr black magic thanks to Fable
+            constexpr lut_t() : len_of(), code_floor(), len_floor()
+            {
+                auto len_at = [](uint32_t c) -> uint32_t
+                {
+                    return c == 0    ? 0
+                           : c <= 29 ? c + 3
+                           : c <= 45 ? 34 + 2 * (c - 30)
+                           : c <= 61 ? 68 + 4 * (c - 46)
+                           : c == 62 ? 160
+                           : c == 63 ? 192
+                                     : 0;
+                };
+                for (uint32_t c = 0; c < 64; ++c)
+                    len_of[c] = uint8_t(len_at(c));
+
+                // Build floor tables: for every length l in [0,255], the largest codebook
+                // length <= l and its code (0 for l < 4).
+                uint32_t cur_code = 0;
+                uint32_t cur_len = 0;
+                uint32_t c = 1;
+                for (uint32_t l = 0; l < 256; ++l)
+                {
+                    while (c < 64 and len_at(c) <= l)
+                    {
+                        cur_code = c;
+                        cur_len = len_at(c);
+                        ++c;
+                    }
+                    code_floor[l] = uint8_t(cur_code);
+                    len_floor[l] = uint8_t(cur_len);
+                }
+            }
+        };
+        inline constexpr lut_t LUT;
+
+        inline constexpr uint32_t min_match_len = 4;
+        inline constexpr uint32_t max_match_len = 192;
+        static_assert(LUT.len_of[0] == 0);
+        static_assert(LUT.len_of[1] == min_match_len);
+        static_assert(LUT.len_of[63] == max_match_len);
+
+        inline constexpr uint32_t literal_suffix = 64;
+
+        // 1 MB window
+        inline constexpr uint32_t win_bits = 20;
+        inline constexpr uint64_t ndis = uint64_t(1) << win_bits;
+        inline constexpr uint64_t hashtab_lag = 32;
+        inline constexpr uint32_t min_dis = hashtab_lag + 1;
+        inline constexpr uint32_t max_dis = uint32_t(min_dis + ndis - 1);
+
+        inline constexpr uint64_t dec_literal_copy = 16;
+        inline constexpr uint64_t lit_lim = 63;
+        inline constexpr uint64_t dis_mask = (uint32_t(1) << win_bits) - 1;
+
+        // The decoder's `cyccpy` chunks require `dis >= vector_width` to be alias-free
+        static_assert(min_dis > vector_width);
+
+        // `lit_lim` goes beyond the 6-bit literal-run field
+        static_assert(lit_lim == (uint64_t(1) << 6) - 1);
+        static_assert(dis_mask == ndis - 1);
+
+        // position of condition bit in the flag byte
+        // this bit indicates whether the decompressor should perform unconditional 64 byte copies
+        // or not
+        inline constexpr uint8_t cond_bit = 1;
+        static_assert(format_bit != cond_bit);
+
+        // here, unconditional decoder does two 32 byte copies, so we must have enough space at the
+        // end
+        static_assert(literal_suffix >= 2 * vector_width);
+    } // namespace heavy
+} // namespace misa77

--- a/lz/misa77/src/isa/lib_avx2.h
+++ b/lz/misa77/src/isa/lib_avx2.h
@@ -1,0 +1,64 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+// AVX2 copy/finder policy (256-bit).
+//
+// CONTRACT: the intrinsics below are AVX2, so this header MUST only be included
+// from a TU compiled with -mavx2.
+
+#include <cstdint>
+#include <immintrin.h>
+
+namespace misa77
+{
+    class lib_avx2
+    {
+    public:
+        // Copies `src[0, vector_width)` to `src[dis, dis + vector_width)`.
+        // It's guaranteed that `dis >= vector_width`, so there's no aliasing.
+        [[gnu::always_inline]]
+        static inline void cyccpy(uint8_t* src, uint64_t dis)
+        {
+            __m256i reg = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
+            _mm256_storeu_si256(reinterpret_cast<__m256i*>(src + dis), reg);
+        }
+
+        // Copies `src[0, vector_width)` to `dst[0, vector_width)`.
+        // It's guaranteed that the two ranges don't alias.
+        [[gnu::always_inline]]
+        static inline void copy32(uint8_t* __restrict dst, const uint8_t* __restrict src)
+        {
+            __m256i reg = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
+            _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst), reg);
+        }
+
+        using vec = __m256i;
+
+        // Return internal representation of `src[0, vector_width)`.
+        [[gnu::always_inline]]
+        static inline vec loadvec(const uint8_t* src)
+        {
+            return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
+        }
+
+        // First differing byte index (0-indexed) between `reg1` and `reg2`.
+        // If there's no such index, return `vector_width`.
+        [[gnu::always_inline]]
+        static inline uint64_t lcp(const vec& reg1, const vec& reg2)
+        {
+            const __m256i eq = _mm256_cmpeq_epi8(reg1, reg2);
+            const uint32_t mask = static_cast<uint32_t>(_mm256_movemask_epi8(eq));
+            const uint32_t diff = ~mask;
+
+// __builtin_ctz(0) is UB, but tzcnt is defined for 0 and conveniently returns 32
+#if defined(__BMI__)
+            return static_cast<uint64_t>(_tzcnt_u32(diff));
+#else
+            return diff ? static_cast<uint64_t>(__builtin_ctz(diff)) : 32;
+#endif
+        }
+    };
+} // namespace misa77

--- a/lz/misa77/src/isa/lib_neon.h
+++ b/lz/misa77/src/isa/lib_neon.h
@@ -1,0 +1,78 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+// ARM NEON (2x128-bit) copy/finder policy.
+//
+// CONTRACT: NEON (AdvSIMD) is guaranteed by the AArch64 ISA, so this header only
+// requires the including TU to be an AArch64 baseline build (-march=armv8-a).
+
+#include "format.h" // vector_width
+
+#include <arm_neon.h>
+#include <cstdint>
+
+namespace misa77
+{
+    class lib_neon
+    {
+    public:
+        // Copies `src[0, vector_width)` to `src[dis, dis + vector_width)`.
+        // It's guaranteed that `dis >= vector_width`, so there's no aliasing.
+        [[gnu::always_inline]]
+        static inline void cyccpy(uint8_t* src, uint64_t dis)
+        {
+            uint8x16_t reg1 = vld1q_u8(src);
+            uint8x16_t reg2 = vld1q_u8(src + vector_width / 2);
+            vst1q_u8(src + dis, reg1);
+            vst1q_u8(src + dis + vector_width / 2, reg2);
+        }
+
+        // Copies `src[0, vector_width)` to `dst[0, vector_width)`.
+        // It's guaranteed that the two ranges don't alias.
+        [[gnu::always_inline]]
+        static inline void copy32(uint8_t* __restrict dst, const uint8_t* __restrict src)
+        {
+            uint8x16_t reg1 = vld1q_u8(src);
+            uint8x16_t reg2 = vld1q_u8(src + vector_width / 2);
+            vst1q_u8(dst, reg1);
+            vst1q_u8(dst + vector_width / 2, reg2);
+        }
+
+        struct vec
+        {
+            uint8x16_t lo, hi;
+        };
+
+        // Return internal representation of `src[0, vector_width)`.
+        [[gnu::always_inline]]
+        static inline vec loadvec(const uint8_t* src)
+        {
+            return vec{vld1q_u8(src), vld1q_u8(src + vector_width / 2)};
+        }
+
+        // First differing byte index (0-indexed) between `reg1` and `reg2`.
+        // If there's no such index, return `vector_width`.
+        [[gnu::always_inline]]
+        static inline uint64_t lcp(const vec& reg1, const vec& reg2)
+        {
+            // thanks to danlark1 on HN: https://news.ycombinator.com/item?id=48925428
+            const uint8x16_t eq0 = vceqq_u8(reg1.lo, reg2.lo);
+            const uint8x16_t eq1 = vceqq_u8(reg1.hi, reg2.hi);
+            const uint64_t mask0 =
+                vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(eq0), 4)), 0);
+            const uint64_t mask1 =
+                vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(eq1), 4)), 0);
+            // __builtin_ctzll(0) is UB, so the all-equal halves must be tested explicitly
+            const uint64_t diff0 = ~mask0;
+            if (diff0)
+                return static_cast<uint64_t>(__builtin_ctzll(diff0)) >> 2;
+            const uint64_t diff1 = ~mask1;
+            if (diff1)
+                return (vector_width / 2) + (static_cast<uint64_t>(__builtin_ctzll(diff1)) >> 2);
+            return vector_width;
+        }
+    };
+} // namespace misa77

--- a/lz/misa77/src/isa/lib_portable.h
+++ b/lz/misa77/src/isa/lib_portable.h
@@ -1,0 +1,69 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+// Portable copy/finder policy.
+//
+// CONTRACT: no ISA requirement, safe to include from any TU.
+
+#include "format.h" // vector_width
+#include "util.h"   // loadu8
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+
+namespace misa77
+{
+    // The compiler should auto-vectorize the `memcpy` calls in here w.r.t. the target architecture,
+    // whenever possible.
+    class lib_portable
+    {
+    public:
+        // Copies `src[0, vector_width)` to `src[dis, dis + vector_width)`
+        // It's guaranteed that `dis >= vector_width`, so there's no aliasing.
+        [[gnu::always_inline]]
+        static inline void cyccpy(uint8_t* src, uint64_t dis)
+        {
+            memcpy(src + dis, src, vector_width);
+        }
+
+        // Copies `src[0, vector_width)` to `dst[0, vector_width)`.
+        // It's guaranteed that the two ranges don't alias.
+        [[gnu::always_inline]]
+        static inline void copy32(uint8_t* __restrict dst, const uint8_t* __restrict src)
+        {
+            memcpy(dst, src, vector_width);
+        }
+
+        // Any internal representation of 32 bytes of contiguous data is fine.
+        using vec = std::array<uint8_t, vector_width>;
+
+        // Return internal representation of `src[0, vector_width)`.
+        [[gnu::always_inline]]
+        static inline vec loadvec(const uint8_t* src)
+        {
+            vec ret;
+            std::memcpy(ret.data(), src, vector_width);
+            return ret;
+        }
+
+        // First differing byte index (0-indexed) between `reg1` and `reg2`.
+        // If there's no such index, return `vector_width`.
+        // Little-endian assumed:
+        // ctz of the XOR points at the lowest differing bit, hence the lowest byte.
+        [[gnu::always_inline]]
+        static inline uint64_t lcp(const vec& reg1, const vec& reg2)
+        {
+            for (uint64_t off = 0; off < vector_width; off += 8)
+            {
+                const uint64_t x = loadu8(reg1.data() + off) ^ loadu8(reg2.data() + off);
+                if (x)
+                    return off + (static_cast<uint64_t>(__builtin_ctzll(x)) >> 3);
+            }
+            return vector_width;
+        }
+    };
+} // namespace misa77

--- a/lz/misa77/src/isa/lib_sse2.h
+++ b/lz/misa77/src/isa/lib_sse2.h
@@ -1,0 +1,77 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+// SSE2 (2x128-bit) copy/finder policy.
+//
+// CONTRACT: SSE2 is guaranteed by the x86-64 ISA, so this header only requires
+// the including TU to be a genuine x86-64 baseline build (-march=x86-64).
+
+#include "format.h" // vector_width
+
+#include <cstdint>
+#include <immintrin.h>
+
+namespace misa77
+{
+    class lib_sse2
+    {
+    public:
+        // Copies `src[0, vector_width)` to `src[dis, dis + vector_width)`.
+        // It's guaranteed that `dis >= vector_width`, so there's no aliasing.
+        [[gnu::always_inline]]
+        static inline void cyccpy(uint8_t* src, uint64_t dis)
+        {
+            __m128i reg1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(src));
+            __m128i reg2 =
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + vector_width / 2));
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(src + dis), reg1);
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(src + dis + vector_width / 2), reg2);
+        }
+
+        // Copies `src[0, vector_width)` to `dst[0, vector_width)`.
+        // It's guaranteed that the two ranges don't alias.
+        [[gnu::always_inline]]
+        static inline void copy32(uint8_t* __restrict dst, const uint8_t* __restrict src)
+        {
+            __m128i reg1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(src));
+            __m128i reg2 =
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + vector_width / 2));
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(dst), reg1);
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(dst + vector_width / 2), reg2);
+        }
+
+        struct vec
+        {
+            __m128i lo, hi;
+        };
+
+        // Return internal representation of `src[0, vector_width)`.
+        [[gnu::always_inline]]
+        static inline vec loadvec(const uint8_t* src)
+        {
+            return vec{_mm_loadu_si128(reinterpret_cast<const __m128i*>(src)),
+                       _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + vector_width / 2))};
+        }
+
+        // First differing byte index (0-indexed) between `reg1` and `reg2`.
+        // If there's no such index, return `vector_width`.
+        [[gnu::always_inline]]
+        static inline uint64_t lcp(const vec& reg1, const vec& reg2)
+        {
+            const __m128i eq0 = _mm_cmpeq_epi8(reg1.lo, reg2.lo);
+            const __m128i eq1 = _mm_cmpeq_epi8(reg1.hi, reg2.hi);
+            const uint32_t mask0 = static_cast<uint32_t>(_mm_movemask_epi8(eq0));
+            const uint32_t mask1 = static_cast<uint32_t>(_mm_movemask_epi8(eq1));
+            const uint32_t diff = ~(mask0 | (mask1 << 16));
+// __builtin_ctz(0) is UB, but tzcnt is defined for 0 and conveniently returns 32
+#if defined(__BMI__)
+            return static_cast<uint64_t>(_tzcnt_u32(diff));
+#else
+            return diff ? static_cast<uint64_t>(__builtin_ctz(diff)) : 32;
+#endif
+        }
+    };
+} // namespace misa77

--- a/lz/misa77/src/isa/target_avx2.cpp
+++ b/lz/misa77/src/isa/target_avx2.cpp
@@ -1,0 +1,58 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+// AVX2 TU.
+// Built only on x86 targets and the implementations herein are chosen at dispatch iff the cpu has
+// AVX2 support.
+
+#include "compress_dispatch.h"
+#include "compressor_zoo/default_compress_impl.h"
+#include "compressor_zoo/heavy_compress_impl.h"
+#include "compressor_zoo/loose_compress_impl.h"
+#include "decompress_dispatch.h"
+#include "decompressor_zoo/heavy_safe_decompress_impl.h"
+#include "decompressor_zoo/heavy_unsafe_decompress_impl.h"
+#include "decompressor_zoo/safe_decompress_impl.h"
+#include "decompressor_zoo/unsafe_decompress_impl.h"
+#include "isa/lib_avx2.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    uint64_t compress_avx2(const uint8_t* __restrict src,
+                           uint64_t src_size,
+                           uint8_t* __restrict dst,
+                           uint64_t dst_cap,
+                           config cfg)
+    {
+        if (cfg.level == 0)
+            return loose_compress_impl<lib_avx2>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 1)
+            return default_compress_impl<lib_avx2>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 2)
+            return heavy_compress_impl<lib_avx2>(src, src_size, dst, dst_cap);
+        return 0;
+    }
+
+    uint64_t decompress_avx2(const uint8_t* __restrict src,
+                             uint64_t src_size,
+                             uint8_t* __restrict dst,
+                             uint64_t dst_cap,
+                             dconfig dcfg)
+    {
+        if ((uint64_t(1) << format_bit) & src[7])
+        {
+            // heavy
+            if (dcfg.safe)
+                return heavy_safe_decompress_impl<lib_avx2>(src, src_size, dst, dst_cap);
+            return heavy_unsafe_decompress_impl<lib_avx2>(src, src_size, dst, dst_cap);
+        }
+
+        // light
+        if (dcfg.safe)
+            return safe_decompress_impl<lib_avx2>(src, src_size, dst, dst_cap);
+        return unsafe_decompress_impl<lib_avx2>(src, src_size, dst, dst_cap);
+    }
+} // namespace misa77

--- a/lz/misa77/src/isa/target_neon.cpp
+++ b/lz/misa77/src/isa/target_neon.cpp
@@ -1,0 +1,56 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+// Baseline for AArch64 (NEON/AdvSIMD support is guaranteed in the ISA).
+
+#include "compress_dispatch.h"
+#include "compressor_zoo/default_compress_impl.h"
+#include "compressor_zoo/heavy_compress_impl.h"
+#include "compressor_zoo/loose_compress_impl.h"
+#include "decompress_dispatch.h"
+#include "decompressor_zoo/heavy_safe_decompress_impl.h"
+#include "decompressor_zoo/heavy_unsafe_decompress_impl.h"
+#include "decompressor_zoo/safe_decompress_impl.h"
+#include "decompressor_zoo/unsafe_decompress_impl.h"
+#include "isa/lib_neon.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    uint64_t compress_neon(const uint8_t* __restrict src,
+                           uint64_t src_size,
+                           uint8_t* __restrict dst,
+                           uint64_t dst_cap,
+                           config cfg)
+    {
+        if (cfg.level == 0)
+            return loose_compress_impl<lib_neon>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 1)
+            return default_compress_impl<lib_neon>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 2)
+            return heavy_compress_impl<lib_neon>(src, src_size, dst, dst_cap);
+        return 0;
+    }
+
+    uint64_t decompress_neon(const uint8_t* __restrict src,
+                             uint64_t src_size,
+                             uint8_t* __restrict dst,
+                             uint64_t dst_cap,
+                             dconfig dcfg)
+    {
+        if ((uint64_t(1) << format_bit) & src[7])
+        {
+            // heavy
+            if (dcfg.safe)
+                return heavy_safe_decompress_impl<lib_neon>(src, src_size, dst, dst_cap);
+            return heavy_unsafe_decompress_impl<lib_neon>(src, src_size, dst, dst_cap);
+        }
+
+        // light
+        if (dcfg.safe)
+            return safe_decompress_impl<lib_neon>(src, src_size, dst, dst_cap);
+        return unsafe_decompress_impl<lib_neon>(src, src_size, dst, dst_cap);
+    }
+} // namespace misa77

--- a/lz/misa77/src/isa/target_portable.cpp
+++ b/lz/misa77/src/isa/target_portable.cpp
@@ -1,0 +1,56 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+// Built on every target.
+
+#include "compress_dispatch.h"
+#include "compressor_zoo/default_compress_impl.h"
+#include "compressor_zoo/heavy_compress_impl.h"
+#include "compressor_zoo/loose_compress_impl.h"
+#include "decompress_dispatch.h"
+#include "decompressor_zoo/heavy_safe_decompress_impl.h"
+#include "decompressor_zoo/heavy_unsafe_decompress_impl.h"
+#include "decompressor_zoo/safe_decompress_impl.h"
+#include "decompressor_zoo/unsafe_decompress_impl.h"
+#include "isa/lib_portable.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    uint64_t compress_portable(const uint8_t* __restrict src,
+                               uint64_t src_size,
+                               uint8_t* __restrict dst,
+                               uint64_t dst_cap,
+                               config cfg)
+    {
+        if (cfg.level == 0)
+            return loose_compress_impl<lib_portable>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 1)
+            return default_compress_impl<lib_portable>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 2)
+            return heavy_compress_impl<lib_portable>(src, src_size, dst, dst_cap);
+        return 0;
+    }
+
+    uint64_t decompress_portable(const uint8_t* __restrict src,
+                                 uint64_t src_size,
+                                 uint8_t* __restrict dst,
+                                 uint64_t dst_cap,
+                                 dconfig dcfg)
+    {
+        if ((uint64_t(1) << format_bit) & src[7])
+        {
+            // heavy
+            if (dcfg.safe)
+                return heavy_safe_decompress_impl<lib_portable>(src, src_size, dst, dst_cap);
+            return heavy_unsafe_decompress_impl<lib_portable>(src, src_size, dst, dst_cap);
+        }
+
+        // light
+        if (dcfg.safe)
+            return safe_decompress_impl<lib_portable>(src, src_size, dst, dst_cap);
+        return unsafe_decompress_impl<lib_portable>(src, src_size, dst, dst_cap);
+    }
+} // namespace misa77

--- a/lz/misa77/src/isa/target_sse2.cpp
+++ b/lz/misa77/src/isa/target_sse2.cpp
@@ -1,0 +1,57 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+// Baseline for x86-64 (SSE2 support is guaranteed in the ISA).
+
+#include "compress_dispatch.h"
+#include "compressor_zoo/default_compress_impl.h"
+#include "compressor_zoo/heavy_compress_impl.h"
+#include "compressor_zoo/loose_compress_impl.h"
+#include "decompress_dispatch.h"
+#include "decompressor_zoo/heavy_safe_decompress_impl.h"
+#include "decompressor_zoo/heavy_unsafe_decompress_impl.h"
+#include "decompressor_zoo/safe_decompress_impl.h"
+#include "decompressor_zoo/unsafe_decompress_impl.h"
+#include "isa/lib_sse2.h"
+
+#include <cstdint>
+
+namespace misa77
+{
+    uint64_t compress_sse2(const uint8_t* __restrict src,
+                           uint64_t src_size,
+                           uint8_t* __restrict dst,
+                           uint64_t dst_cap,
+                           config cfg)
+    {
+        if (cfg.level == 0)
+            return loose_compress_impl<lib_sse2>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 1)
+            return default_compress_impl<lib_sse2>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 2)
+            return heavy_compress_impl<lib_sse2>(src, src_size, dst, dst_cap);
+        return 0;
+    }
+
+    uint64_t decompress_sse2(const uint8_t* __restrict src,
+                             uint64_t src_size,
+                             uint8_t* __restrict dst,
+                             uint64_t dst_cap,
+                             dconfig dcfg)
+    {
+        if ((uint64_t(1) << format_bit) & src[7])
+        {
+            // heavy
+            if (dcfg.safe)
+                return heavy_safe_decompress_impl<lib_sse2>(src, src_size, dst, dst_cap);
+            return heavy_unsafe_decompress_impl<lib_sse2>(src, src_size, dst, dst_cap);
+        }
+
+        // light
+        if (dcfg.safe)
+            return safe_decompress_impl<lib_sse2>(src, src_size, dst, dst_cap);
+        return unsafe_decompress_impl<lib_sse2>(src, src_size, dst, dst_cap);
+    }
+
+} // namespace misa77

--- a/lz/misa77/src/suffix/sais.h
+++ b/lz/misa77/src/suffix/sais.h
@@ -1,0 +1,272 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <type_traits>
+#include <vector>
+
+namespace misa77
+{
+    class sais_chan
+    {
+    public:
+        static constexpr int32_t emp = -1;
+
+        // prefetch offsets
+        static constexpr uint32_t pd = 64; // gather
+        static constexpr uint32_t pd2 = 5; // cursors
+
+        // working memory
+        std::vector<int32_t> s32;       // widened input
+        std::vector<uint32_t> st_pool;  // (symbol << 1 | type)
+        std::vector<uint32_t> cnt_pool; // frequency prefix sums
+        std::vector<uint32_t> lms_pool; // lms indices
+        std::vector<int32_t> nm;        // for naming, (n+1)/2 slots
+        std::vector<uint32_t> bkt;      // bucket cursors, shared across levels
+
+        template <typename T> void sa(const T* s, uint32_t n, int32_t* sa)
+        {
+            static_assert(std::is_integral_v<T>);
+            static_assert(sizeof(T) <= sizeof(uint32_t));
+
+            if (n == 0)
+                return;
+            if (s32.size() < n)
+                s32.resize(n);
+
+            uint32_t mn = *std::min_element(s, s + n);
+            uint32_t mx = *std::max_element(s, s + n);
+            for (uint32_t i = 0; i < n; i++)
+                s32[i] = int32_t(s[i] - mn);
+
+            core(s32.data(), sa, n, mx - mn + 1, 0, 0, 0);
+        }
+
+        // sa + inverse permutation
+        void sa(const uint8_t* s, uint32_t n, int32_t* sa, int32_t* rank)
+        {
+            this->sa(s, n, sa);
+
+            const int32_t* sap = sa;
+            int32_t* rk = rank;
+            for (uint32_t i = 0; i < n; i++)
+            {
+                if (i + pd < n)
+                    __builtin_prefetch(rk + sap[i + pd], 1);
+                rk[sap[i]] = int32_t(i);
+            }
+        }
+
+    private:
+        // s[i] in [0, k)
+        // st, cnt, lms are given offsets so they're disjoint across recursion levels
+        // bkt is shared
+        void core(const int32_t* s,
+                  int32_t* sa,
+                  uint32_t n,
+                  uint32_t k,
+                  uint64_t st_off,
+                  uint64_t cnt_off,
+                  uint64_t lms_off)
+        {
+            if (n == 0)
+                return;
+            if (n == 1)
+            {
+                sa[0] = 0;
+                return;
+            }
+
+            if (st_pool.size() < st_off + n)
+                st_pool.resize(st_off + n);
+            if (cnt_pool.size() < cnt_off + k + 1)
+                cnt_pool.resize(cnt_off + k + 1);
+            if (lms_pool.size() < lms_off + n / 2 + 1)
+                lms_pool.resize(lms_off + n / 2 + 1);
+            if (bkt.size() < uint64_t(k) + 1)
+                bkt.resize(uint64_t(k) + 1);
+            if (nm.size() < (uint64_t(n) + 1) / 2)
+                nm.resize((uint64_t(n) + 1) / 2);
+
+            uint32_t* st = st_pool.data() + st_off;
+            uint32_t* cnt = cnt_pool.data() + cnt_off;
+            uint32_t* lms = lms_pool.data() + lms_off;
+            uint32_t* bk = bkt.data();
+
+            // classify types, compute frequencies, identify lms
+            uint32_t lcnt = 0;
+            {
+                std::fill(cnt, cnt + k + 1, 0);
+                st[n - 1] = uint32_t(s[n - 1]) << 1;
+                cnt[s[n - 1]]++;
+                for (uint32_t i = n - 1, t = 0; i-- > 0;)
+                {
+                    cnt[s[i]]++;
+
+                    const uint32_t tn = t;
+                    t = (s[i] < s[i + 1] ? 1 : (s[i] > s[i + 1] ? 0 : t));
+                    st[i] = (uint32_t(s[i]) << 1) | t;
+
+                    // i + 1 is lms iff type[i+1] = S and type[i] = L
+                    lms[lcnt] = i + 1;
+                    lcnt += tn & (t ^ 1);
+                }
+
+                uint32_t acc = 0;
+                for (uint32_t c = 0; c <= k; c++)
+                {
+                    const uint32_t x = cnt[c];
+                    cnt[c] = acc;
+                    acc += x;
+                }
+            }
+
+            auto cursors = [&]() -> void { std::copy(cnt, cnt + k + 1, bk); };
+
+            auto induce = [&]() -> void
+            {
+                // induce L, left to right
+                cursors();
+                sa[bk[st[n - 1] >> 1]++] = int32_t(n) - 1;
+                for (uint32_t i = 0; i < n; i++)
+                {
+                    if (i + pd < n)
+                        __builtin_prefetch(st + sa[i + pd] - 1);
+                    if (i + pd2 < n)
+                    {
+                        const int32_t pj = sa[i + pd2];
+                        const uint32_t pidx = pj > 0 ? uint32_t(pj) - 1 : 0;
+                        __builtin_prefetch(bk + (st[pidx] >> 1));
+                    }
+                    const int32_t j = sa[i];
+                    if (j > 0)
+                    {
+                        const uint32_t v = st[j - 1];
+                        if (!(v & 1))
+                            sa[bk[v >> 1]++] = j - 1;
+                    }
+                }
+                // induce S, right to left
+                cursors();
+                for (uint32_t i = n; i-- > 0;)
+                {
+                    if (i >= pd)
+                        __builtin_prefetch(st + sa[i - pd] - 1);
+                    if (i >= pd2)
+                    {
+                        const int32_t pj = sa[i - pd2];
+                        const uint32_t pidx = pj > 0 ? uint32_t(pj) - 1 : 0;
+                        __builtin_prefetch(bk + (st[pidx] >> 1) + 1);
+                    }
+                    const int32_t j = sa[i];
+                    if (j > 0)
+                    {
+                        const uint32_t v = st[j - 1];
+                        if (v & 1)
+                            sa[--bk[(v >> 1) + 1]] = j - 1;
+                    }
+                }
+            };
+
+            // stage 1: induce and sort the lms substrings
+            std::fill(sa, sa + n, emp);
+            if (lcnt == 0)
+            {
+                induce();
+                return;
+            }
+            cursors();
+
+            // place lms substrings into the SA
+            for (uint32_t r = 0; r < lcnt; r++)
+            {
+                const uint32_t i = lms[r];
+                sa[--bk[(st[i] >> 1) + 1]] = int32_t(i);
+            }
+            induce();
+
+            // store sorted (up to lms boundaries) lms substrings
+            {
+                uint32_t w = 0;
+                for (uint32_t i = 0; i < n; i++)
+                {
+                    if (i + pd < n)
+                        __builtin_prefetch(st + sa[i + pd] - 1);
+                    const int32_t j = sa[i];
+                    if (j > 0 and (st[j] & 1) and !(st[j - 1] & 1))
+                        sa[w++] = j;
+                }
+            }
+
+            // label sorted lms substrings
+            int32_t* names = nm.data();
+            int32_t prev = sa[0];
+            uint32_t label = 1;
+            names[uint32_t(prev) >> 1] = 0;
+            for (uint32_t i = 1; i < lcnt; i++)
+            {
+                if (i + 1 < lcnt)
+                    __builtin_prefetch(st + sa[i + 1]);
+                const int32_t cur = sa[i];
+                bool eq = true;
+                for (uint32_t d = 0;; d++)
+                {
+                    const uint32_t px = uint32_t(prev) + d, qx = uint32_t(cur) + d;
+                    if (px == n or qx == n or st[px] != st[qx])
+                    {
+                        eq = false;
+                        break;
+                    }
+                    if (d > 0)
+                    {
+                        // lms end
+                        const bool pe = (st[px] & 1) and !(st[px - 1] & 1);
+                        const bool qe = (st[qx] & 1) and !(st[qx - 1] & 1);
+                        if (pe and qe)
+                            break;
+                        if (pe != qe)
+                        {
+                            eq = false;
+                            break;
+                        }
+                    }
+                }
+                label += !eq;
+                names[uint32_t(cur) >> 1] = int32_t(label - 1);
+                prev = cur;
+            }
+
+            // reduced string at sa[n - lcnt...n), text order = lms[] reversed
+            int32_t* rs = sa + (n - lcnt);
+            for (uint32_t i = 0; i < lcnt; i++)
+                rs[i] = names[lms[lcnt - 1 - i] >> 1];
+
+            if (label < lcnt)
+                core(rs, sa, lcnt, label, st_off + n, cnt_off + k + 1, lms_off + n / 2 + 1);
+            else
+                for (uint32_t i = 0; i < lcnt; i++)
+                    sa[rs[i]] = int32_t(i);
+
+            // recursion may have reallocated the pools
+            st = st_pool.data() + st_off;
+            cnt = cnt_pool.data() + cnt_off;
+            lms = lms_pool.data() + lms_off;
+            bk = bkt.data();
+
+            // final induction
+            std::fill(sa + lcnt, sa + n, emp);
+            cursors();
+            for (uint32_t i = lcnt; i-- > 0;)
+            {
+                const int32_t j = int32_t(lms[lcnt - 1 - uint32_t(sa[i])]);
+                sa[i] = emp;
+                sa[--bk[(st[j] >> 1) + 1]] = j;
+            }
+            induce();
+        }
+    };
+} // namespace misa77

--- a/lz/misa77/src/util.h
+++ b/lz/misa77/src/util.h
@@ -1,0 +1,56 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+
+// ISA-agnostic helpers.
+// See src/isa for ISA-specialized helpers
+
+namespace misa77
+{
+    [[gnu::always_inline]]
+    inline uint16_t loadu2(const uint8_t* ptr)
+    {
+        uint16_t v;
+        memcpy(&v, ptr, 2);
+        return v;
+    }
+
+    [[gnu::always_inline]]
+    inline void storeu2(uint8_t* ptr, const uint16_t val)
+    {
+        memcpy(ptr, &val, 2);
+    }
+
+    [[gnu::always_inline]]
+    inline uint32_t loadu4(const uint8_t* ptr)
+    {
+        uint32_t v;
+        memcpy(&v, ptr, 4);
+        return v;
+    }
+
+    [[gnu::always_inline]]
+    inline void storeu4(uint8_t* ptr, const uint32_t val)
+    {
+        memcpy(ptr, &val, 4);
+    }
+
+    [[gnu::always_inline]]
+    inline uint64_t loadu8(const uint8_t* ptr)
+    {
+        uint64_t v;
+        memcpy(&v, ptr, 8);
+        return v;
+    }
+
+    [[gnu::always_inline]]
+    inline void storeu8(uint8_t* ptr, const uint64_t val)
+    {
+        memcpy(ptr, &val, 8);
+    }
+} // namespace misa77


### PR DESCRIPTION
misa77 is an LZ77 codec for the "write once, read many" niche. It trades compression speed for very high decompression throughput and decent ratios. It decodes much faster than most codecs in its ratio class on most data types and architectures.

- **License**: MIT
- **Repository**: https://github.com/welcome-to-the-sunny-side/misa77 (this PR vendors [v0.5.0](https://github.com/welcome-to-the-sunny-side/misa77/releases/tag/v0.5.0))

### Registered variants

- `misa77` (levels 0-2): level 0 decodes fastest, level 1 (the library default) trades a little decode speed for ratio, level 2 has slightly better ratios than `lz4hc -12`'s ratio while still decoding at level-1 speeds.
- `misa77_safe` (levels 0-1): same compressor, but decompression runs with full input validation (guaranteed to terminate and stay in-bounds on corrupt/malicious input). Level 2's format does not have a safe decoder yet, so the safe variant stops at level 1.

Detailed benchmark results can be found [here](https://github.com/welcome-to-the-sunny-side/misa77/blob/main/README.md). A small portion is attached below.

### Results (silesia.tar, Intel i7-14650HX (@2.2 GHz), single core, turbo disabled)

| Compressor name          | Compression | Decompress. |  Ratio |
| ------------------------ | ----------- | ----------- | ------ |
| misa77 0.5.0 -0          |   54.3 MB/s |   5359 MB/s |  42.64 |
| misa77 0.5.0 safe -0     |   54.1 MB/s |   5216 MB/s |  42.64 |
| misa77 0.5.0 -2          |   7.01 MB/s |   4470 MB/s |  35.51 |
| misa77 0.5.0 -1          |   51.2 MB/s |   4378 MB/s |  39.65 |
| misa77 0.5.0 safe -1     |   51.2 MB/s |   4252 MB/s |  39.65 |
| zxc 0.13.1 -3            |    116 MB/s |   2838 MB/s |  45.46 |
| zxc 0.13.1 -4            |   81.2 MB/s |   2726 MB/s |  42.63 |
| lzsse8fast 2019-04-18    |    183 MB/s |   2663 MB/s |  44.80 |
| zxc 0.13.1 -5            |   48.4 MB/s |   2602 MB/s |  40.25 |
| lz4hc 1.10.0 -12         |   7.31 MB/s |   2531 MB/s |  36.45 |
| lzsse4fast 2019-04-18    |    187 MB/s |   2525 MB/s |  45.26 |
| lz4 1.10.0               |    371 MB/s |   2506 MB/s |  47.59 |
| lz4hc 1.10.0 -9          |   22.0 MB/s |   2454 MB/s |  36.75 |
| lzav 5.11 -2             |   58.4 MB/s |   1729 MB/s |  34.97 |
| zxc 0.13.1 -7            |   4.27 MB/s |   1645 MB/s |  33.00 |
| zstd 1.5.7 -1            |    297 MB/s |    903 MB/s |  34.54 |
| snappy 1.2.2             |    376 MB/s |    858 MB/s |  47.89 |

(misa77 rows first, then competitors sorted by decompression speed)

On ARM64 (Apple M3) the gap is larger: level 0 decodes silesia.tar at ~12.7 GB/s vs lz4's ~5.2 GB/s, and level 2 beats lz4hc -12's ratio (35.51 vs 36.45) while decoding ~2.0x faster (9.9 vs 4.9 GB/s). Refer to the README for more details.

### Requirements

- C++20
- A 64-bit little-endian system.

### Integration

- Added the codec source under `lz/misa77/` (MIT licensed), byte-identical to the misa77 repository at tag v0.5.0.
- Registered in `bench/codecs.h`, `bench/lz_codecs.cpp`, and `bench/lzbench.h`; listed in `README.md` + `CHANGELOG`.
- The Makefile requires C++20 and a 64-bit little-endian system. Unsupported systems get `BENCH_REMOVE_MISA77` automatically, and `DONT_BUILD_MISA77=1` is available as a manual override.

### Verification

Benchmarked across the Silesia corpus on x86-64 (Intel, GCC) and ARM64 (Apple M3, Apple clang), at every level of both variants. lzbench's built-in decompression check passed on all runs, including a separate sweep of small inputs sized around the format's small-mode and literal-suffix boundaries. The safe decoder has additionally been mutation-fuzzed under ASan/UBSan.

---

Supersedes #307 (accidentally closed during a branch rename).

Updated from misa77 0.4.0 to 0.5.0 since this PR was opened. 