### PR TITLE
aceapex: fix four small-input bugs, re-enable in FASTEST 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,9 @@ v2.x.y
 - updated nvcomp to support CUDA 13 and cccl 3 (thanks to @fwyzard)
 - updated zxc to 0.13.2 (thanks to @hellobertrand)
 - added misa77 0.6.0 (by @welcome-to-the-sunny-side)
+- fixed: aceapex produced wrong results on tiny inputs (1/2/5 bytes) and could abort
+         with a heap double-free after many small buffers, and could corrupt output
+         above 2 GiB; re-enabled in the FASTEST alias
 
 v2.3 (Jun 15, 2026)
 - improvement: Reorganized compressor alias groups by type — ALL is now a composite of LZ /

--- a/bench/lzbench.h
+++ b/bench/lzbench.h
@@ -168,7 +168,7 @@ static const compressor_desc_t comp_desc[] =
      //                                       last_level,       mt_mode,
      // name,       name_version,    first_level,  additional_param,  compress_func,               decompress_func,               init_func,               deinit_func,             max_input_size
     { "memcpy",     "memcpy",                  0,   0,    0,  BENCH_POOL_MT, lzbench_memcpy,              lzbench_memcpy,                NULL,                    NULL },
-    { "aceapex",    "aceapex 1.0",             1,   2,    0, FULL_THREADING, lzbench_aceapex_compress,     lzbench_aceapex_decompress,    lzbench_aceapex_init,    lzbench_aceapex_deinit },
+    { "aceapex",    "aceapex 1.0.1",             1,   2,    0, FULL_THREADING, lzbench_aceapex_compress,     lzbench_aceapex_decompress,    lzbench_aceapex_init,    lzbench_aceapex_deinit },
 #ifdef BENCH_HAS_CUDA
     { "aceapex_cuda","aceapex_cuda 0.9",        1,   2,    0,  NO_THREADING,  lzbench_aceapex_compress,    lzbench_aceapex_cuda_decompress, lzbench_aceapex_cuda_init, lzbench_aceapex_cuda_deinit },
 #endif
@@ -307,10 +307,10 @@ static const alias_desc_t alias_desc[] =
               "LZ/SYMMETRIC/MISC" },
     // CI uses FASTEST for multi-threaded testing
     { "FASTEST", "All LZ/SYMMETRIC/MISC compressors, each at only its fastest level.",
-     /* LZ */ "memcpy/aceapex-DISABLED,1/brieflz,1/brotli,0/fastlz,1/fastlzma2,1/kanzi,1/libdeflate,1/lizard,10/lz4fast,99/lz4/lz4hc,1/lzav,1/" \
+     /* LZ */ "memcpy/aceapex,1/brieflz,1/brotli,0/fastlz,1/fastlzma2,1/kanzi,1/libdeflate,1/lizard,10/lz4fast,99/lz4/lz4hc,1/lzav,1/" \
               "lzf,0/lzfse/lzham,0/lzlib,0/lzma,0/lzo1,1/lzo1a,1/lzo1b,1/lzo1c,1/lzo1f,1/lzo1x,1/lzo1y,1/lzo1z/lzo2a/lzsse2,1/" \
               "lzsse4fast/lzsse4,1/lzsse8,1/lzvn/memlz/misa77,0/misa77_safe,0/quicklz,1/slz_gzip,1/snappy/ucl_nrv2b,1/ucl_nrv2d,1/ucl_nrv2e,1/xz,0/yalz77,1/" \
-              "zlib,1/zlib-ng,1/zstd_fast,-5/zstd,1/zxc,1/" /* aceapex is disabled as it has issues with tiny inputs */ \
+              "zlib,1/zlib-ng,1/zstd_fast,-5/zstd,1/zxc,1/" \
 /* SYMMETR */ "bsc1/bzip2,1/bzip3,1/density,1/ppmd8,1/zpaq,1/" \
    /* MISC */ "crush,0/lzjb/skim/tamp,8/tornado-DISABLED,1/zling,0" }, /* Tornado is disabled as it has issues with incompressible data */
     { "SLOW", "Lists very slow compressors.",

--- a/lz/aceapex/aceapex_api.cpp
+++ b/lz/aceapex/aceapex_api.cpp
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #define ACEAPEX_NO_MAIN
 #include "ax_align.h"
 #include "aceapex_main.cpp"
@@ -74,10 +75,13 @@ int64_t aceapex_decompress(
     std::vector<BlockOffsets> boffs(hdr.num_blocks);
     memcpy(boffs.data(),p,hdr.num_blocks*sizeof(BlockOffsets));
     p+=hdr.num_blocks*sizeof(BlockOffsets);
-    uint8_t* zl=(uint8_t*)malloc(hdr.zlit_sz);
-    uint8_t* zo=(uint8_t*)malloc(hdr.zoff_sz);
-    uint8_t* zn=(uint8_t*)malloc(hdr.zlen_sz);
-    uint8_t* zc=(uint8_t*)malloc(hdr.zcmd_sz);
+    // malloc(0) may legally return NULL; a zero-length stream is not an error.
+    // Tiny inputs (1/2/5 bytes) produce zlit_sz==0, and the old !zl check turned
+    // that empty stream into ACEAPEX_ERR_MEMORY (-1). Allocate at least 1 byte.
+    uint8_t* zl=(uint8_t*)malloc(hdr.zlit_sz?hdr.zlit_sz:1);
+    uint8_t* zo=(uint8_t*)malloc(hdr.zoff_sz?hdr.zoff_sz:1);
+    uint8_t* zn=(uint8_t*)malloc(hdr.zlen_sz?hdr.zlen_sz:1);
+    uint8_t* zc=(uint8_t*)malloc(hdr.zcmd_sz?hdr.zcmd_sz:1);
     if(!zl||!zo||!zn||!zc){free(zl);free(zo);free(zn);free(zc);return ACEAPEX_ERR_MEMORY;}
     memcpy(zl,p,hdr.zlit_sz); p+=hdr.zlit_sz;
     memcpy(zo,p,hdr.zoff_sz); p+=hdr.zoff_sz;
@@ -86,9 +90,9 @@ int64_t aceapex_decompress(
     size_t os=AX_read64((zo)),ns=AX_read64((zn)),cs=AX_read64((zc));
     size_t ls=0; uint8_t* l=lit_decompress(zl,hdr.zlit_sz,ls);
     if(!l){free(zl);free(zo);free(zn);free(zc);return ACEAPEX_ERR_MEMORY;}
-    uint8_t* o=(uint8_t*)malloc(os);
-    uint8_t* n=(uint8_t*)malloc(ns);
-    uint8_t* c=(uint8_t*)malloc(cs);
+    uint8_t* o=(uint8_t*)malloc(os?os:1);
+    uint8_t* n=(uint8_t*)malloc(ns?ns:1);
+    uint8_t* c=(uint8_t*)malloc(cs?cs:1);
     if(!o||!n||!c){free(o);free(n);free(c);free(zl);free(zo);free(zn);free(zc);return ACEAPEX_ERR_MEMORY;}
     fse_chunked_decomp(zo,os,o); fse_chunked_decomp(zn,ns,n); fse_chunked_decomp(zc,cs,c);
     free(zl);free(zo);free(zn);free(zc);

--- a/lz/aceapex/aceapex_main.cpp
+++ b/lz/aceapex/aceapex_main.cpp
@@ -60,9 +60,9 @@ struct WorkerArgs {
 };
  
 struct ThreadHashTable {
-    int32_t*  pos;
+    int64_t*  pos;
     uint32_t* epoch;
-    int32_t*  chain;
+    int64_t*  chain;
     uint32_t  cur_epoch;
     uint32_t  hash_mask;
     uint32_t  chain_mask;
@@ -105,11 +105,11 @@ static inline int find_matches(const uint8_t* src, size_t pos, size_t bstart, si
         if (l>=6) out[n++]={l,d,i};
     }
     uint32_t h=((AX_read32((src+pos))*0x9E3779B1u)>>10)&ht->hash_mask;
-    int32_t head=(ht->epoch[h]==ht->cur_epoch)?ht->pos[h]:-1;
-    ht->pos[h]=(int32_t)pos; ht->epoch[h]=ht->cur_epoch;
+    int64_t head=(ht->epoch[h]==ht->cur_epoch)?ht->pos[h]:-1;
+    ht->pos[h]=(int64_t)pos; ht->epoch[h]=ht->cur_epoch;
     if (head>=0) ht->chain[pos & ht->chain_mask]=head;
-    int32_t cur=head; int attempts=max_attempts;
-    while(cur>=(int32_t)bstart && attempts-->0 && n<maxout) {
+    int64_t cur=head; int attempts=max_attempts;
+    while(cur>=(int64_t)bstart && attempts-->0 && n<maxout) {
         uint32_t dist=(uint32_t)(pos-cur); if(dist>=MAX_DIST) break;
         bool is_rep=false; for(int r=0;r<4;r++) if(dist==rep[r]){is_rep=true;break;}
         if(!is_rep){
@@ -122,7 +122,7 @@ static inline int find_matches(const uint8_t* src, size_t pos, size_t bstart, si
                 if(l>=mlen) out[n++]={l,dist,-1};
             }
         }
-        int32_t nxt=ht->chain[cur & ht->chain_mask];
+        int64_t nxt=ht->chain[cur & ht->chain_mask];
         if(nxt<0||nxt>=cur) break; cur=nxt;
     }
     return n;
@@ -167,7 +167,7 @@ static void compress_block(const uint8_t* src, size_t src_size,
         for(int mi=0;mi<nm;mi++) if(matches[mi].len>c_len){c_len=matches[mi].len;c_off=matches[mi].off;c_rep=matches[mi].rep;}
         if (c_len >= 6 && c_len < 64 && pos+13 < bend) {
             uint32_t h1=((AX_read32((src+pos+1))*0x9E3779B1u)>>10)&ht->hash_mask;
-            int32_t mp1=(ht->epoch[h1]==ht->cur_epoch)?ht->pos[h1]:-1;
+            int64_t mp1=(ht->epoch[h1]==ht->cur_epoch)?ht->pos[h1]:-1;
             if (mp1>=0 && (size_t)mp1>=bstart && (size_t)mp1<pos+1) {
                 uint32_t dist1=(uint32_t)(pos+1-mp1);
                 if (dist1<MAX_DIST && dist1!=rep[0]) {
@@ -189,7 +189,7 @@ static void compress_block(const uint8_t* src, size_t src_size,
             // Lazy check pos+2
             if (c_len >= 6 && c_len < 64 && pos+14 < bend) {
                 uint32_t h2=((AX_read32((src+pos+2))*0x9E3779B1u)>>10)&ht->hash_mask;
-                int32_t mp2=(ht->epoch[h2]==ht->cur_epoch)?ht->pos[h2]:-1;
+                int64_t mp2=(ht->epoch[h2]==ht->cur_epoch)?ht->pos[h2]:-1;
                 if (mp2>=0 && (size_t)mp2>=bstart && (size_t)mp2<pos+2) {
                     uint32_t dist2=(uint32_t)(pos+2-mp2);
                     if (dist2<MAX_DIST && dist2!=rep[0]) {
@@ -232,7 +232,7 @@ static void compress_block(const uint8_t* src, size_t src_size,
               uint32_t step=1+(c_len>>3);
               for(size_t ii=1;ii<c_len&&pos+ii+4<bend;ii+=step){
                 uint32_t hh=((AX_read32((src+pos+ii))*0x9E3779B1u)>>10)&ht->hash_mask;
-                ht->chain[(pos+ii)&ht->chain_mask]=ht->pos[hh]; ht->pos[hh]=(int32_t)(pos+ii); ht->epoch[hh]=ht->cur_epoch;
+                ht->chain[(pos+ii)&ht->chain_mask]=ht->pos[hh]; ht->pos[hh]=(int64_t)(pos+ii); ht->epoch[hh]=ht->cur_epoch;
               }
             }
             pos+=c_len; continue;
@@ -241,7 +241,7 @@ static void compress_block(const uint8_t* src, size_t src_size,
         res->lit_buf[lit_i++]=src[pos++]; lit_run++; miss++;
         if (miss>=1 && pos+12<bend) {
             uint32_t hh=((AX_read32((src+pos))*0x9E3779B1u)>>10)&ht->hash_mask;
-            if(hh<=ht->hash_mask) { ht->pos[hh]=(int32_t)pos; ht->epoch[hh]=ht->cur_epoch; }
+            if(hh<=ht->hash_mask) { ht->pos[hh]=(int64_t)pos; ht->epoch[hh]=ht->cur_epoch; }
             if (lit_i>=lit_cap) { ov=1; break; }
             res->lit_buf[lit_i++]=src[pos++]; lit_run++;
         }
@@ -462,11 +462,11 @@ static bool encode_file(const uint8_t* src, size_t src_size, int threads, int le
     for(int i=0;i<threads;i++) {
         htabs[i]=(ThreadHashTable*)calloc(1,sizeof(ThreadHashTable));
         if(!htabs[i]){return false;}
-        htabs[i]->pos  =(int32_t*) calloc(ht_sz,sizeof(int32_t));
+        htabs[i]->pos  =(int64_t*) calloc(ht_sz,sizeof(int64_t));
         htabs[i]->epoch=(uint32_t*)calloc(ht_sz,sizeof(uint32_t));
-        htabs[i]->chain=(int32_t*) malloc(((size_t)chain_mask+1)*sizeof(int32_t));
+        htabs[i]->chain=(int64_t*) malloc(((size_t)chain_mask+1)*sizeof(int64_t));
         if(!htabs[i]->pos||!htabs[i]->epoch||!htabs[i]->chain){return false;}
-        memset(htabs[i]->chain,-1,((size_t)chain_mask+1)*sizeof(int32_t));
+        memset(htabs[i]->chain,-1,((size_t)chain_mask+1)*sizeof(int64_t));
         htabs[i]->cur_epoch=0;
         htabs[i]->hash_mask=hash_mask;
         htabs[i]->chain_mask=chain_mask;

--- a/lz/aceapex/aceapex_main.cpp
+++ b/lz/aceapex/aceapex_main.cpp
@@ -321,13 +321,13 @@ static void decompress_streams(
             if (lv==0x0F) lv+=read_varint(len,np,len_sz);
             uint32_t l=lv+6, dist=rep[ri];
             if (ri>0) { for(int i=ri;i>0;i--) rep[i]=rep[i-1]; rep[0]=dist; }
-            if (!dist||out+l>dst_size) break;
+            if (!dist||dist>out||out+l>dst_size) break;
             copy_match(dst,out,dist,l); out+=l;
         } else {
             uint32_t lv=(c==0xFE)?read_varint(len,np,len_sz):(uint32_t)(c&0x3F);
             uint32_t l=lv+6, dist=read_varint(off,op,off_sz);
             rep[3]=rep[2];rep[2]=rep[1];rep[1]=rep[0];rep[0]=dist;
-            if (!dist||out+l>dst_size) break;
+            if (!dist||dist>out||out+l>dst_size) break;
             copy_match(dst,out,dist,l); out+=l;
         }
     }
@@ -589,7 +589,12 @@ static uint8_t* lit_compress(const uint8_t* src, size_t sz, size_t& out_sz) {
     struct ZW{const uint8_t*in;size_t isz;uint8_t*out;size_t osz;size_t cap;};
     ZW zws[NW];
     for(int t=0;t<NW;t++){
-        size_t off=(size_t)t*csz,isz=(t<NW-1)?csz:sz-off;
+        // Guard against unsigned underflow: for sz in {1,2,5,...} the last
+        // worker's offset (3*ceil(sz/4)) exceeds sz, so sz-off wrapped around
+        // to ~2^64 -> ZSTD_compressBound(huge) -> malloc failure -> zlit_sz=0
+        // -> the literal stream was silently dropped and decode produced garbage.
+        size_t off=(size_t)t*csz; if(off>sz) off=sz;
+        size_t isz=(t<NW-1)?((off+csz<=sz)?csz:(sz-off)):(sz-off);
         zws[t]={src+off,isz,nullptr,0,ZSTD_compressBound(isz)+8};
         zws[t].out=(uint8_t*)malloc(zws[t].cap);
         if(!zws[t].out){out_sz=0;return nullptr;}}
@@ -612,7 +617,13 @@ static uint8_t* lit_compress(const uint8_t* src, size_t sz, size_t& out_sz) {
     out_sz=totalsz; return res;
 }
 static uint8_t* lit_decompress(const uint8_t* src, size_t src_sz, size_t& orig_sz) {
-    uint64_t h=*(const uint64_t*)src;
+    // Guard: an empty or truncated literal stream must not be read as a header.
+    // Tiny inputs (1/2/5 bytes) produce zlit_sz==0; reading 8 bytes from a
+    // zero-length buffer gave a garbage orig_sz -> malloc(garbage) -> either a
+    // -1 decode or heap corruption that surfaced as a double-free thousands of
+    // calls later. (lzbench issue: aceapex tiny-input failures + tcache abort.)
+    if (!src || src_sz < 8) { orig_sz = 0; return (uint8_t*)malloc(1); }
+    uint64_t h=AX_read64(src);
     orig_sz=h & ~(uint64_t(1)<<62);
     uint8_t* out=(uint8_t*)malloc(orig_sz);
     if(!out) return nullptr;
@@ -623,7 +634,10 @@ static uint8_t* lit_decompress(const uint8_t* src, size_t src_sz, size_t& orig_s
     struct DW{uint8_t*out;size_t raw;const uint8_t*in;size_t isz;};
     DW dws[NW]; const uint8_t* p=p0;
     for(int t=0;t<NW;t++){
-        size_t off=(size_t)t*csz,raw=(t<NW-1)?csz:orig_sz-off;
+        // Same underflow guard as in lit_compress: orig_sz-off would wrap for
+        // sizes where 3*ceil(orig_sz/4) > orig_sz (1, 2, 5, ...).
+        size_t off=(size_t)t*csz; if(off>orig_sz) off=orig_sz;
+        size_t raw=(t<NW-1)?((off+csz<=orig_sz)?csz:(orig_sz-off)):(orig_sz-off);
         dws[t]={out+off,raw,p,(size_t)zsz[t]}; p+=(size_t)zsz[t];}
     auto dfn=[](void*a)->void*{DW*d=(DW*)a;
         ZSTD_decompress(d->out,d->raw,d->in,d->isz); return nullptr;};
@@ -817,7 +831,8 @@ static int do_decompress(const char* in_path, const char* out_path) {
     struct FD{const uint8_t*s;size_t sz;uint8_t*d;};
     FD fds[3]={{zoff,off_sz,off},{zlen,len_sz,len},{zcmd,cmd_sz,cmd}};
     auto fdfn=[](void*a)->void*{FD*f=(FD*)a;
-        size_t orig=*(const uint64_t*)f->s&~(uint64_t(1)<<63);
+        if(!f->s || f->sz < 8) return nullptr;   // empty stream: nothing to decode
+        size_t orig=AX_read64(f->s)&~(uint64_t(1)<<63);
         fse_chunked_decomp(f->s,orig,f->d); return nullptr;};
     pthread_t fpts[4];
     pthread_create(&fpts[0],nullptr,litfn,&larg);

--- a/lz/aceapex/lit_fse.cpp
+++ b/lz/aceapex/lit_fse.cpp
@@ -71,12 +71,13 @@ static uint8_t* fse_comp(const uint8_t* src,size_t sz,size_t& out_sz,int nc=16){
 }
 
 static uint8_t* fse_decomp(const uint8_t* src,size_t sz,size_t& orig_sz){
-    uint32_t nc=*(const uint32_t*)src;
+    if(!src || sz < 8){ orig_sz=0; return (uint8_t*)malloc(1); }
+    uint32_t nc=AX_read32(src);
     if(nc==0||nc>256){
-        orig_sz=*(const uint64_t*)src&~(uint64_t(1)<<63);
-        int raw=(*(const uint64_t*)src>>63)&1;
-        uint8_t* out=(uint8_t*)malloc(orig_sz);
-    if(!out) return nullptr;
+        uint64_t h=AX_read64(src);
+        orig_sz=h&~(uint64_t(1)<<63);
+        int raw=(h>>63)&1;
+        uint8_t* out=(uint8_t*)malloc(orig_sz?orig_sz:1);
         if(!out) return nullptr;
         if(raw) memcpy(out,src+8,orig_sz);
         else LIT_decompress(out,orig_sz,src+8,sz-8);


### PR DESCRIPTION
Fixes yasha1971-coder/aceapex#2.The four bugs reported there share one root cause: lit_compress splits the literal buffer across NW=4 workers, and for the last worker the offset 3*ceil(sz/4) exceeds sz whenever 3*ceil(sz/4) > sz. The subtraction sz-off then wraps to about 2^64, ZSTD_compressBound of that is astronomical, the allocation fails, and the literal stream is silently dropped. The arithmetic predicts exactly the sizes reported: 1, 2 and 5 bytes.

Fixing that surfaced three more:

- lit_decompress read an 8-byte header from a zero-length stream. That out-of-bounds read corrupted heap metadata and only surfaced as the double-free thousands of calls later.
- aceapex_decompress returned -1 because malloc(0) may legally return NULL, and the null check treated an empty stream as an allocation failure.
- fse_decomp had the same header read on an empty stream, plus a duplicated null check.

Direct pointer dereferences on stream headers are replaced with the alignment-safe AX_read32/64 helpers introduced in #292, so the new paths keep the strict-alignment guarantee. A match whose distance exceeds the bytes written so far is now rejected rather than copied from before the output.

With these fixes the tiny-input failures and the heap abort are gone, so this also lifts aceapex-DISABLED from the FASTEST alias.

Verified on x86-64 Linux, GCC 11.4.0, AMD EPYC 4344P, after a clean rebuild:

- sizes 0 to 16 bytes through lzbench: all pass, no mismatch
- the exact repro from yasha1971-coder/aceapex#2, -eaceapex -t0,0 -jr . over 5074 files: exit 0, was SIGABRT at chunk 2155
- the CI command -eFASTEST -t0,0 -T2 -jr . with aceapex enabled: exit 0, all codecs complete

Full-tree cross-compilation for 32-bit ARM was not possible here (an unrelated NEON source in another codec fails to build), so the ARM paths are covered by the alignment-safe accessors rather than by a local run.