### PR TITLE
Add gpucompact 1.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ v2.x.y (work-in-progress)
        NULL work_mem, which used to SEGFAULT (e.g. "lzbench -eCUDA" without a GPU)
 - added misa77 0.6.0 (by @welcome-to-the-sunny-side)
 - added OpenZL v0.2.0 (thanks to @fwyzard)
+- added GPUCompact 1.0 (by @UDPSendToFailed)
 - added a CUDA build job (nvcc 13.2, Ubuntu 24.04) to the Azure Pipelines CI
 - updated aceapex to 1.0.1 (thanks to @yasha1971-coder)
 - updated lzav to 5.16 (thanks to @avaneev)

--- a/Makefile
+++ b/Makefile
@@ -1114,6 +1114,10 @@ ifeq "$(ENABLE_CUDA)" "1"
 
     ACEAPEX_CUDA_FILES = lz/aceapex/cuda/aceapex_cuda.cu.o lz/aceapex/cuda/aceapex_cuda_lzbench.o
 
+  ifneq "$(DONT_BUILD_GPUCOMPACT)" "1"
+    GPUCOMPACT_FILES = lz/gpucompact/kernels.cu.o lz/gpucompact/context.cu.o lz/gpucompact/gpucompact_lzbench.o
+  endif
+
   ifneq "$(DONT_BUILD_NVCOMP)" "1"
     DEFINES += -DBENCH_HAS_NVCOMP
     NVCOMP_CPP_SRC = $(wildcard misc/nvcomp/src/*.cpp misc/nvcomp/src/lowlevel/*.cpp)
@@ -1134,7 +1138,7 @@ endif # ifeq "$(ENABLE_CUDA)"
 
 MKDIR = mkdir -p
 
-lzbench: $(BUGGY_C_FILES) $(BUGGY_CC_FILES) $(BUGGY_CXX_FILES) $(ACEAPEX_FILES) $(BSC_C_FILES) $(BSC_CXX_FILES) $(BSC_CUDA_FILES) $(ACEAPEX_CUDA_FILES) $(BZIP2_FILES) $(BZIP3_FILES) $(CSC_FILES) $(KANZI_FILES) $(FASTLZMA2_OBJ) $(ZSTD_FILES) $(LZSSE_FILES) $(LZFSE_FILES) $(XZ_FILES) $(LIBLZG_FILES) $(BRIEFLZ_FILES) $(LZF_FILES) $(BROTLI_FILES) $(LZMA_FILES) $(ZLING_FILES) $(QUICKLZ_FILES) $(OPENZL_C_FILES) $(OPENZL_S_FILES) $(SNAPPY_FILES) $(ZLIB_FILES) $(ZLIB_NG_FILES) $(LZHAM_FILES) $(LZO_FILES) $(UCL_FILES) $(LZ4_FILES) $(LIZARD_FILES) $(LIBDEFLATE_FILES) $(ZXC_FILES) $(MISA77_FILES) $(MISC_FILES) $(NVCOMP_FILES) $(PPMD_FILES) $(BENCH_FILES) $(SKIM_FILE)
+lzbench: $(BUGGY_C_FILES) $(BUGGY_CC_FILES) $(BUGGY_CXX_FILES) $(ACEAPEX_FILES) $(BSC_C_FILES) $(BSC_CXX_FILES) $(BSC_CUDA_FILES) $(ACEAPEX_CUDA_FILES) $(GPUCOMPACT_FILES) $(BZIP2_FILES) $(BZIP3_FILES) $(CSC_FILES) $(KANZI_FILES) $(FASTLZMA2_OBJ) $(ZSTD_FILES) $(LZSSE_FILES) $(LZFSE_FILES) $(XZ_FILES) $(LIBLZG_FILES) $(BRIEFLZ_FILES) $(LZF_FILES) $(BROTLI_FILES) $(LZMA_FILES) $(ZLING_FILES) $(QUICKLZ_FILES) $(OPENZL_C_FILES) $(OPENZL_S_FILES) $(SNAPPY_FILES) $(ZLIB_FILES) $(ZLIB_NG_FILES) $(LZHAM_FILES) $(LZO_FILES) $(UCL_FILES) $(LZ4_FILES) $(LIZARD_FILES) $(LIBDEFLATE_FILES) $(ZXC_FILES) $(MISA77_FILES) $(MISC_FILES) $(NVCOMP_FILES) $(PPMD_FILES) $(BENCH_FILES) $(SKIM_FILE)
 	$(CXX) $^ -o $@ $(LDFLAGS) $(LDFLAGS_LIBDL)
 	@echo Linked GCC_VERSION=$(GCC_VERSION) CLANG_VERSION=$(CLANG_VERSION) COMPILER=$(COMPILER)
 
@@ -1289,6 +1293,15 @@ lz/aceapex/cuda/aceapex_cuda.cu.o: lz/aceapex/cuda/aceapex_cuda.cu
 
 lz/aceapex/cuda/aceapex_cuda_lzbench.o: lz/aceapex/cuda/aceapex_cuda_lzbench.cpp
 	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+# GPUCOMPACT CUDA compressor
+lz/gpucompact/%.cu.o: lz/gpucompact/%.cu
+	@$(MKDIR) $(dir $@)
+	$(CUDA_CC) $(CUDA_CXXFLAGS) $(CXXFLAGS) -Ilz/gpucompact -Ibench -c $< -o $@
+
+lz/gpucompact/gpucompact_lzbench.o: lz/gpucompact/gpucompact_lzbench.cpp
+	@$(MKDIR) $(dir $@)
+	$(CXX) $(CXXFLAGS) -Ilz/gpucompact -Ibench -c $< -o $@
 
 $(BSC_CUDA_FILES): %.cu.o: %.cu
 	@$(MKDIR) $(dir $@)

--- a/Makefile
+++ b/Makefile
@@ -1114,7 +1114,9 @@ ifeq "$(ENABLE_CUDA)" "1"
 
     ACEAPEX_CUDA_FILES = lz/aceapex/cuda/aceapex_cuda.cu.o lz/aceapex/cuda/aceapex_cuda_lzbench.o
 
-  ifneq "$(DONT_BUILD_GPUCOMPACT)" "1"
+  ifeq "$(DONT_BUILD_GPUCOMPACT)" "1"
+    DEFINES += -DBENCH_REMOVE_GPUCOMPACT
+  else
     GPUCOMPACT_FILES = lz/gpucompact/kernels.cu.o lz/gpucompact/context.cu.o lz/gpucompact/gpucompact_lzbench.o
   endif
 
@@ -1297,11 +1299,11 @@ lz/aceapex/cuda/aceapex_cuda_lzbench.o: lz/aceapex/cuda/aceapex_cuda_lzbench.cpp
 # GPUCOMPACT CUDA compressor
 lz/gpucompact/%.cu.o: lz/gpucompact/%.cu
 	@$(MKDIR) $(dir $@)
-	$(CUDA_CC) $(CUDA_CXXFLAGS) $(CXXFLAGS) -Ilz/gpucompact -Ibench -c $< -o $@
+	$(CUDA_CC) $(CUDA_CXXFLAGS) $(CXXFLAGS) -c $< -o $@
 
 lz/gpucompact/gpucompact_lzbench.o: lz/gpucompact/gpucompact_lzbench.cpp
 	@$(MKDIR) $(dir $@)
-	$(CXX) $(CXXFLAGS) -Ilz/gpucompact -Ibench -c $< -o $@
+	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(BSC_CUDA_FILES): %.cu.o: %.cu
 	@$(MKDIR) $(dir $@)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Notes column says otherwise.
 | [fastlz 0.5.0](https://github.com/ariya/FastLZ) | 2020-02-02 | |
 | [fast-lzma2 1.0.1](https://github.com/conor42/fast-lzma2) | 2019-05-06 | |
 | [glza 0.12](https://encode.su/threads/2427-GLZA) | 2026-03-23 | |
+| [gpucompact 1.0](https://github.com/UDPSendToFailed/gpucompact) | 2026-07-27 | CUDA only |
 | [kanzi 2.5.3](https://github.com/flanglet/kanzi-cpp) | 2026-04-22 | |
 | [libdeflate v1.25](https://github.com/ebiggers/libdeflate) | 2025-11-01 | |
 | [lizard v2.1](https://github.com/inikep/lizard) | 2025-01-26 | |

--- a/bench/codecs.h
+++ b/bench/codecs.h
@@ -698,3 +698,23 @@ int64_t lzbench_zxc_decompress(char *inbuf, size_t insize, char *outbuf,
     #define lzbench_aceapex3_decompress NULL
 #endif // BENCH_REMOVE_ACEAPEX
 
+#ifndef BENCH_REMOVE_GPUCOMPACT
+#ifdef BENCH_HAS_CUDA
+    char* lzbench_gpucompact_init(size_t insize, size_t level, size_t threads);
+    void lzbench_gpucompact_deinit(char* workmem);
+    int64_t lzbench_gpucompact_compress(char *inbuf, size_t insize, char *outbuf, size_t outsize, codec_options_t *codec_options);
+    int64_t lzbench_gpucompact_decompress(char *inbuf, size_t insize, char *outbuf, size_t outsize, codec_options_t *codec_options);
+#else
+    #define lzbench_gpucompact_init NULL
+    #define lzbench_gpucompact_deinit NULL
+    #define lzbench_gpucompact_compress NULL
+    #define lzbench_gpucompact_decompress NULL
+#endif
+#else
+    #define lzbench_gpucompact_init NULL
+    #define lzbench_gpucompact_deinit NULL
+    #define lzbench_gpucompact_compress NULL
+    #define lzbench_gpucompact_decompress NULL
+#endif // BENCH_REMOVE_GPUCOMPACT
+
+

--- a/bench/codecs.h
+++ b/bench/codecs.h
@@ -657,9 +657,6 @@ int64_t lzbench_zxc_decompress(char *inbuf, size_t insize, char *outbuf,
 #define lzbench_zxc_decompress NULL
 #endif
 
-
-#endif // LZBENCH_COMPRESSORS_H
-
 #ifndef BENCH_REMOVE_ACEAPEX
     char* lzbench_aceapex_init(size_t insize, size_t level, size_t threads);
     void lzbench_aceapex_deinit(char* workmem);
@@ -716,5 +713,7 @@ int64_t lzbench_zxc_decompress(char *inbuf, size_t insize, char *outbuf,
     #define lzbench_gpucompact_compress NULL
     #define lzbench_gpucompact_decompress NULL
 #endif // BENCH_REMOVE_GPUCOMPACT
+
+#endif // LZBENCH_COMPRESSORS_H
 
 

--- a/bench/lzbench.h
+++ b/bench/lzbench.h
@@ -199,10 +199,10 @@ static const compressor_desc_t comp_desc[] =
     { "fastlz",     "fastlz 0.5.0",            1,   2,    0,  BENCH_POOL_MT, lzbench_fastlz_compress,     lzbench_fastlz_decompress,     NULL,                    NULL },
     { "fastlzma2",  "fastlzma2 1.0.1",         1,  10,    0, FULL_THREADING, lzbench_fastlzma2_compress,  lzbench_fastlzma2_decompress,  NULL,                    NULL },
     { "gipfeli",    "gipfeli 2016-07-13",      0,   0,    0,  BENCH_POOL_MT, lzbench_gipfeli_compress,    lzbench_gipfeli_decompress,    NULL,                    NULL },
+    { "glza",       "glza 0.12",               0,   0,    0,   NO_THREADING, lzbench_glza_compress,       lzbench_glza_decompress,       NULL,                    NULL },
 #if !defined(BENCH_REMOVE_GPUCOMPACT) && defined(BENCH_HAS_CUDA)
     { "gpucompact", "gpucompact 1.0",          1,   5,    0,  NO_THREADING,  lzbench_gpucompact_compress, lzbench_gpucompact_decompress, lzbench_gpucompact_init,  lzbench_gpucompact_deinit },
 #endif
-    { "glza",       "glza 0.12",               0,   0,    0,   NO_THREADING, lzbench_glza_compress,       lzbench_glza_decompress,       NULL,                    NULL },
     { "kanzi",      "kanzi 2.5.3",             1,   9,    0, FULL_THREADING, lzbench_kanzi_compress,      lzbench_kanzi_decompress,      NULL,                    NULL },
     { "libdeflate", "libdeflate 1.25",         1,  12,    0,  BENCH_POOL_MT, lzbench_libdeflate_compress, lzbench_libdeflate_decompress, NULL,                    NULL },
     { "lizard",     "lizard 2.1",             10,  49,    0,  BENCH_POOL_MT, lzbench_lizard_compress,     lzbench_lizard_decompress,     NULL,                    NULL },

--- a/bench/lzbench.h
+++ b/bench/lzbench.h
@@ -199,6 +199,9 @@ static const compressor_desc_t comp_desc[] =
     { "fastlz",     "fastlz 0.5.0",            1,   2,    0,  BENCH_POOL_MT, lzbench_fastlz_compress,     lzbench_fastlz_decompress,     NULL,                    NULL },
     { "fastlzma2",  "fastlzma2 1.0.1",         1,  10,    0, FULL_THREADING, lzbench_fastlzma2_compress,  lzbench_fastlzma2_decompress,  NULL,                    NULL },
     { "gipfeli",    "gipfeli 2016-07-13",      0,   0,    0,  BENCH_POOL_MT, lzbench_gipfeli_compress,    lzbench_gipfeli_decompress,    NULL,                    NULL },
+#if !defined(BENCH_REMOVE_GPUCOMPACT) && defined(BENCH_HAS_CUDA)
+    { "gpucompact", "gpucompact 1.0",          1,   5,    0,  NO_THREADING,  lzbench_gpucompact_compress, lzbench_gpucompact_decompress, lzbench_gpucompact_init,  lzbench_gpucompact_deinit },
+#endif
     { "glza",       "glza 0.12",               0,   0,    0,   NO_THREADING, lzbench_glza_compress,       lzbench_glza_decompress,       NULL,                    NULL },
     { "kanzi",      "kanzi 2.5.3",             1,   9,    0, FULL_THREADING, lzbench_kanzi_compress,      lzbench_kanzi_decompress,      NULL,                    NULL },
     { "libdeflate", "libdeflate 1.25",         1,  12,    0,  BENCH_POOL_MT, lzbench_libdeflate_compress, lzbench_libdeflate_decompress, NULL,                    NULL },
@@ -349,7 +352,7 @@ static const alias_desc_t alias_desc[] =
 #endif
 #ifdef BENCH_HAS_CUDA
     { "CUDA",     "Represents all CUDA-based compressors.",
-                  "memcpy/cudaMemcpy/nvcomp_lz4/bsc_cuda/aceapex_cuda" },
+                  "memcpy/cudaMemcpy/nvcomp_lz4/bsc_cuda/aceapex_cuda/gpucompact" },
 #endif
 #if !defined(BENCH_REMOVE_LZO)
     { "lzo1",     nullptr, "lzo1,1,99" },

--- a/doc/licenses/AGPL-3.0.txt
+++ b/doc/licenses/AGPL-3.0.txt
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/lz/gpucompact/LICENSE
+++ b/lz/gpucompact/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/lz/gpucompact/context.cu
+++ b/lz/gpucompact/context.cu
@@ -1,0 +1,653 @@
+/*
+ * GPUCompact
+ * Copyright (C) 2026 UDPSendToFailed
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "context.cuh"
+#include "kernels.cuh"
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <cub/cub.cuh>
+#include <iostream>
+#include <stdexcept>
+
+#define CUDA_CHECK(call)                                                       \
+  do {                                                                         \
+    cudaError_t err = call;                                                    \
+    if (err != cudaSuccess) {                                                  \
+      std::cerr << "CUDA Error: " << cudaGetErrorString(err) << " at "         \
+                << __FILE__ << ":" << __LINE__ << std::endl;                   \
+      exit(1);                                                                 \
+    }                                                                          \
+  } while (0)
+
+CompressionContext::CompressionContext(int macro_bytes, int mini_bytes,
+                                       int state_L) {
+  macro_size = macro_bytes;
+  mini_size = mini_bytes;
+  L = state_L;
+
+  max_chunks = (macro_size + mini_size - 1) / mini_size;
+  max_words = (int)(mini_size * 1.5 / 8) + 80;
+
+  size_t payload_alloc_size =
+      macro_size + (size_t)max_chunks * max_words * sizeof(uint64_t) + 65536;
+
+  CUDA_CHECK(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+
+  CUDA_CHECK(cudaMallocHost(&host_in, macro_size));
+  CUDA_CHECK(cudaMallocHost(&host_out, payload_alloc_size));
+  CUDA_CHECK(cudaMallocHost(&host_last_rank, sizeof(int)));
+
+  CUDA_CHECK(cudaMalloc(&d_data, macro_size));
+  CUDA_CHECK(cudaMalloc(&d_rank, macro_size * sizeof(int)));
+  CUDA_CHECK(cudaMalloc(&d_sa, macro_size * sizeof(int)));
+  CUDA_CHECK(cudaMalloc(&d_sa_alt, macro_size * sizeof(int)));
+  CUDA_CHECK(cudaMalloc(&d_keys, macro_size * sizeof(uint64_t)));
+  CUDA_CHECK(cudaMalloc(&d_keys_alt, macro_size * sizeof(uint64_t)));
+  CUDA_CHECK(cudaMalloc(&d_diff, macro_size * sizeof(int)));
+  CUDA_CHECK(cudaMalloc(&d_unique_ranks, macro_size * sizeof(int)));
+  CUDA_CHECK(cudaMalloc(&d_bwt, macro_size));
+  CUDA_CHECK(cudaMalloc(&d_primary_idx, sizeof(int)));
+
+  CUDA_CHECK(
+      cudaMalloc(&d_out_symbols, (macro_size + 65536) * sizeof(uint16_t)));
+  CUDA_CHECK(cudaMalloc(&d_chunk_sym_lens, max_chunks * sizeof(uint32_t)));
+  CUDA_CHECK(cudaMalloc(&d_hist, 257 * sizeof(uint32_t)));
+  CUDA_CHECK(cudaMalloc(&d_p, 257 * sizeof(int)));
+  CUDA_CHECK(cudaMalloc(&d_prefix_p, 257 * sizeof(int)));
+  CUDA_CHECK(cudaMalloc(&d_max_x, 257 * sizeof(int)));
+  CUDA_CHECK(cudaMalloc(&d_symbol_spread, L * sizeof(int)));
+  CUDA_CHECK(cudaMalloc(&d_enc_table, L * sizeof(int)));
+  CUDA_CHECK(cudaMalloc(&d_dec_table, L * sizeof(int)));
+  CUDA_CHECK(cudaMalloc(&d_dec_symbol, L * sizeof(int)));
+  CUDA_CHECK(cudaMalloc(&d_next_state, 257 * sizeof(int)));
+  CUDA_CHECK(
+      cudaMalloc(&d_out_words, max_chunks * max_words * sizeof(uint64_t)));
+  CUDA_CHECK(cudaMalloc(&d_chunk_bit_lens, max_chunks * sizeof(uint32_t)));
+  CUDA_CHECK(cudaMalloc(&d_chunk_word_lens, max_chunks * sizeof(uint32_t)));
+  CUDA_CHECK(cudaMalloc(&d_word_offsets, (max_chunks + 1) * sizeof(uint32_t)));
+  CUDA_CHECK(
+      cudaMalloc(&d_dense_words, max_chunks * max_words * sizeof(uint64_t)));
+
+  CUDA_CHECK(cudaMalloc(&d_payload, payload_alloc_size));
+  CUDA_CHECK(cudaMalloc(&d_gpu_hash, sizeof(uint64_t)));
+
+  size_t sort_bytes = 0, scan_bytes = 0;
+  cub::DoubleBuffer<uint64_t> d_keys_db(d_keys, d_keys_alt);
+  cub::DoubleBuffer<int> d_sa_db(d_sa, d_sa_alt);
+  cub::DeviceRadixSort::SortPairs(nullptr, sort_bytes, d_keys_db, d_sa_db,
+                                  macro_size, 0, 64, stream);
+  cub::DeviceScan::InclusiveSum(nullptr, scan_bytes, d_diff, d_unique_ranks,
+                                macro_size, stream);
+
+  temp_storage_bytes = std::max(sort_bytes, scan_bytes) + 65536;
+  CUDA_CHECK(cudaMalloc(&d_temp_storage, temp_storage_bytes));
+
+  CUDA_CHECK(cudaEventCreate(&e_start));
+  CUDA_CHECK(cudaEventCreate(&e_end));
+}
+
+CompressionContext::~CompressionContext() {
+  if (stream)
+    cudaStreamSynchronize(stream);
+
+  cudaFreeHost(host_in);
+  cudaFreeHost(host_out);
+  cudaFreeHost(host_last_rank);
+
+  cudaFree(d_data);
+  cudaFree(d_rank);
+  cudaFree(d_sa);
+  cudaFree(d_sa_alt);
+  cudaFree(d_keys);
+  cudaFree(d_keys_alt);
+  cudaFree(d_diff);
+  cudaFree(d_unique_ranks);
+  cudaFree(d_bwt);
+  cudaFree(d_primary_idx);
+  cudaFree(d_out_symbols);
+  cudaFree(d_chunk_sym_lens);
+  cudaFree(d_hist);
+  cudaFree(d_p);
+  cudaFree(d_prefix_p);
+  cudaFree(d_max_x);
+  cudaFree(d_symbol_spread);
+  cudaFree(d_enc_table);
+  cudaFree(d_dec_table);
+  cudaFree(d_dec_symbol);
+  cudaFree(d_next_state);
+  cudaFree(d_out_words);
+  cudaFree(d_chunk_bit_lens);
+  cudaFree(d_chunk_word_lens);
+  cudaFree(d_word_offsets);
+  cudaFree(d_dense_words);
+  cudaFree(d_payload);
+  cudaFree(d_gpu_hash);
+  cudaFree(d_temp_storage);
+
+  cudaEventDestroy(e_start);
+  cudaEventDestroy(e_end);
+  if (stream)
+    cudaStreamDestroy(stream);
+}
+
+void CompressionContext::compress_chunk(int threads_comp, int mini_chunk_size) {
+  int n = bytes_read;
+  if (n <= 1) {
+    is_raw = 1;
+    comp_size = n;
+    std::memcpy(host_out, host_in, n);
+    CUDA_CHECK(cudaMemsetAsync(d_gpu_hash, 0, sizeof(uint64_t), stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_data, host_in, std::max(1, n),
+                               cudaMemcpyHostToDevice, stream));
+    gpu_hash_kernel<<<1, 256, 0, stream>>>(d_data, d_gpu_hash, std::max(1, n));
+    CUDA_CHECK(cudaMemcpyAsync(&gpu_hash, d_gpu_hash, sizeof(uint64_t),
+                               cudaMemcpyDeviceToHost, stream));
+    cudaStreamSynchronize(stream);
+    return;
+  }
+
+  bool all_equal = true;
+  uint8_t first_byte = host_in[0];
+  for (int i = 1; i < n; i++) {
+    if (host_in[i] != first_byte) {
+      all_equal = false;
+      break;
+    }
+  }
+
+  if (all_equal) {
+    is_raw = 2;
+    comp_size = 1;
+    host_out[0] = host_in[0];
+    CUDA_CHECK(cudaMemsetAsync(d_gpu_hash, 0, sizeof(uint64_t), stream));
+    CUDA_CHECK(
+        cudaMemcpyAsync(d_data, host_in, 1, cudaMemcpyHostToDevice, stream));
+    gpu_hash_kernel<<<1, 256, 0, stream>>>(d_data, d_gpu_hash, 1);
+    CUDA_CHECK(cudaMemcpyAsync(&gpu_hash, d_gpu_hash, sizeof(uint64_t),
+                               cudaMemcpyDeviceToHost, stream));
+    cudaStreamSynchronize(stream);
+    return;
+  }
+
+  CUDA_CHECK(cudaEventRecord(e_start, stream));
+  CUDA_CHECK(
+      cudaMemcpyAsync(d_data, host_in, n, cudaMemcpyHostToDevice, stream));
+
+  int blocks = (n + 255) / 256;
+  cast_uint8_to_int32_kernel<<<blocks, 256, 0, stream>>>(d_data, d_rank, n);
+
+  int k = 1;
+  int max_iter = (int)std::ceil(std::log2(n)) + 2;
+
+  cub::DoubleBuffer<uint64_t> d_keys_db(d_keys, d_keys_alt);
+  cub::DoubleBuffer<int> d_sa_db(d_sa, d_sa_alt);
+
+  // ASYNC SA DOUBLING WITH PINNED MEMORY EARLY EXIT CHECK
+  for (int iter = 0; iter < max_iter; iter++) {
+    sa_key_kernel<<<blocks, 256, 0, stream>>>(d_rank, d_sa_db.Current(),
+                                              d_keys_db.Current(), n, k);
+
+    size_t t_bytes = temp_storage_bytes;
+    cub::DeviceRadixSort::SortPairs(d_temp_storage, t_bytes, d_keys_db, d_sa_db,
+                                    n, 0, 64, stream);
+
+    sa_diff_kernel<<<blocks, 256, 0, stream>>>(d_keys_db.Current(), d_diff, n);
+
+    t_bytes = temp_storage_bytes;
+    cub::DeviceScan::InclusiveSum(d_temp_storage, t_bytes, d_diff,
+                                  d_unique_ranks, n, stream);
+
+    sa_rank_kernel<<<blocks, 256, 0, stream>>>(d_unique_ranks,
+                                               d_sa_db.Current(), d_rank, n);
+
+    // Asynchronous transfer to pinned memory + stream synchronization
+    CUDA_CHECK(cudaMemcpyAsync(host_last_rank, d_unique_ranks + n - 1,
+                               sizeof(int), cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+
+    if (*host_last_rank == n) {
+      break; // Early exit when Suffix Array is 100% sorted
+    }
+
+    k *= 2;
+  }
+
+  extract_bwt_kernel<<<blocks, 256, 0, stream>>>(d_sa_db.Current(), d_data,
+                                                 d_bwt, d_primary_idx, n);
+  CUDA_CHECK(cudaMemcpyAsync(&primary_idx, d_primary_idx, sizeof(int),
+                             cudaMemcpyDeviceToHost, stream));
+
+  num_chunks = (n + mini_chunk_size - 1) / mini_chunk_size;
+  int z_blocks = (num_chunks + threads_comp - 1) / threads_comp;
+
+  CUDA_CHECK(cudaMemsetAsync(d_hist, 0, 257 * sizeof(uint32_t), stream));
+
+  zrle_encode_kernel<<<z_blocks, threads_comp, threads_comp * 260, stream>>>(
+      d_bwt, d_out_symbols, d_chunk_sym_lens, n, mini_chunk_size, threads_comp);
+  compute_histogram_kernel<<<z_blocks, threads_comp, 0, stream>>>(
+      d_out_symbols, d_chunk_sym_lens, d_hist, num_chunks, mini_chunk_size);
+  build_tans_all_kernel<<<1, 257, 0, stream>>>(
+      d_hist, d_p, d_prefix_p, d_max_x, d_symbol_spread, d_enc_table,
+      d_dec_table, d_dec_symbol, d_next_state, L, 257);
+  tabled_encode_kernel<<<z_blocks, threads_comp, (L + 514) * sizeof(int),
+                         stream>>>(d_out_symbols, d_chunk_sym_lens, d_out_words,
+                                   d_chunk_bit_lens, d_p, d_prefix_p, d_max_x,
+                                   d_enc_table, num_chunks, mini_chunk_size,
+                                   max_words, L);
+
+  int c_blocks = (num_chunks + 255) / 256;
+  bit_to_word_kernel<<<c_blocks, 256, 0, stream>>>(
+      d_chunk_bit_lens, d_chunk_word_lens, num_chunks);
+
+  CUDA_CHECK(cudaMemsetAsync(d_word_offsets, 0, sizeof(uint32_t), stream));
+  size_t t_bytes = temp_storage_bytes;
+  cub::DeviceScan::InclusiveSum(d_temp_storage, t_bytes, d_chunk_word_lens,
+                                d_word_offsets + 1, num_chunks, stream);
+
+  uint32_t total_w = 0;
+  CUDA_CHECK(cudaMemcpyAsync(&total_w, d_word_offsets + num_chunks,
+                             sizeof(uint32_t), cudaMemcpyDeviceToHost, stream));
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+  total_words = (int)total_w;
+
+  uint32_t b_len_bits = num_chunks * 4;
+  uint32_t b_len_dec = L * 4;
+  uint32_t b_len_words = total_words * 8;
+  uint32_t header_total = 4 + b_len_bits + (b_len_dec * 2) + b_len_words;
+
+  if (header_total >= (uint32_t)n) {
+    is_raw = 1;
+    comp_size = n;
+    std::memcpy(host_out, host_in, n);
+    CUDA_CHECK(cudaMemsetAsync(d_gpu_hash, 0, sizeof(uint64_t), stream));
+    int hash_threads = 256;
+    int hash_blocks = ((n + 7) / 8 + hash_threads - 1) / hash_threads;
+    gpu_hash_kernel<<<hash_blocks, hash_threads, 0, stream>>>(d_data,
+                                                              d_gpu_hash, n);
+    CUDA_CHECK(cudaMemcpyAsync(&gpu_hash, d_gpu_hash, sizeof(uint64_t),
+                               cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaEventRecord(e_end, stream));
+    cudaStreamSynchronize(stream);
+    return;
+  }
+
+  if (num_chunks > 0) {
+    dense_pack_kernel<<<z_blocks, threads_comp, 0, stream>>>(
+        d_out_words, d_word_offsets, d_chunk_word_lens, d_dense_words,
+        num_chunks, max_words);
+  }
+
+  is_raw = 0;
+
+  uint32_t n_chunks_val = num_chunks;
+  CUDA_CHECK(cudaMemcpyAsync(d_payload, &n_chunks_val, 4,
+                             cudaMemcpyHostToDevice, stream));
+  int offset = 4;
+
+  if (b_len_bits > 0) {
+    CUDA_CHECK(cudaMemcpyAsync(d_payload + offset, d_chunk_bit_lens, b_len_bits,
+                               cudaMemcpyDeviceToDevice, stream));
+    offset += b_len_bits;
+  }
+  CUDA_CHECK(cudaMemcpyAsync(d_payload + offset, d_dec_table, b_len_dec,
+                             cudaMemcpyDeviceToDevice, stream));
+  offset += b_len_dec;
+  CUDA_CHECK(cudaMemcpyAsync(d_payload + offset, d_dec_symbol, b_len_dec,
+                             cudaMemcpyDeviceToDevice, stream));
+  offset += b_len_dec;
+
+  if (b_len_words > 0) {
+    CUDA_CHECK(cudaMemcpyAsync(d_payload + offset, d_dense_words, b_len_words,
+                               cudaMemcpyDeviceToDevice, stream));
+    offset += b_len_words;
+  }
+
+  comp_size = offset;
+
+  CUDA_CHECK(cudaMemsetAsync(d_gpu_hash, 0, sizeof(uint64_t), stream));
+  int hash_threads = 256;
+  int hash_blocks = ((comp_size + 7) / 8 + hash_threads - 1) / hash_threads;
+  gpu_hash_kernel<<<hash_blocks, hash_threads, 0, stream>>>(
+      d_payload, d_gpu_hash, comp_size);
+
+  CUDA_CHECK(cudaMemcpyAsync(host_out, d_payload, comp_size,
+                             cudaMemcpyDeviceToHost, stream));
+  CUDA_CHECK(cudaMemcpyAsync(&gpu_hash, d_gpu_hash, sizeof(uint64_t),
+                             cudaMemcpyDeviceToHost, stream));
+
+  CUDA_CHECK(cudaEventRecord(e_end, stream));
+  cudaStreamSynchronize(stream);
+}
+
+DecompressionContext::DecompressionContext(int macro_bytes, int mini_bytes,
+                                           int state_L) {
+  macro_size = macro_bytes;
+  mini_size = mini_bytes;
+  L = state_L;
+
+  max_chunks = (macro_size + mini_size - 1) / mini_size;
+  max_words = (int)(mini_size * 1.5 / 8) + 80;
+
+  size_t payload_alloc_size =
+      macro_size + (size_t)max_chunks * max_words * sizeof(uint64_t) + 65536;
+
+  CUDA_CHECK(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+
+  CUDA_CHECK(cudaMallocHost(&host_in, payload_alloc_size));
+  CUDA_CHECK(cudaMallocHost(&host_out, macro_size));
+  CUDA_CHECK(cudaMallocHost(&host_calc_hash, sizeof(uint64_t)));
+
+  // Pinned host scalars for async copy safety
+  CUDA_CHECK(cudaMallocHost(&host_uncomp_size, sizeof(int)));
+  CUDA_CHECK(cudaMallocHost(&host_primary_idx, sizeof(int)));
+
+  CUDA_CHECK(cudaMalloc(&d_data, macro_size));
+  CUDA_CHECK(cudaMalloc(&d_bwt, macro_size));
+  CUDA_CHECK(cudaMalloc(&d_keys, macro_size * sizeof(uint64_t)));
+  CUDA_CHECK(cudaMalloc(&d_keys_alt, macro_size * sizeof(uint64_t)));
+  CUDA_CHECK(cudaMalloc(&d_primary_idx, sizeof(int)));
+
+  CUDA_CHECK(cudaMalloc(&d_global_LF, macro_size * sizeof(int)));
+  CUDA_CHECK(cudaMalloc(&d_J_in, macro_size * sizeof(int)));
+  CUDA_CHECK(cudaMalloc(&d_D_in, macro_size * sizeof(int)));
+  CUDA_CHECK(cudaMalloc(&d_J_out, macro_size * sizeof(int)));
+  CUDA_CHECK(cudaMalloc(&d_D_out, macro_size * sizeof(int)));
+
+  CUDA_CHECK(cudaMalloc(&d_chunk_bit_lengths, max_chunks * sizeof(uint32_t)));
+  CUDA_CHECK(cudaMalloc(&d_chunk_word_lens, max_chunks * sizeof(uint32_t)));
+
+  size_t dec_bytes = L * sizeof(int) * 2;
+  CUDA_CHECK(cudaMalloc(&d_decoding_table, dec_bytes));
+  d_decoding_symbol = d_decoding_table + L;
+
+  CUDA_CHECK(cudaMalloc(&d_word_offsets, (max_chunks + 1) * sizeof(uint32_t)));
+  CUDA_CHECK(
+      cudaMalloc(&d_dense_words, max_chunks * max_words * sizeof(uint64_t)));
+
+  CUDA_CHECK(cudaMalloc(&d_offsets, sizeof(uint64_t)));
+  CUDA_CHECK(cudaMemsetAsync(d_offsets, 0, sizeof(uint64_t), stream));
+  CUDA_CHECK(cudaMalloc(&d_sizes, sizeof(int)));
+
+  CUDA_CHECK(cudaMalloc(&d_payload, payload_alloc_size));
+  CUDA_CHECK(cudaMalloc(&d_gpu_hash, sizeof(uint64_t)));
+
+  size_t sort_bytes = 0, scan_bytes = 0;
+  cub::DoubleBuffer<uint64_t> d_keys_db(d_keys, d_keys_alt);
+  cub::DoubleBuffer<int> d_sa_db(d_J_in, d_J_out);
+  cub::DeviceRadixSort::SortPairs(nullptr, sort_bytes, d_keys_db, d_sa_db,
+                                  macro_size, 0, 64, stream);
+  cub::DeviceScan::InclusiveSum(nullptr, scan_bytes, d_chunk_word_lens,
+                                d_word_offsets, max_chunks, stream);
+
+  temp_storage_bytes = std::max(sort_bytes, scan_bytes) + 65536;
+  CUDA_CHECK(cudaMalloc(&d_temp_storage, temp_storage_bytes));
+
+  // OPTIMIZATION FIX: Set-aside exactly dec_bytes (16 KB) rather than 32 MB!
+  CUDA_CHECK(cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, dec_bytes));
+
+  cudaStreamAttrValue attr;
+  std::memset(&attr, 0, sizeof(attr));
+  attr.accessPolicyWindow.base_ptr = (void *)d_decoding_table;
+  attr.accessPolicyWindow.num_bytes = dec_bytes;
+  attr.accessPolicyWindow.hitRatio = 1.0f; // 100% L2 Persistence Preference
+  attr.accessPolicyWindow.hitProp = cudaAccessPropertyPersisting;
+  attr.accessPolicyWindow.missProp = cudaAccessPropertyStreaming;
+
+  CUDA_CHECK(cudaStreamSetAttribute(
+      stream, cudaStreamAttributeAccessPolicyWindow, &attr));
+
+  // -------------------------------------------------------------------------
+  // PRE-CAPTURE: Inverse BWT CUDA Graph for full-size macro chunks
+  // Eliminates ~30 kernel launch overheads per decompression (~150-300us)
+  // -------------------------------------------------------------------------
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+  {
+    int blocks_u = (macro_size + 255) / 256;
+    int steps = (int)std::ceil(std::log2((double)macro_size));
+
+    *host_uncomp_size = macro_size;
+    *host_primary_idx = 0;
+
+    CUDA_CHECK(cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal));
+
+    CUDA_CHECK(cudaMemcpyAsync(d_sizes, host_uncomp_size, sizeof(int),
+                               cudaMemcpyHostToDevice, stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_primary_idx, host_primary_idx, sizeof(int),
+                               cudaMemcpyHostToDevice, stream));
+
+    dim3 grid_k(blocks_u, 1);
+    fill_key_kernel<<<grid_k, 256, 0, stream>>>(d_offsets, d_sizes, d_bwt,
+                                                d_keys, 1);
+    fill_sequence_kernel<<<blocks_u, 256, 0, stream>>>(d_J_in, macro_size);
+
+    cub::DoubleBuffer<uint64_t> keys_db(d_keys, d_keys_alt);
+    cub::DoubleBuffer<int> f_to_l_db(d_J_in, d_J_out);
+    size_t t_bytes = temp_storage_bytes;
+    cub::DeviceRadixSort::SortPairs(d_temp_storage, t_bytes, keys_db, f_to_l_db,
+                                    macro_size, 0, 64, stream);
+
+    build_lf_kernel<<<blocks_u, 256, 0, stream>>>(f_to_l_db.Current(),
+                                                  d_global_LF, macro_size);
+
+    dim3 grid_p(blocks_u, 1);
+    dim3 block_p(256, 1);
+    jump_init_kernel<<<grid_p, block_p, 0, stream>>>(
+        d_global_LF, d_primary_idx, d_offsets, d_sizes, d_J_in, d_D_in);
+
+    int *curr_J = d_J_in, *curr_D = d_D_in;
+    int *next_J = d_J_out, *next_D = d_D_out;
+    for (int s = 0; s < steps; s++) {
+      jump_step_kernel<<<grid_p, block_p, 0, stream>>>(
+          curr_J, curr_D, next_J, next_D, d_offsets, d_sizes);
+      std::swap(curr_J, next_J);
+      std::swap(curr_D, next_D);
+    }
+
+    jump_scatter_kernel<<<grid_p, block_p, 0, stream>>>(
+        curr_D, d_bwt, d_data, d_primary_idx, d_offsets, d_sizes);
+
+    CUDA_CHECK(cudaStreamEndCapture(stream, &graph));
+    CUDA_CHECK(cudaGraphInstantiateWithFlags(&graph_exec, graph, 0));
+  }
+
+  CUDA_CHECK(cudaEventCreate(&e_start));
+  CUDA_CHECK(cudaEventCreate(&e_end));
+}
+
+DecompressionContext::~DecompressionContext() {
+  if (stream) {
+    cudaStreamSynchronize(stream);
+  }
+
+  if (graph_exec) {
+    cudaGraphExecDestroy(graph_exec);
+    graph_exec = nullptr;
+  }
+  if (graph) {
+    cudaGraphDestroy(graph);
+    graph = nullptr;
+  }
+  if (stream) {
+    cudaStreamDestroy(stream);
+  }
+
+  cudaFreeHost(host_in);
+  cudaFreeHost(host_out);
+  cudaFreeHost(host_calc_hash);
+  cudaFreeHost(host_uncomp_size);
+  cudaFreeHost(host_primary_idx);
+
+  cudaFree(d_data);
+  cudaFree(d_bwt);
+  cudaFree(d_keys);
+  cudaFree(d_keys_alt);
+  cudaFree(d_primary_idx);
+  cudaFree(d_global_LF);
+  cudaFree(d_J_in);
+  cudaFree(d_D_in);
+  cudaFree(d_J_out);
+  cudaFree(d_D_out);
+  cudaFree(d_chunk_bit_lengths);
+  cudaFree(d_chunk_word_lens);
+  cudaFree(d_decoding_table);
+  cudaFree(d_word_offsets);
+  cudaFree(d_dense_words);
+  cudaFree(d_offsets);
+  cudaFree(d_sizes);
+  cudaFree(d_payload);
+  cudaFree(d_gpu_hash);
+  cudaFree(d_temp_storage);
+
+  cudaEventDestroy(e_start);
+  cudaEventDestroy(e_end);
+}
+
+bool DecompressionContext::decompress_chunk(int threads_decomp,
+                                            int mini_chunk_size) {
+  CUDA_CHECK(cudaEventRecord(e_start, stream));
+
+  CUDA_CHECK(cudaMemcpyAsync(d_payload, host_in, comp_size,
+                             cudaMemcpyHostToDevice, stream));
+  CUDA_CHECK(cudaMemsetAsync(d_gpu_hash, 0, sizeof(uint64_t), stream));
+
+  int hash_threads = 256;
+  int hash_blocks = ((comp_size + 7) / 8 + hash_threads - 1) / hash_threads;
+  gpu_hash_kernel<<<hash_blocks, hash_threads, 0, stream>>>(
+      d_payload, d_gpu_hash, comp_size);
+
+  CUDA_CHECK(cudaMemcpyAsync(host_calc_hash, d_gpu_hash, sizeof(uint64_t),
+                             cudaMemcpyDeviceToHost, stream));
+
+  if (is_raw == 1) {
+    CUDA_CHECK(cudaMemcpyAsync(d_data, d_payload, comp_size,
+                               cudaMemcpyDeviceToDevice, stream));
+  } else if (is_raw == 2) {
+    CUDA_CHECK(cudaMemsetAsync(d_data, host_in[0], uncomp_size, stream));
+  } else {
+    num_chunks = (uncomp_size + mini_chunk_size - 1) / mini_chunk_size;
+
+    int offset = 4;
+    int b_len_bits = num_chunks * 4;
+    if (b_len_bits > 0) {
+      CUDA_CHECK(cudaMemcpyAsync(d_chunk_bit_lengths, d_payload + offset,
+                                 b_len_bits, cudaMemcpyDeviceToDevice, stream));
+    }
+    offset += b_len_bits;
+
+    int b_len_dec = L * 4;
+    CUDA_CHECK(cudaMemcpyAsync(d_decoding_table, d_payload + offset, b_len_dec,
+                               cudaMemcpyDeviceToDevice, stream));
+    offset += b_len_dec;
+
+    CUDA_CHECK(cudaMemcpyAsync(d_decoding_symbol, d_payload + offset, b_len_dec,
+                               cudaMemcpyDeviceToDevice, stream));
+    offset += b_len_dec;
+
+    if (num_chunks > 0) {
+      int c_blocks = (num_chunks + 255) / 256;
+      bit_to_word_kernel<<<c_blocks, 256, 0, stream>>>(
+          d_chunk_bit_lengths, d_chunk_word_lens, num_chunks);
+
+      CUDA_CHECK(cudaMemsetAsync(d_word_offsets, 0, sizeof(uint32_t), stream));
+      size_t t_bytes = temp_storage_bytes;
+      cub::DeviceScan::InclusiveSum(d_temp_storage, t_bytes, d_chunk_word_lens,
+                                    d_word_offsets + 1, num_chunks, stream);
+
+      int header_bytes = 4 + b_len_bits + (2 * b_len_dec);
+      int b_len_words =
+          (comp_size > header_bytes) ? (comp_size - header_bytes) : 0;
+      if (b_len_words > 0) {
+        CUDA_CHECK(cudaMemcpyAsync(d_dense_words, d_payload + offset,
+                                   b_len_words, cudaMemcpyDeviceToDevice,
+                                   stream));
+      }
+
+      int blocks = (num_chunks + threads_decomp - 1) / threads_decomp;
+      // DYNAMIC SMEM SIZE: (2 * L * sizeof(int)) + (threads_decomp * 256 bytes)
+      // for alphabet
+      size_t smem_size = (2 * L * sizeof(int)) + (size_t)threads_decomp * 256;
+
+      if (smem_size > 49152) {
+        CUDA_CHECK(cudaFuncSetAttribute(
+            (const void *)tabled_decode_kernel,
+            cudaFuncAttributeMaxDynamicSharedMemorySize, (int)smem_size));
+      }
+
+      tabled_decode_kernel<<<blocks, threads_decomp, smem_size, stream>>>(
+          d_dense_words, d_word_offsets, d_chunk_bit_lengths, d_bwt,
+          d_decoding_table, d_decoding_symbol, uncomp_size, mini_chunk_size, L);
+    }
+  }
+
+  if (is_raw == 0) {
+    // Write scalars into pinned memory BEFORE graph launch reads them
+    *host_uncomp_size = uncomp_size;
+    *host_primary_idx = primary_idx;
+
+    if (uncomp_size == macro_size && graph_exec) {
+      // CUDA GRAPH FAST PATH: Replay pre-captured inverse BWT graph
+      CUDA_CHECK(cudaGraphLaunch(graph_exec, stream));
+    } else {
+      // FALLBACK PATH: Inline launches for partial/last macro chunk
+      CUDA_CHECK(cudaMemcpyAsync(d_sizes, host_uncomp_size, sizeof(int),
+                                 cudaMemcpyHostToDevice, stream));
+      CUDA_CHECK(cudaMemcpyAsync(d_primary_idx, host_primary_idx, sizeof(int),
+                                 cudaMemcpyHostToDevice, stream));
+
+      int blocks_u = (uncomp_size + 255) / 256;
+
+      dim3 grid_k(blocks_u, 1);
+      fill_key_kernel<<<grid_k, 256, 0, stream>>>(d_offsets, d_sizes, d_bwt,
+                                                  d_keys, 1);
+      fill_sequence_kernel<<<blocks_u, 256, 0, stream>>>(d_J_in, uncomp_size);
+
+      cub::DoubleBuffer<uint64_t> keys_db(d_keys, d_keys_alt);
+      cub::DoubleBuffer<int> f_to_l_db(d_J_in, d_J_out);
+      size_t t_bytes = temp_storage_bytes;
+      cub::DeviceRadixSort::SortPairs(d_temp_storage, t_bytes, keys_db,
+                                      f_to_l_db, uncomp_size, 0, 64, stream);
+
+      build_lf_kernel<<<blocks_u, 256, 0, stream>>>(f_to_l_db.Current(),
+                                                    d_global_LF, uncomp_size);
+
+      dim3 grid_p(blocks_u, 1);
+      dim3 block_p(256, 1);
+      jump_init_kernel<<<grid_p, block_p, 0, stream>>>(
+          d_global_LF, d_primary_idx, d_offsets, d_sizes, d_J_in, d_D_in);
+
+      int *curr_J = d_J_in, *curr_D = d_D_in;
+      int *next_J = d_J_out, *next_D = d_D_out;
+      int steps = (int)std::ceil(std::log2(uncomp_size));
+
+      for (int s = 0; s < steps; s++) {
+        jump_step_kernel<<<grid_p, block_p, 0, stream>>>(
+            curr_J, curr_D, next_J, next_D, d_offsets, d_sizes);
+        std::swap(curr_J, next_J);
+        std::swap(curr_D, next_D);
+      }
+
+      jump_scatter_kernel<<<grid_p, block_p, 0, stream>>>(
+          curr_D, d_bwt, d_data, d_primary_idx, d_offsets, d_sizes);
+    }
+  }
+
+  CUDA_CHECK(cudaMemcpyAsync(host_out, d_data, uncomp_size,
+                             cudaMemcpyDeviceToHost, stream));
+  CUDA_CHECK(cudaEventRecord(e_end, stream));
+  return true;
+}

--- a/lz/gpucompact/context.cu
+++ b/lz/gpucompact/context.cu
@@ -28,9 +28,10 @@
   do {                                                                         \
     cudaError_t err = call;                                                    \
     if (err != cudaSuccess) {                                                  \
-      std::cerr << "CUDA Error: " << cudaGetErrorString(err) << " at "         \
-                << __FILE__ << ":" << __LINE__ << std::endl;                   \
-      exit(1);                                                                 \
+      std::string msg = std::string("CUDA Error: ") + cudaGetErrorString(err)  \
+                        + " at " + __FILE__ + ":" + std::to_string(__LINE__); \
+      std::cerr << msg << std::endl;                                           \
+      throw std::runtime_error(msg);                                          \
     }                                                                          \
   } while (0)
 
@@ -151,36 +152,13 @@ void CompressionContext::compress_chunk(int threads_comp, int mini_chunk_size) {
     is_raw = 1;
     comp_size = n;
     std::memcpy(host_out, host_in, n);
-    CUDA_CHECK(cudaMemsetAsync(d_gpu_hash, 0, sizeof(uint64_t), stream));
-    CUDA_CHECK(cudaMemcpyAsync(d_data, host_in, std::max(1, n),
-                               cudaMemcpyHostToDevice, stream));
-    gpu_hash_kernel<<<1, 256, 0, stream>>>(d_data, d_gpu_hash, std::max(1, n));
-    CUDA_CHECK(cudaMemcpyAsync(&gpu_hash, d_gpu_hash, sizeof(uint64_t),
-                               cudaMemcpyDeviceToHost, stream));
-    cudaStreamSynchronize(stream);
     return;
   }
 
-  bool all_equal = true;
-  uint8_t first_byte = host_in[0];
-  for (int i = 1; i < n; i++) {
-    if (host_in[i] != first_byte) {
-      all_equal = false;
-      break;
-    }
-  }
-
-  if (all_equal) {
+  if (std::memcmp(host_in, host_in + 1, n - 1) == 0) {
     is_raw = 2;
     comp_size = 1;
     host_out[0] = host_in[0];
-    CUDA_CHECK(cudaMemsetAsync(d_gpu_hash, 0, sizeof(uint64_t), stream));
-    CUDA_CHECK(
-        cudaMemcpyAsync(d_data, host_in, 1, cudaMemcpyHostToDevice, stream));
-    gpu_hash_kernel<<<1, 256, 0, stream>>>(d_data, d_gpu_hash, 1);
-    CUDA_CHECK(cudaMemcpyAsync(&gpu_hash, d_gpu_hash, sizeof(uint64_t),
-                               cudaMemcpyDeviceToHost, stream));
-    cudaStreamSynchronize(stream);
     return;
   }
 
@@ -225,6 +203,15 @@ void CompressionContext::compress_chunk(int threads_comp, int mini_chunk_size) {
     }
 
     k *= 2;
+  }
+
+  if (*host_last_rank < n) {
+    // Input is strictly periodic (period P < n), so suffix ranks cannot be unique.
+    // Inverse BWT pointer jumping requires a single cycle of length n, so fall back to raw mode.
+    is_raw = 1;
+    comp_size = n;
+    std::memcpy(host_out, host_in, n);
+    return;
   }
 
   extract_bwt_kernel<<<blocks, 256, 0, stream>>>(d_sa_db.Current(), d_data,
@@ -274,13 +261,6 @@ void CompressionContext::compress_chunk(int threads_comp, int mini_chunk_size) {
     is_raw = 1;
     comp_size = n;
     std::memcpy(host_out, host_in, n);
-    CUDA_CHECK(cudaMemsetAsync(d_gpu_hash, 0, sizeof(uint64_t), stream));
-    int hash_threads = 256;
-    int hash_blocks = ((n + 7) / 8 + hash_threads - 1) / hash_threads;
-    gpu_hash_kernel<<<hash_blocks, hash_threads, 0, stream>>>(d_data,
-                                                              d_gpu_hash, n);
-    CUDA_CHECK(cudaMemcpyAsync(&gpu_hash, d_gpu_hash, sizeof(uint64_t),
-                               cudaMemcpyDeviceToHost, stream));
     CUDA_CHECK(cudaEventRecord(e_end, stream));
     cudaStreamSynchronize(stream);
     return;
@@ -319,15 +299,7 @@ void CompressionContext::compress_chunk(int threads_comp, int mini_chunk_size) {
 
   comp_size = offset;
 
-  CUDA_CHECK(cudaMemsetAsync(d_gpu_hash, 0, sizeof(uint64_t), stream));
-  int hash_threads = 256;
-  int hash_blocks = ((comp_size + 7) / 8 + hash_threads - 1) / hash_threads;
-  gpu_hash_kernel<<<hash_blocks, hash_threads, 0, stream>>>(
-      d_payload, d_gpu_hash, comp_size);
-
   CUDA_CHECK(cudaMemcpyAsync(host_out, d_payload, comp_size,
-                             cudaMemcpyDeviceToHost, stream));
-  CUDA_CHECK(cudaMemcpyAsync(&gpu_hash, d_gpu_hash, sizeof(uint64_t),
                              cudaMemcpyDeviceToHost, stream));
 
   CUDA_CHECK(cudaEventRecord(e_end, stream));
@@ -397,19 +369,24 @@ DecompressionContext::DecompressionContext(int macro_bytes, int mini_bytes,
   temp_storage_bytes = std::max(sort_bytes, scan_bytes) + 65536;
   CUDA_CHECK(cudaMalloc(&d_temp_storage, temp_storage_bytes));
 
-  // OPTIMIZATION FIX: Set-aside exactly dec_bytes (16 KB) rather than 32 MB!
-  CUDA_CHECK(cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, dec_bytes));
-
-  cudaStreamAttrValue attr;
-  std::memset(&attr, 0, sizeof(attr));
-  attr.accessPolicyWindow.base_ptr = (void *)d_decoding_table;
-  attr.accessPolicyWindow.num_bytes = dec_bytes;
-  attr.accessPolicyWindow.hitRatio = 1.0f; // 100% L2 Persistence Preference
-  attr.accessPolicyWindow.hitProp = cudaAccessPropertyPersisting;
-  attr.accessPolicyWindow.missProp = cudaAccessPropertyStreaming;
-
-  CUDA_CHECK(cudaStreamSetAttribute(
-      stream, cudaStreamAttributeAccessPolicyWindow, &attr));
+#if CUDART_VERSION >= 11000
+  if (cudaDeviceGetLimit(&orig_l2_limit, cudaLimitPersistingL2CacheSize) == cudaSuccess &&
+      cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, dec_bytes) == cudaSuccess) {
+    l2_modified = true;
+    cudaStreamAttrValue attr;
+    std::memset(&attr, 0, sizeof(attr));
+    attr.accessPolicyWindow.base_ptr = (void *)d_decoding_table;
+    attr.accessPolicyWindow.num_bytes = dec_bytes;
+    attr.accessPolicyWindow.hitRatio = 1.0f; // 100% L2 Persistence Preference
+    attr.accessPolicyWindow.hitProp = cudaAccessPropertyPersisting;
+    attr.accessPolicyWindow.missProp = cudaAccessPropertyStreaming;
+    if (cudaStreamSetAttribute(stream, cudaStreamAttributeAccessPolicyWindow, &attr) != cudaSuccess) {
+      cudaGetLastError();
+    }
+  } else {
+    cudaGetLastError();
+  }
+#endif
 
   // -------------------------------------------------------------------------
   // PRE-CAPTURE: Inverse BWT CUDA Graph for full-size macro chunks
@@ -462,7 +439,11 @@ DecompressionContext::DecompressionContext(int macro_bytes, int mini_bytes,
         curr_D, d_bwt, d_data, d_primary_idx, d_offsets, d_sizes);
 
     CUDA_CHECK(cudaStreamEndCapture(stream, &graph));
+#if CUDART_VERSION >= 11040
     CUDA_CHECK(cudaGraphInstantiateWithFlags(&graph_exec, graph, 0));
+#else
+    CUDA_CHECK(cudaGraphInstantiate(&graph_exec, graph, nullptr, nullptr, 0));
+#endif
   }
 
   CUDA_CHECK(cudaEventCreate(&e_start));
@@ -473,6 +454,13 @@ DecompressionContext::~DecompressionContext() {
   if (stream) {
     cudaStreamSynchronize(stream);
   }
+
+#if CUDART_VERSION >= 11000
+  if (l2_modified) {
+    cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, orig_l2_limit);
+    cudaGetLastError();
+  }
+#endif
 
   if (graph_exec) {
     cudaGraphExecDestroy(graph_exec);
@@ -519,19 +507,14 @@ DecompressionContext::~DecompressionContext() {
 
 bool DecompressionContext::decompress_chunk(int threads_decomp,
                                             int mini_chunk_size) {
+  if (comp_size <= 0 || uncomp_size <= 0 || uncomp_size > macro_size) {
+    return false;
+  }
+
   CUDA_CHECK(cudaEventRecord(e_start, stream));
 
   CUDA_CHECK(cudaMemcpyAsync(d_payload, host_in, comp_size,
                              cudaMemcpyHostToDevice, stream));
-  CUDA_CHECK(cudaMemsetAsync(d_gpu_hash, 0, sizeof(uint64_t), stream));
-
-  int hash_threads = 256;
-  int hash_blocks = ((comp_size + 7) / 8 + hash_threads - 1) / hash_threads;
-  gpu_hash_kernel<<<hash_blocks, hash_threads, 0, stream>>>(
-      d_payload, d_gpu_hash, comp_size);
-
-  CUDA_CHECK(cudaMemcpyAsync(host_calc_hash, d_gpu_hash, sizeof(uint64_t),
-                             cudaMemcpyDeviceToHost, stream));
 
   if (is_raw == 1) {
     CUDA_CHECK(cudaMemcpyAsync(d_data, d_payload, comp_size,

--- a/lz/gpucompact/context.cu
+++ b/lz/gpucompact/context.cu
@@ -86,6 +86,8 @@ CompressionContext::CompressionContext(int macro_bytes, int mini_bytes,
 
   CUDA_CHECK(cudaMalloc(&d_payload, payload_alloc_size));
   CUDA_CHECK(cudaMalloc(&d_gpu_hash, sizeof(uint64_t)));
+  CUDA_CHECK(cudaMalloc(&d_overflow_flag, sizeof(uint32_t)));
+  CUDA_CHECK(cudaMallocHost(&host_overflow_flag, sizeof(uint32_t)));
 
   size_t sort_bytes = 0, scan_bytes = 0;
   cub::DoubleBuffer<uint64_t> d_keys_db(d_keys, d_keys_alt);
@@ -138,6 +140,8 @@ CompressionContext::~CompressionContext() {
   cudaFree(d_dense_words);
   cudaFree(d_payload);
   cudaFree(d_gpu_hash);
+  cudaFree(d_overflow_flag);
+  cudaFreeHost(host_overflow_flag);
   cudaFree(d_temp_storage);
 
   cudaEventDestroy(e_start);
@@ -231,11 +235,24 @@ void CompressionContext::compress_chunk(int threads_comp, int mini_chunk_size) {
   build_tans_all_kernel<<<1, 257, 0, stream>>>(
       d_hist, d_p, d_prefix_p, d_max_x, d_symbol_spread, d_enc_table,
       d_dec_table, d_dec_symbol, d_next_state, L, 257);
+  CUDA_CHECK(cudaMemsetAsync(d_overflow_flag, 0, sizeof(uint32_t), stream));
   tabled_encode_kernel<<<z_blocks, threads_comp, (L + 514) * sizeof(int),
                          stream>>>(d_out_symbols, d_chunk_sym_lens, d_out_words,
                                    d_chunk_bit_lens, d_p, d_prefix_p, d_max_x,
                                    d_enc_table, num_chunks, mini_chunk_size,
-                                   max_words, L);
+                                   max_words, L, d_overflow_flag);
+  CUDA_CHECK(cudaMemcpyAsync(host_overflow_flag, d_overflow_flag,
+                             sizeof(uint32_t), cudaMemcpyDeviceToHost, stream));
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+
+  if (*host_overflow_flag != 0) {
+    is_raw = 1;
+    comp_size = n;
+    std::memcpy(host_out, host_in, n);
+    CUDA_CHECK(cudaEventRecord(e_end, stream));
+    cudaStreamSynchronize(stream);
+    return;
+  }
 
   int c_blocks = (num_chunks + 255) / 256;
   bit_to_word_kernel<<<c_blocks, 256, 0, stream>>>(

--- a/lz/gpucompact/context.cuh
+++ b/lz/gpucompact/context.cuh
@@ -1,0 +1,156 @@
+/*
+ * GPUCompact
+ * Copyright (C) 2026 UDPSendToFailed
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+#include <cstdint>
+#include <cuda_runtime.h>
+
+struct LaunchConfig {
+  int macro_mb = 4;
+  int mini_size = 1024;
+  int L = 2048;
+  int threads_comp = 32;
+  int threads_decomp = 128;
+};
+
+class CompressionContext {
+public:
+  int macro_size;
+  int mini_size;
+  int L;
+  int max_chunks;
+  int max_words;
+
+  cudaStream_t stream = nullptr;
+
+  unsigned char *host_in = nullptr;
+  unsigned char *host_out = nullptr;
+  int *host_last_rank = nullptr;
+
+  uint8_t *d_data = nullptr;
+  int *d_rank = nullptr;
+  int *d_sa = nullptr;
+  int *d_sa_alt = nullptr;
+  uint64_t *d_keys = nullptr;
+  uint64_t *d_keys_alt = nullptr;
+  int *d_diff = nullptr;
+  int *d_unique_ranks = nullptr;
+  uint8_t *d_bwt = nullptr;
+  int *d_primary_idx = nullptr;
+
+  uint16_t *d_out_symbols = nullptr;
+  uint32_t *d_chunk_sym_lens = nullptr;
+  uint32_t *d_hist = nullptr;
+  int *d_p = nullptr;
+  int *d_prefix_p = nullptr;
+  int *d_max_x = nullptr;
+  int *d_symbol_spread = nullptr;
+  int *d_enc_table = nullptr;
+  int *d_dec_table = nullptr;
+  int *d_dec_symbol = nullptr;
+  int *d_next_state = nullptr;
+  uint64_t *d_out_words = nullptr;
+  uint32_t *d_chunk_bit_lens = nullptr;
+  uint32_t *d_chunk_word_lens = nullptr;
+  uint32_t *d_word_offsets = nullptr;
+  uint64_t *d_dense_words = nullptr;
+
+  uint8_t *d_payload = nullptr;
+  uint64_t *d_gpu_hash = nullptr;
+
+  void *d_temp_storage = nullptr;
+  size_t temp_storage_bytes = 0;
+
+  cudaEvent_t e_start = nullptr, e_end = nullptr;
+
+  int bytes_read = 0;
+  int is_raw = 0;
+  int num_chunks = 0;
+  int total_words = 0;
+  int primary_idx = 0;
+  uint64_t gpu_hash = 0;
+  int comp_size = 0;
+
+  CompressionContext(int macro_bytes, int mini_bytes, int state_L);
+  ~CompressionContext();
+
+  void compress_chunk(int threads_comp, int mini_chunk_size);
+};
+
+class DecompressionContext {
+public:
+  int macro_size;
+  int mini_size;
+  int L;
+  int max_chunks;
+  int max_words;
+
+  cudaStream_t stream = nullptr;
+  cudaEvent_t e_start = nullptr, e_end = nullptr;
+
+  cudaGraph_t graph = nullptr;
+  cudaGraphExec_t graph_exec = nullptr;
+
+  unsigned char *host_in = nullptr;
+  unsigned char *host_out = nullptr;
+  uint64_t *host_calc_hash = nullptr;
+
+  // Pinned Host Buffers for Async Copy Safety
+  int *host_uncomp_size = nullptr;
+  int *host_primary_idx = nullptr;
+
+  uint8_t *d_data = nullptr;
+  uint8_t *d_bwt = nullptr;
+  uint64_t *d_keys = nullptr;
+  uint64_t *d_keys_alt = nullptr;
+  int *d_primary_idx = nullptr;
+
+  int *d_global_LF = nullptr;
+  int *d_J_in = nullptr;
+  int *d_D_in = nullptr;
+  int *d_J_out = nullptr;
+  int *d_D_out = nullptr;
+
+  uint32_t *d_chunk_bit_lengths = nullptr;
+  uint32_t *d_chunk_word_lens = nullptr;
+  int *d_decoding_table = nullptr;
+  int *d_decoding_symbol = nullptr;
+  uint32_t *d_word_offsets = nullptr;
+  uint64_t *d_dense_words = nullptr;
+
+  uint64_t *d_offsets = nullptr;
+  int *d_sizes = nullptr;
+
+  uint8_t *d_payload = nullptr;
+  uint64_t *d_gpu_hash = nullptr;
+
+  void *d_temp_storage = nullptr;
+  size_t temp_storage_bytes = 0;
+
+  int comp_size = 0;
+  int uncomp_size = 0;
+  int is_raw = 0;
+  int num_chunks = 0;
+  int total_words = 0;
+  int primary_idx = 0;
+  uint64_t gpu_hash = 0;
+
+  DecompressionContext(int macro_bytes, int mini_bytes, int state_L);
+  ~DecompressionContext();
+
+  bool decompress_chunk(int threads_decomp, int mini_chunk_size);
+};

--- a/lz/gpucompact/context.cuh
+++ b/lz/gpucompact/context.cuh
@@ -148,6 +148,8 @@ public:
   int total_words = 0;
   int primary_idx = 0;
   uint64_t gpu_hash = 0;
+  size_t orig_l2_limit = 0;
+  bool l2_modified = false;
 
   DecompressionContext(int macro_bytes, int mini_bytes, int state_L);
   ~DecompressionContext();

--- a/lz/gpucompact/context.cuh
+++ b/lz/gpucompact/context.cuh
@@ -71,6 +71,9 @@ public:
 
   uint8_t *d_payload = nullptr;
   uint64_t *d_gpu_hash = nullptr;
+  uint32_t *d_overflow_flag = nullptr;
+
+  uint32_t *host_overflow_flag = nullptr;
 
   void *d_temp_storage = nullptr;
   size_t temp_storage_bytes = 0;

--- a/lz/gpucompact/gpucompact_lzbench.cpp
+++ b/lz/gpucompact/gpucompact_lzbench.cpp
@@ -19,7 +19,6 @@ struct GpucompactChunkHeader {
   uint32_t primary_idx;
   uint8_t is_raw;
   uint8_t reserved[3];
-  uint64_t gpu_hash;
 };
 #pragma pack(pop)
 
@@ -31,7 +30,6 @@ struct GpucompactState {
 };
 
 char *lzbench_gpucompact_init(size_t insize, size_t level, size_t threads) {
-  (void)insize;
   (void)threads;
   int device_count = 0;
   if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
@@ -75,7 +73,12 @@ char *lzbench_gpucompact_init(size_t insize, size_t level, size_t threads) {
     state->config.threads_decomp = 128;
   }
 
-  state->macro_bytes = (size_t)state->config.macro_mb * 1024 * 1024;
+  size_t full_macro = (size_t)state->config.macro_mb * 1024 * 1024;
+  if (insize > 0) {
+    state->macro_bytes = std::min(full_macro, std::max((size_t)65536, insize));
+  } else {
+    state->macro_bytes = full_macro;
+  }
 
   try {
     state->comp_ctx = new CompressionContext(
@@ -99,7 +102,6 @@ char *lzbench_gpucompact_init(size_t insize, size_t level, size_t threads) {
     state->decomp_ctx->primary_idx = state->comp_ctx->primary_idx;
     state->decomp_ctx->num_chunks = state->comp_ctx->num_chunks;
     state->decomp_ctx->total_words = state->comp_ctx->total_words;
-    state->decomp_ctx->gpu_hash = state->comp_ctx->gpu_hash;
 
     std::memcpy(state->decomp_ctx->host_in, state->comp_ctx->host_out,
                 state->comp_ctx->comp_size);
@@ -138,44 +140,47 @@ int64_t lzbench_gpucompact_compress(char *inbuf, size_t insize, char *outbuf,
   GpucompactState *state = (GpucompactState *)codec_options->work_mem;
   CompressionContext *ctx = state->comp_ctx;
 
-  size_t in_offset = 0;
-  size_t out_offset = 0;
+  try {
+    size_t in_offset = 0;
+    size_t out_offset = 0;
 
-  while (in_offset < insize) {
-    size_t chunk_in_size = std::min(insize - in_offset, state->macro_bytes);
+    while (in_offset < insize) {
+      size_t chunk_in_size = std::min(insize - in_offset, state->macro_bytes);
 
-    if (out_offset + sizeof(GpucompactChunkHeader) > outsize) {
-      return 0;
+      if (out_offset + sizeof(GpucompactChunkHeader) > outsize) {
+        return 0;
+      }
+
+      std::memcpy(ctx->host_in, inbuf + in_offset, chunk_in_size);
+      ctx->bytes_read = (int)chunk_in_size;
+
+      ctx->compress_chunk(state->config.threads_comp, state->config.mini_size);
+      cudaDeviceSynchronize();
+
+      if (out_offset + sizeof(GpucompactChunkHeader) + ctx->comp_size > outsize) {
+        return 0;
+      }
+
+      GpucompactChunkHeader header;
+      header.comp_size = (uint32_t)ctx->comp_size;
+      header.uncomp_size = (uint32_t)chunk_in_size;
+      header.primary_idx = (uint32_t)ctx->primary_idx;
+      header.is_raw = (uint8_t)ctx->is_raw;
+      std::memset(header.reserved, 0, sizeof(header.reserved));
+
+      std::memcpy(outbuf + out_offset, &header, sizeof(GpucompactChunkHeader));
+      out_offset += sizeof(GpucompactChunkHeader);
+
+      std::memcpy(outbuf + out_offset, ctx->host_out, ctx->comp_size);
+      out_offset += ctx->comp_size;
+
+      in_offset += chunk_in_size;
     }
 
-    std::memcpy(ctx->host_in, inbuf + in_offset, chunk_in_size);
-    ctx->bytes_read = (int)chunk_in_size;
-
-    ctx->compress_chunk(state->config.threads_comp, state->config.mini_size);
-    cudaDeviceSynchronize();
-
-    if (out_offset + sizeof(GpucompactChunkHeader) + ctx->comp_size > outsize) {
-      return 0;
-    }
-
-    GpucompactChunkHeader header;
-    header.comp_size = (uint32_t)ctx->comp_size;
-    header.uncomp_size = (uint32_t)chunk_in_size;
-    header.primary_idx = (uint32_t)ctx->primary_idx;
-    header.is_raw = (uint8_t)ctx->is_raw;
-    std::memset(header.reserved, 0, sizeof(header.reserved));
-    header.gpu_hash = ctx->gpu_hash;
-
-    std::memcpy(outbuf + out_offset, &header, sizeof(GpucompactChunkHeader));
-    out_offset += sizeof(GpucompactChunkHeader);
-
-    std::memcpy(outbuf + out_offset, ctx->host_out, ctx->comp_size);
-    out_offset += ctx->comp_size;
-
-    in_offset += chunk_in_size;
+    return (int64_t)out_offset;
+  } catch (...) {
+    return 0;
   }
-
-  return (int64_t)out_offset;
 }
 
 int64_t lzbench_gpucompact_decompress(char *inbuf, size_t insize, char *outbuf,
@@ -186,47 +191,50 @@ int64_t lzbench_gpucompact_decompress(char *inbuf, size_t insize, char *outbuf,
   GpucompactState *state = (GpucompactState *)codec_options->work_mem;
   DecompressionContext *ctx = state->decomp_ctx;
 
-  size_t in_offset = 0;
-  size_t out_offset = 0;
+  try {
+    size_t in_offset = 0;
+    size_t out_offset = 0;
 
-  while (in_offset < insize) {
-    if (in_offset + sizeof(GpucompactChunkHeader) > insize) {
-      return 0;
+    while (in_offset < insize) {
+      if (in_offset + sizeof(GpucompactChunkHeader) > insize) {
+        return 0;
+      }
+
+      GpucompactChunkHeader header;
+      std::memcpy(&header, inbuf + in_offset, sizeof(GpucompactChunkHeader));
+      in_offset += sizeof(GpucompactChunkHeader);
+
+      if (in_offset + header.comp_size > insize) {
+        return 0;
+      }
+
+      if (out_offset + header.uncomp_size > outsize) {
+        return 0;
+      }
+
+      std::memcpy(ctx->host_in, inbuf + in_offset, header.comp_size);
+      ctx->comp_size = (int)header.comp_size;
+      ctx->uncomp_size = (int)header.uncomp_size;
+      ctx->primary_idx = (int)header.primary_idx;
+      ctx->is_raw = (int)header.is_raw;
+
+      cudaDeviceSynchronize();
+
+      if (!ctx->decompress_chunk(state->config.threads_decomp,
+                                 state->config.mini_size)) {
+        return 0;
+      }
+      cudaDeviceSynchronize();
+
+      std::memcpy(outbuf + out_offset, ctx->host_out, header.uncomp_size);
+      out_offset += header.uncomp_size;
+      in_offset += header.comp_size;
     }
 
-    GpucompactChunkHeader header;
-    std::memcpy(&header, inbuf + in_offset, sizeof(GpucompactChunkHeader));
-    in_offset += sizeof(GpucompactChunkHeader);
-
-    if (in_offset + header.comp_size > insize) {
-      return 0;
-    }
-
-    if (out_offset + header.uncomp_size > outsize) {
-      return 0;
-    }
-
-    std::memcpy(ctx->host_in, inbuf + in_offset, header.comp_size);
-    ctx->comp_size = (int)header.comp_size;
-    ctx->uncomp_size = (int)header.uncomp_size;
-    ctx->primary_idx = (int)header.primary_idx;
-    ctx->is_raw = (int)header.is_raw;
-    ctx->gpu_hash = header.gpu_hash;
-
-    cudaDeviceSynchronize();
-
-    if (!ctx->decompress_chunk(state->config.threads_decomp,
-                               state->config.mini_size)) {
-      return 0;
-    }
-    cudaDeviceSynchronize();
-
-    std::memcpy(outbuf + out_offset, ctx->host_out, header.uncomp_size);
-    out_offset += header.uncomp_size;
-    in_offset += header.comp_size;
+    return (int64_t)out_offset;
+  } catch (...) {
+    return 0;
   }
-
-  return (int64_t)out_offset;
 }
 
 #endif // BENCH_HAS_CUDA

--- a/lz/gpucompact/gpucompact_lzbench.cpp
+++ b/lz/gpucompact/gpucompact_lzbench.cpp
@@ -1,0 +1,233 @@
+/*
+ * GPUCompact
+ * lzbench glue wrapper
+ */
+#ifndef BENCH_REMOVE_GPUCOMPACT
+#ifdef BENCH_HAS_CUDA
+#include "bench/codecs.h"
+#include "context.cuh"
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <new>
+
+#pragma pack(push, 1)
+struct GpucompactChunkHeader {
+  uint32_t comp_size;
+  uint32_t uncomp_size;
+  uint32_t primary_idx;
+  uint8_t is_raw;
+  uint8_t reserved[3];
+  uint64_t gpu_hash;
+};
+#pragma pack(pop)
+
+struct GpucompactState {
+  CompressionContext *comp_ctx = nullptr;
+  DecompressionContext *decomp_ctx = nullptr;
+  LaunchConfig config;
+  size_t macro_bytes = 0;
+};
+
+char *lzbench_gpucompact_init(size_t insize, size_t level, size_t threads) {
+  (void)insize;
+  (void)threads;
+  int device_count = 0;
+  if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+    fprintf(stderr, "gpucompact: no CUDA device available\n");
+    return NULL;
+  }
+
+  GpucompactState *state = new (std::nothrow) GpucompactState();
+  if (!state)
+    return NULL;
+
+  if (level == 1) { // best_speed
+    state->config.macro_mb = 4;
+    state->config.mini_size = 256;
+    state->config.L = 512;
+    state->config.threads_comp = 32;
+    state->config.threads_decomp = 32;
+  } else if (level == 2) { // speed
+    state->config.macro_mb = 4;
+    state->config.mini_size = 512;
+    state->config.L = 512;
+    state->config.threads_comp = 32;
+    state->config.threads_decomp = 32;
+  } else if (level == 3) { // balanced
+    state->config.macro_mb = 4;
+    state->config.mini_size = 512;
+    state->config.L = 1024;
+    state->config.threads_comp = 32;
+    state->config.threads_decomp = 64;
+  } else if (level == 4) { // ratio
+    state->config.macro_mb = 4;
+    state->config.mini_size = 2048;
+    state->config.L = 2048;
+    state->config.threads_comp = 32;
+    state->config.threads_decomp = 64;
+  } else { // best_ratio (level >= 5)
+    state->config.macro_mb = 8;
+    state->config.mini_size = 8192;
+    state->config.L = 2048;
+    state->config.threads_comp = 32;
+    state->config.threads_decomp = 128;
+  }
+
+  state->macro_bytes = (size_t)state->config.macro_mb * 1024 * 1024;
+
+  try {
+    state->comp_ctx = new CompressionContext(
+        state->macro_bytes, state->config.mini_size, state->config.L);
+    state->decomp_ctx = new DecompressionContext(
+        state->macro_bytes, state->config.mini_size, state->config.L);
+
+    // Warmup CUDA context, streams, CUB kernels & CUDA graph (matching
+    // benchmark.cpp)
+    int dummy_n = (int)std::min((size_t)1024 * 1024, state->macro_bytes);
+    for (int i = 0; i < dummy_n; i++)
+      state->comp_ctx->host_in[i] = (unsigned char)(i % 255);
+    state->comp_ctx->bytes_read = dummy_n;
+    state->comp_ctx->compress_chunk(state->config.threads_comp,
+                                    state->config.mini_size);
+    cudaDeviceSynchronize();
+
+    state->decomp_ctx->uncomp_size = dummy_n;
+    state->decomp_ctx->comp_size = state->comp_ctx->comp_size;
+    state->decomp_ctx->is_raw = state->comp_ctx->is_raw;
+    state->decomp_ctx->primary_idx = state->comp_ctx->primary_idx;
+    state->decomp_ctx->num_chunks = state->comp_ctx->num_chunks;
+    state->decomp_ctx->total_words = state->comp_ctx->total_words;
+    state->decomp_ctx->gpu_hash = state->comp_ctx->gpu_hash;
+
+    std::memcpy(state->decomp_ctx->host_in, state->comp_ctx->host_out,
+                state->comp_ctx->comp_size);
+    state->decomp_ctx->decompress_chunk(state->config.threads_decomp,
+                                        state->config.mini_size);
+    cudaDeviceSynchronize();
+
+  } catch (...) {
+    if (state->comp_ctx)
+      delete state->comp_ctx;
+    if (state->decomp_ctx)
+      delete state->decomp_ctx;
+    delete state;
+    return NULL;
+  }
+
+  return (char *)state;
+}
+
+void lzbench_gpucompact_deinit(char *workmem) {
+  if (!workmem)
+    return;
+  GpucompactState *state = (GpucompactState *)workmem;
+  if (state->comp_ctx)
+    delete state->comp_ctx;
+  if (state->decomp_ctx)
+    delete state->decomp_ctx;
+  delete state;
+}
+
+int64_t lzbench_gpucompact_compress(char *inbuf, size_t insize, char *outbuf,
+                                    size_t outsize,
+                                    codec_options_t *codec_options) {
+  if (!codec_options || !codec_options->work_mem)
+    return 0;
+  GpucompactState *state = (GpucompactState *)codec_options->work_mem;
+  CompressionContext *ctx = state->comp_ctx;
+
+  size_t in_offset = 0;
+  size_t out_offset = 0;
+
+  while (in_offset < insize) {
+    size_t chunk_in_size = std::min(insize - in_offset, state->macro_bytes);
+
+    if (out_offset + sizeof(GpucompactChunkHeader) > outsize) {
+      return 0;
+    }
+
+    std::memcpy(ctx->host_in, inbuf + in_offset, chunk_in_size);
+    ctx->bytes_read = (int)chunk_in_size;
+
+    ctx->compress_chunk(state->config.threads_comp, state->config.mini_size);
+    cudaDeviceSynchronize();
+
+    if (out_offset + sizeof(GpucompactChunkHeader) + ctx->comp_size > outsize) {
+      return 0;
+    }
+
+    GpucompactChunkHeader header;
+    header.comp_size = (uint32_t)ctx->comp_size;
+    header.uncomp_size = (uint32_t)chunk_in_size;
+    header.primary_idx = (uint32_t)ctx->primary_idx;
+    header.is_raw = (uint8_t)ctx->is_raw;
+    std::memset(header.reserved, 0, sizeof(header.reserved));
+    header.gpu_hash = ctx->gpu_hash;
+
+    std::memcpy(outbuf + out_offset, &header, sizeof(GpucompactChunkHeader));
+    out_offset += sizeof(GpucompactChunkHeader);
+
+    std::memcpy(outbuf + out_offset, ctx->host_out, ctx->comp_size);
+    out_offset += ctx->comp_size;
+
+    in_offset += chunk_in_size;
+  }
+
+  return (int64_t)out_offset;
+}
+
+int64_t lzbench_gpucompact_decompress(char *inbuf, size_t insize, char *outbuf,
+                                      size_t outsize,
+                                      codec_options_t *codec_options) {
+  if (!codec_options || !codec_options->work_mem)
+    return 0;
+  GpucompactState *state = (GpucompactState *)codec_options->work_mem;
+  DecompressionContext *ctx = state->decomp_ctx;
+
+  size_t in_offset = 0;
+  size_t out_offset = 0;
+
+  while (in_offset < insize) {
+    if (in_offset + sizeof(GpucompactChunkHeader) > insize) {
+      return 0;
+    }
+
+    GpucompactChunkHeader header;
+    std::memcpy(&header, inbuf + in_offset, sizeof(GpucompactChunkHeader));
+    in_offset += sizeof(GpucompactChunkHeader);
+
+    if (in_offset + header.comp_size > insize) {
+      return 0;
+    }
+
+    if (out_offset + header.uncomp_size > outsize) {
+      return 0;
+    }
+
+    std::memcpy(ctx->host_in, inbuf + in_offset, header.comp_size);
+    ctx->comp_size = (int)header.comp_size;
+    ctx->uncomp_size = (int)header.uncomp_size;
+    ctx->primary_idx = (int)header.primary_idx;
+    ctx->is_raw = (int)header.is_raw;
+    ctx->gpu_hash = header.gpu_hash;
+
+    cudaDeviceSynchronize();
+
+    if (!ctx->decompress_chunk(state->config.threads_decomp,
+                               state->config.mini_size)) {
+      return 0;
+    }
+    cudaDeviceSynchronize();
+
+    std::memcpy(outbuf + out_offset, ctx->host_out, header.uncomp_size);
+    out_offset += header.uncomp_size;
+    in_offset += header.comp_size;
+  }
+
+  return (int64_t)out_offset;
+}
+
+#endif // BENCH_HAS_CUDA
+#endif // BENCH_REMOVE_GPUCOMPACT

--- a/lz/gpucompact/kernels.cu
+++ b/lz/gpucompact/kernels.cu
@@ -1,0 +1,567 @@
+/*
+ * GPUCompact
+ * Copyright (C) 2026 UDPSendToFailed
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "kernels.cuh"
+
+__global__ void cast_uint8_to_int32_kernel(const unsigned char *__restrict__ in,
+                                           int *__restrict__ out, int n) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < n)
+    out[idx] = (int)in[idx];
+}
+
+__global__ void bit_to_word_kernel(const unsigned int *__restrict__ bits,
+                                   unsigned int *__restrict__ words, int n) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < n)
+    words[idx] = (bits[idx] + 63) / 64;
+}
+
+__global__ void fill_sequence_kernel(int *__restrict__ out, int n) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < n)
+    out[idx] = idx;
+}
+
+__global__ void sa_key_kernel(const int *__restrict__ rank,
+                              int *__restrict__ sa,
+                              unsigned long long *__restrict__ keys, int n,
+                              int k) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= n)
+    return;
+  unsigned long long r1 = rank[idx];
+  unsigned long long r2 = rank[(idx + k) % n];
+  keys[idx] = (r1 << 32) | r2;
+  sa[idx] = idx;
+}
+
+__global__ void
+sa_diff_kernel(const unsigned long long *__restrict__ sorted_keys,
+               int *__restrict__ diff, int n) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= n)
+    return;
+  if (idx == 0)
+    diff[idx] = 1;
+  else
+    diff[idx] = (sorted_keys[idx] != sorted_keys[idx - 1]) ? 1 : 0;
+}
+
+__global__ void sa_rank_kernel(const int *__restrict__ unique_ranks,
+                               const int *__restrict__ sa_sorted,
+                               int *__restrict__ rank, int n) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= n)
+    return;
+  rank[sa_sorted[idx]] = unique_ranks[idx] - 1;
+}
+
+__global__ void extract_bwt_kernel(const int *__restrict__ sa,
+                                   const unsigned char *__restrict__ data,
+                                   unsigned char *__restrict__ bwt,
+                                   int *__restrict__ primary_idx, int n) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= n)
+    return;
+  int s = sa[idx];
+  if (s == 0)
+    *primary_idx = idx;
+  bwt[idx] = data[(s == 0) ? n - 1 : s - 1];
+}
+
+__global__ void
+zrle_encode_kernel(const unsigned char *__restrict__ bwt,
+                   unsigned short *__restrict__ out_symbols,
+                   unsigned int *__restrict__ chunk_symbol_lengths,
+                   int total_size, int chunk_size, int threads_comp) {
+  int chunk_id = blockIdx.x * blockDim.x + threadIdx.x;
+  int start = chunk_id * chunk_size;
+  if (start >= total_size)
+    return;
+  int end = start + chunk_size;
+  if (end > total_size)
+    end = total_size;
+
+  extern __shared__ unsigned char s_alphabet[];
+  unsigned char *alphabet = &s_alphabet[threadIdx.x * 260];
+  for (int i = 0; i < 256; i++)
+    alphabet[i] = (unsigned char)i;
+
+  int zero_run = 0, sym_offset = 0, out_base = chunk_id * chunk_size;
+  for (int i = start; i < end; i++) {
+    unsigned char c = bwt[i], idx = 0;
+    for (int j = 0; j < 256; j++) {
+      if (alphabet[j] == c) {
+        idx = (unsigned char)j;
+        break;
+      }
+    }
+    for (int j = idx; j > 0; j--)
+      alphabet[j] = alphabet[j - 1];
+    alphabet[0] = c;
+
+    if (idx == 0) {
+      zero_run++;
+    } else {
+      if (zero_run > 0) {
+        int temp = zero_run;
+        while (temp > 0) {
+          if (temp % 2 == 1) {
+            out_symbols[out_base + sym_offset++] = 0;
+            temp = (temp - 1) / 2;
+          } else {
+            out_symbols[out_base + sym_offset++] = 1;
+            temp = (temp - 2) / 2;
+          }
+        }
+        zero_run = 0;
+      }
+      out_symbols[out_base + sym_offset++] = idx + 1;
+    }
+  }
+  if (zero_run > 0) {
+    int temp = zero_run;
+    while (temp > 0) {
+      if (temp % 2 == 1) {
+        out_symbols[out_base + sym_offset++] = 0;
+        temp = (temp - 1) / 2;
+      } else {
+        out_symbols[out_base + sym_offset++] = 1;
+        temp = (temp - 2) / 2;
+      }
+    }
+  }
+  chunk_symbol_lengths[chunk_id] = sym_offset;
+}
+
+__global__ void
+compute_histogram_kernel(const unsigned short *__restrict__ symbols,
+                         const unsigned int *__restrict__ lengths,
+                         unsigned int *__restrict__ hist, int num_chunks,
+                         int chunk_size) {
+  int chunk_id = blockIdx.x * blockDim.x + threadIdx.x;
+  if (chunk_id >= num_chunks)
+    return;
+  int length = lengths[chunk_id], base = chunk_id * chunk_size;
+  for (int i = 0; i < length; i++) {
+    atomicAdd(&hist[symbols[base + i]], 1);
+  }
+}
+
+__global__ void build_tans_all_kernel(
+    const unsigned int *__restrict__ hist, int *__restrict__ p_out,
+    int *__restrict__ prefix_p_out, int *__restrict__ max_x,
+    int *__restrict__ symbol_spread, int *__restrict__ encoding_table,
+    int *__restrict__ decoding_table, int *__restrict__ decoding_symbol,
+    int *__restrict__ next_state, int L, int alphabet_size) {
+  int tid = threadIdx.x;
+  if (tid >= alphabet_size)
+    return;
+
+  __shared__ unsigned int s_hist[257];
+  __shared__ int s_p[257];
+  s_hist[tid] = hist[tid];
+  s_p[tid] = (hist[tid] > 0) ? 1 : 0;
+  __syncthreads();
+
+  int p_sum = 0;
+  double weight_sum = 0.0;
+  for (int i = 0; i < alphabet_size; i++) {
+    p_sum += s_p[i];
+    weight_sum += (double)s_hist[i];
+  }
+  int remaining = L - p_sum;
+  if (remaining > 0) {
+    double weight = (double)s_hist[tid];
+    int add = (weight_sum > 0.0) ? (int)((remaining * weight) / weight_sum)
+                                 : (tid == 0 ? remaining : 0);
+    s_p[tid] += add;
+  }
+  __syncthreads();
+
+  p_sum = 0;
+  double max_weight = -1.0;
+  int max_idx = 0;
+  for (int i = 0; i < alphabet_size; i++) {
+    p_sum += s_p[i];
+    if ((double)s_hist[i] > max_weight) {
+      max_weight = (double)s_hist[i];
+      max_idx = i;
+    }
+  }
+  if (L - p_sum > 0 && tid == max_idx && weight_sum > 0.0)
+    s_p[tid] += (L - p_sum);
+  __syncthreads();
+
+  p_out[tid] = s_p[tid];
+  max_x[tid] = 2 * s_p[tid] - 1;
+  int prefix = 0;
+  for (int i = 0; i < tid; i++)
+    prefix += s_p[i];
+  prefix_p_out[tid] = prefix;
+
+  int step = (L / 2) + 3;
+  for (int k = 0; k < s_p[tid]; k++) {
+    symbol_spread[((prefix + k) * step) % L] = tid;
+  }
+  __syncthreads();
+
+  if (tid == 0) {
+    for (int i = 0; i < alphabet_size; i++)
+      next_state[i] = s_p[i];
+    for (int x = L; x < 2 * L; x++) {
+      int s = symbol_spread[x - L];
+      decoding_symbol[x - L] = s;
+      int state = next_state[s];
+      decoding_table[x - L] = state;
+      encoding_table[prefix_p_out[s] + state - s_p[s]] = x;
+      next_state[s] = state + 1;
+    }
+  }
+}
+
+__global__ void tabled_encode_kernel(const unsigned short *__restrict__ symbols,
+                                     const unsigned int *__restrict__ lengths,
+                                     unsigned long long *__restrict__ out_words,
+                                     unsigned int *__restrict__ bit_lengths,
+                                     const int *__restrict__ p,
+                                     const int *__restrict__ prefix_p,
+                                     const int *__restrict__ max_x,
+                                     const int *__restrict__ enc_table,
+                                     int num_chunks, int chunk_size,
+                                     int max_words, int L) {
+  int chunk_id = blockIdx.x * blockDim.x + threadIdx.x;
+
+  extern __shared__ unsigned char s_mem_th[];
+  int *s_enc = (int *)s_mem_th;
+  int *s_p = (int *)(s_mem_th + L * sizeof(int));
+  int *s_prefix_p = (int *)(s_mem_th + L * sizeof(int) + 257 * sizeof(int));
+
+  // Coalesced, branch-free shared memory pre-staging
+  for (int i = threadIdx.x; i < L; i += blockDim.x)
+    s_enc[i] = enc_table[i];
+  for (int i = threadIdx.x; i < 257; i += blockDim.x) {
+    s_p[i] = p[i];
+    s_prefix_p[i] = prefix_p[i];
+  }
+  __syncthreads();
+
+  if (chunk_id >= num_chunks)
+    return;
+
+  int len = lengths[chunk_id], in_base = chunk_id * chunk_size,
+      out_base = chunk_id * max_words;
+  unsigned long long bit_buf = 0;
+  int bit_cnt = 0, word_off = 0, x = L;
+
+  for (int i = len - 1; i >= 0; i--) {
+    unsigned short s = symbols[in_base + i];
+    int mx = max_x[s];
+    while (x > mx) {
+      bit_buf |= ((unsigned long long)(x & 1) << bit_cnt++);
+      if (bit_cnt == 64) {
+        out_words[out_base + word_off++] = bit_buf;
+        bit_cnt = 0;
+        bit_buf = 0;
+      }
+      x >>= 1;
+    }
+    x = s_enc[s_prefix_p[s] + x - s_p[s]];
+  }
+
+  int state_bits = 32 - __clz(L);
+  for (int b = 0; b < state_bits; b++) {
+    bit_buf |= ((unsigned long long)((x >> b) & 1) << bit_cnt++);
+    if (bit_cnt == 64) {
+      out_words[out_base + word_off++] = bit_buf;
+      bit_cnt = 0;
+      bit_buf = 0;
+    }
+  }
+  if (bit_cnt > 0)
+    out_words[out_base + word_off++] = bit_buf;
+  bit_lengths[chunk_id] = (word_off * 64) - (64 - bit_cnt);
+  if (bit_cnt == 0)
+    bit_lengths[chunk_id] = word_off * 64;
+}
+
+__global__ void tabled_decode_kernel(
+    const unsigned long long *__restrict__ in_words,
+    const unsigned int *__restrict__ word_offsets,
+    const unsigned int *__restrict__ bit_lengths,
+    unsigned char *__restrict__ bwt, const int *__restrict__ dec_table,
+    const int *__restrict__ dec_symbol, int total_size, int chunk_size, int L) {
+  extern __shared__ int s_dec_mem[];
+  int *s_dec_table = s_dec_mem;
+  int *s_dec_symbol = &s_dec_mem[L];
+
+  // OPTIMIZATION FIX: Move MTF alphabet table from local stack (DRAM) into
+  // Shared Memory!
+  unsigned char *s_alphabets = (unsigned char *)&s_dec_mem[2 * L];
+  unsigned char *alphabet = &s_alphabets[threadIdx.x * 256];
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+  for (int i = threadIdx.x * 4; i < L; i += blockDim.x * 4) {
+    if (i + 3 < L) {
+      cp_async_16(&s_dec_table[i], &dec_table[i]);
+      cp_async_16(&s_dec_symbol[i], &dec_symbol[i]);
+    } else {
+      for (int k = i; k < L; k++) {
+        s_dec_table[k] = dec_table[k];
+        s_dec_symbol[k] = dec_symbol[k];
+      }
+    }
+  }
+  cp_async_commit();
+  cp_async_wait_all();
+  __syncthreads();
+#else
+  for (int i = threadIdx.x; i < L; i += blockDim.x) {
+    s_dec_table[i] = dec_table[i];
+    s_dec_symbol[i] = dec_symbol[i];
+  }
+  __syncthreads();
+#endif
+
+  for (int i = 0; i < 256; i++)
+    alphabet[i] = (unsigned char)i;
+
+  int chunk_id = blockIdx.x * blockDim.x + threadIdx.x;
+  int start = chunk_id * chunk_size;
+  if (start >= total_size)
+    return;
+  int end = start + chunk_size;
+  if (end > total_size)
+    end = total_size;
+
+  int word_base = word_offsets[chunk_id];
+  int current_bit_idx = (int)bit_lengths[chunk_id] - 1;
+  int x = 0;
+  int state_bits = 32 - __clz(L);
+
+  for (int b = state_bits - 1; b >= 0; b--) {
+    unsigned int bit = 0;
+    if (current_bit_idx >= 0) {
+      bit = (unsigned int)((in_words[word_base + (current_bit_idx >> 6)] >>
+                            (current_bit_idx & 63)) &
+                           1ULL);
+      current_bit_idx--;
+    }
+    x |= (bit << b);
+  }
+
+  int out_idx = start, run_length = 0, power = 1;
+  while (out_idx + run_length < end) {
+    int s = s_dec_symbol[x - L];
+    x = s_dec_table[x - L];
+    while (x < L) {
+      unsigned int bit = 0;
+      if (current_bit_idx >= 0) {
+        bit = (unsigned int)((in_words[word_base + (current_bit_idx >> 6)] >>
+                              (current_bit_idx & 63)) &
+                             1ULL);
+        current_bit_idx--;
+      }
+      x = (x << 1) | bit;
+    }
+    if (s == 0) {
+      run_length += power * 1;
+      power *= 2;
+    } else if (s == 1) {
+      run_length += power * 2;
+      power *= 2;
+    } else {
+      if (run_length > 0) {
+        for (int i = 0; i < run_length && out_idx < end; i++)
+          bwt[out_idx++] = alphabet[0];
+        run_length = 0;
+        power = 1;
+      }
+      if (out_idx < end) {
+        unsigned int mtf = s - 1;
+        unsigned char c = alphabet[mtf];
+        bwt[out_idx++] = c;
+        for (int j = mtf; j > 0; j--)
+          alphabet[j] = alphabet[j - 1];
+        alphabet[0] = c;
+      }
+    }
+  }
+  if (run_length > 0) {
+    for (int i = 0; i < run_length && out_idx < end; i++)
+      bwt[out_idx++] = alphabet[0];
+  }
+}
+
+__global__ void dense_pack_kernel(const unsigned long long *__restrict__ in,
+                                  const unsigned int *__restrict__ offsets,
+                                  const unsigned int *__restrict__ lens,
+                                  unsigned long long *__restrict__ out, int n,
+                                  int max_w) {
+  int cid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (cid >= n)
+    return;
+  int len = lens[cid], in_b = cid * max_w, out_b = offsets[cid];
+
+  uintptr_t in_ptr = reinterpret_cast<uintptr_t>(in + in_b);
+  uintptr_t out_ptr = reinterpret_cast<uintptr_t>(out + out_b);
+
+  // SAFE ALIGNMENT CHECK: Ensure both pointers are 16-byte aligned before
+  // vector load/store
+  if ((in_ptr % 16 == 0) && (out_ptr % 16 == 0)) {
+    const ulonglong2 *in_128 = reinterpret_cast<const ulonglong2 *>(in + in_b);
+    ulonglong2 *out_128 = reinterpret_cast<ulonglong2 *>(out + out_b);
+    int vec_len = len / 2;
+    for (int i = 0; i < vec_len; i++) {
+      out_128[i] = in_128[i];
+    }
+    if (len % 2) {
+      out[out_b + len - 1] = in[in_b + len - 1];
+    }
+  } else {
+    for (int i = 0; i < len; i++) {
+      out[out_b + i] = in[in_b + i];
+    }
+  }
+}
+
+__global__ void fill_key_kernel(const unsigned long long *__restrict__ offsets,
+                                const int *__restrict__ sizes,
+                                const unsigned char *__restrict__ bwt,
+                                unsigned long long *__restrict__ key,
+                                int num_chunks) {
+  int cid = blockIdx.y;
+  if (cid >= num_chunks)
+    return;
+
+  int lid = blockIdx.x * blockDim.x + threadIdx.x;
+  int size = sizes[cid];
+  if (lid >= size)
+    return;
+
+  unsigned long long off = offsets[cid];
+  key[off + lid] = (((unsigned long long)cid) << 48) |
+                   (((unsigned long long)bwt[off + lid]) << 32) |
+                   (unsigned long long)lid;
+}
+
+__global__ void build_lf_kernel(const int *__restrict__ F_to_L,
+                                int *__restrict__ LF, int n) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < n) {
+    LF[F_to_L[idx]] = idx;
+  }
+}
+
+__global__ void
+jump_init_kernel(const int *__restrict__ LF,
+                 const int *__restrict__ primary_indices,
+                 const unsigned long long *__restrict__ chunk_offsets,
+                 const int *__restrict__ chunk_sizes, int *__restrict__ J,
+                 int *__restrict__ D) {
+  int cid = blockIdx.y, lid = blockIdx.x * blockDim.x + threadIdx.x,
+      size = chunk_sizes[cid];
+  if (lid >= size)
+    return;
+  unsigned long long off = chunk_offsets[cid];
+  int gid = off + lid, prim = off + primary_indices[cid],
+      g_target = off + LF[gid];
+  if (gid == prim) {
+    J[gid] = gid;
+    D[gid] = 0;
+  } else {
+    J[gid] = g_target;
+    D[gid] = 1;
+  }
+}
+
+__global__ void jump_step_kernel(const int *__restrict__ J_in,
+                                 const int *__restrict__ D_in,
+                                 int *__restrict__ J_out,
+                                 int *__restrict__ D_out,
+                                 const unsigned long long *__restrict__ offsets,
+                                 const int *__restrict__ sizes) {
+  int cid = blockIdx.y, lid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (lid >= sizes[cid])
+    return;
+  int gid = offsets[cid] + lid, my_J = J_in[gid];
+  J_out[gid] = J_in[my_J];
+  D_out[gid] = D_in[gid] + D_in[my_J];
+}
+
+__global__ void jump_scatter_kernel(
+    const int *__restrict__ D, const unsigned char *__restrict__ bwt,
+    unsigned char *__restrict__ out, const int *__restrict__ primary,
+    const unsigned long long *__restrict__ offsets,
+    const int *__restrict__ sizes) {
+  int cid = blockIdx.y, lid = blockIdx.x * blockDim.x + threadIdx.x,
+      size = sizes[cid];
+  if (lid >= size)
+    return;
+  unsigned long long off = offsets[cid];
+  int gid = off + lid, prim = off + primary[cid],
+      d_forw = (gid == prim) ? 0 : (size - D[gid]);
+  out[off + size - 1 - d_forw] = bwt[gid];
+}
+
+__global__ void gpu_hash_kernel(const unsigned char *__restrict__ data,
+                                unsigned long long *__restrict__ d_hash,
+                                int size) {
+  int tid = threadIdx.x;
+  int idx = blockIdx.x * blockDim.x + tid;
+  unsigned long long local_hash = 0;
+
+  int num_words = (size + 7) / 8;
+
+  if (idx < num_words) {
+    int start_byte = idx * 8;
+    int remain = size - start_byte;
+    unsigned long long val = 0;
+
+    if (remain >= 8) {
+      val = *reinterpret_cast<const unsigned long long *>(data + start_byte);
+    } else {
+      for (int i = 0; i < remain; i++) {
+        val |= (static_cast<unsigned long long>(data[start_byte + i]))
+               << (i * 8);
+      }
+    }
+
+    local_hash = val * 0xbf58476d1ce4e5b9ULL;
+    local_hash ^= (local_hash >> 31);
+  }
+
+  for (int offset = 16; offset > 0; offset /= 2) {
+    local_hash ^= __shfl_down_sync(0xFFFFFFFF, local_hash, offset);
+  }
+
+  __shared__ unsigned long long shared_hash[32];
+  if (tid % 32 == 0)
+    shared_hash[tid / 32] = local_hash;
+  __syncthreads();
+
+  if (tid < 32) {
+    local_hash = (tid < ((blockDim.x + 31) / 32)) ? shared_hash[tid] : 0;
+    for (int offset = 16; offset > 0; offset /= 2) {
+      local_hash ^= __shfl_down_sync(0xFFFFFFFF, local_hash, offset);
+    }
+    if (tid == 0 && local_hash != 0) {
+      atomicXor(d_hash, local_hash);
+    }
+  }
+}

--- a/lz/gpucompact/kernels.cu
+++ b/lz/gpucompact/kernels.cu
@@ -244,7 +244,8 @@ __global__ void tabled_encode_kernel(const unsigned short *__restrict__ symbols,
                                      const int *__restrict__ max_x,
                                      const int *__restrict__ enc_table,
                                      int num_chunks, int chunk_size,
-                                     int max_words, int L) {
+                                     int max_words, int L,
+                                     uint32_t *__restrict__ d_overflow_flag) {
   int chunk_id = blockIdx.x * blockDim.x + threadIdx.x;
 
   extern __shared__ unsigned char s_mem_th[];
@@ -275,9 +276,11 @@ __global__ void tabled_encode_kernel(const unsigned short *__restrict__ symbols,
     while (x > mx) {
       bit_buf |= ((uint64_t)(x & 1) << bit_cnt++);
       if (bit_cnt == 64) {
-        if (word_off < max_words) {
-          out_words[out_base + word_off++] = bit_buf;
+        if (word_off >= max_words) {
+          atomicExch(d_overflow_flag, 1u);
+          return;
         }
+        out_words[out_base + word_off++] = bit_buf;
         bit_cnt = 0;
         bit_buf = 0;
       }
@@ -290,17 +293,21 @@ __global__ void tabled_encode_kernel(const unsigned short *__restrict__ symbols,
   for (int b = 0; b < state_bits; b++) {
     bit_buf |= ((uint64_t)((x >> b) & 1) << bit_cnt++);
     if (bit_cnt == 64) {
-      if (word_off < max_words) {
-        out_words[out_base + word_off++] = bit_buf;
+      if (word_off >= max_words) {
+        atomicExch(d_overflow_flag, 1u);
+        return;
       }
+      out_words[out_base + word_off++] = bit_buf;
       bit_cnt = 0;
       bit_buf = 0;
     }
   }
   if (bit_cnt > 0) {
-    if (word_off < max_words) {
-      out_words[out_base + word_off++] = bit_buf;
+    if (word_off >= max_words) {
+      atomicExch(d_overflow_flag, 1u);
+      return;
     }
+    out_words[out_base + word_off++] = bit_buf;
   }
   bit_lengths[chunk_id] = (word_off * 64) - (64 - bit_cnt);
   if (bit_cnt == 0)

--- a/lz/gpucompact/kernels.cu
+++ b/lz/gpucompact/kernels.cu
@@ -39,19 +39,19 @@ __global__ void fill_sequence_kernel(int *__restrict__ out, int n) {
 
 __global__ void sa_key_kernel(const int *__restrict__ rank,
                               int *__restrict__ sa,
-                              unsigned long long *__restrict__ keys, int n,
+                              uint64_t *__restrict__ keys, int n,
                               int k) {
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx >= n)
     return;
-  unsigned long long r1 = rank[idx];
-  unsigned long long r2 = rank[(idx + k) % n];
+  uint64_t r1 = rank[idx];
+  uint64_t r2 = rank[(idx + k) % n];
   keys[idx] = (r1 << 32) | r2;
   sa[idx] = idx;
 }
 
 __global__ void
-sa_diff_kernel(const unsigned long long *__restrict__ sorted_keys,
+sa_diff_kernel(const uint64_t *__restrict__ sorted_keys,
                int *__restrict__ diff, int n) {
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx >= n)
@@ -237,7 +237,7 @@ __global__ void build_tans_all_kernel(
 
 __global__ void tabled_encode_kernel(const unsigned short *__restrict__ symbols,
                                      const unsigned int *__restrict__ lengths,
-                                     unsigned long long *__restrict__ out_words,
+                                     uint64_t *__restrict__ out_words,
                                      unsigned int *__restrict__ bit_lengths,
                                      const int *__restrict__ p,
                                      const int *__restrict__ prefix_p,
@@ -266,14 +266,14 @@ __global__ void tabled_encode_kernel(const unsigned short *__restrict__ symbols,
 
   int len = lengths[chunk_id], in_base = chunk_id * chunk_size,
       out_base = chunk_id * max_words;
-  unsigned long long bit_buf = 0;
+  uint64_t bit_buf = 0;
   int bit_cnt = 0, word_off = 0, x = L;
 
   for (int i = len - 1; i >= 0; i--) {
     unsigned short s = symbols[in_base + i];
     int mx = max_x[s];
     while (x > mx) {
-      bit_buf |= ((unsigned long long)(x & 1) << bit_cnt++);
+      bit_buf |= ((uint64_t)(x & 1) << bit_cnt++);
       if (bit_cnt == 64) {
         out_words[out_base + word_off++] = bit_buf;
         bit_cnt = 0;
@@ -286,7 +286,7 @@ __global__ void tabled_encode_kernel(const unsigned short *__restrict__ symbols,
 
   int state_bits = 32 - __clz(L);
   for (int b = 0; b < state_bits; b++) {
-    bit_buf |= ((unsigned long long)((x >> b) & 1) << bit_cnt++);
+    bit_buf |= ((uint64_t)((x >> b) & 1) << bit_cnt++);
     if (bit_cnt == 64) {
       out_words[out_base + word_off++] = bit_buf;
       bit_cnt = 0;
@@ -301,7 +301,7 @@ __global__ void tabled_encode_kernel(const unsigned short *__restrict__ symbols,
 }
 
 __global__ void tabled_decode_kernel(
-    const unsigned long long *__restrict__ in_words,
+    const uint64_t *__restrict__ in_words,
     const unsigned int *__restrict__ word_offsets,
     const unsigned int *__restrict__ bit_lengths,
     unsigned char *__restrict__ bwt, const int *__restrict__ dec_table,
@@ -408,10 +408,10 @@ __global__ void tabled_decode_kernel(
   }
 }
 
-__global__ void dense_pack_kernel(const unsigned long long *__restrict__ in,
+__global__ void dense_pack_kernel(const uint64_t *__restrict__ in,
                                   const unsigned int *__restrict__ offsets,
                                   const unsigned int *__restrict__ lens,
-                                  unsigned long long *__restrict__ out, int n,
+                                  uint64_t *__restrict__ out, int n,
                                   int max_w) {
   int cid = blockIdx.x * blockDim.x + threadIdx.x;
   if (cid >= n)
@@ -440,10 +440,10 @@ __global__ void dense_pack_kernel(const unsigned long long *__restrict__ in,
   }
 }
 
-__global__ void fill_key_kernel(const unsigned long long *__restrict__ offsets,
+__global__ void fill_key_kernel(const uint64_t *__restrict__ offsets,
                                 const int *__restrict__ sizes,
                                 const unsigned char *__restrict__ bwt,
-                                unsigned long long *__restrict__ key,
+                                uint64_t *__restrict__ key,
                                 int num_chunks) {
   int cid = blockIdx.y;
   if (cid >= num_chunks)
@@ -454,10 +454,10 @@ __global__ void fill_key_kernel(const unsigned long long *__restrict__ offsets,
   if (lid >= size)
     return;
 
-  unsigned long long off = offsets[cid];
-  key[off + lid] = (((unsigned long long)cid) << 48) |
-                   (((unsigned long long)bwt[off + lid]) << 32) |
-                   (unsigned long long)lid;
+  uint64_t off = offsets[cid];
+  key[off + lid] = (((uint64_t)cid) << 48) |
+                   (((uint64_t)bwt[off + lid]) << 32) |
+                   (uint64_t)lid;
 }
 
 __global__ void build_lf_kernel(const int *__restrict__ F_to_L,
@@ -471,14 +471,14 @@ __global__ void build_lf_kernel(const int *__restrict__ F_to_L,
 __global__ void
 jump_init_kernel(const int *__restrict__ LF,
                  const int *__restrict__ primary_indices,
-                 const unsigned long long *__restrict__ chunk_offsets,
+                 const uint64_t *__restrict__ chunk_offsets,
                  const int *__restrict__ chunk_sizes, int *__restrict__ J,
                  int *__restrict__ D) {
   int cid = blockIdx.y, lid = blockIdx.x * blockDim.x + threadIdx.x,
       size = chunk_sizes[cid];
   if (lid >= size)
     return;
-  unsigned long long off = chunk_offsets[cid];
+  uint64_t off = chunk_offsets[cid];
   int gid = off + lid, prim = off + primary_indices[cid],
       g_target = off + LF[gid];
   if (gid == prim) {
@@ -494,7 +494,7 @@ __global__ void jump_step_kernel(const int *__restrict__ J_in,
                                  const int *__restrict__ D_in,
                                  int *__restrict__ J_out,
                                  int *__restrict__ D_out,
-                                 const unsigned long long *__restrict__ offsets,
+                                 const uint64_t *__restrict__ offsets,
                                  const int *__restrict__ sizes) {
   int cid = blockIdx.y, lid = blockIdx.x * blockDim.x + threadIdx.x;
   if (lid >= sizes[cid])
@@ -507,37 +507,37 @@ __global__ void jump_step_kernel(const int *__restrict__ J_in,
 __global__ void jump_scatter_kernel(
     const int *__restrict__ D, const unsigned char *__restrict__ bwt,
     unsigned char *__restrict__ out, const int *__restrict__ primary,
-    const unsigned long long *__restrict__ offsets,
+    const uint64_t *__restrict__ offsets,
     const int *__restrict__ sizes) {
   int cid = blockIdx.y, lid = blockIdx.x * blockDim.x + threadIdx.x,
       size = sizes[cid];
   if (lid >= size)
     return;
-  unsigned long long off = offsets[cid];
+  uint64_t off = offsets[cid];
   int gid = off + lid, prim = off + primary[cid],
       d_forw = (gid == prim) ? 0 : (size - D[gid]);
   out[off + size - 1 - d_forw] = bwt[gid];
 }
 
 __global__ void gpu_hash_kernel(const unsigned char *__restrict__ data,
-                                unsigned long long *__restrict__ d_hash,
+                                uint64_t *__restrict__ d_hash,
                                 int size) {
   int tid = threadIdx.x;
   int idx = blockIdx.x * blockDim.x + tid;
-  unsigned long long local_hash = 0;
+  uint64_t local_hash = 0;
 
   int num_words = (size + 7) / 8;
 
   if (idx < num_words) {
     int start_byte = idx * 8;
     int remain = size - start_byte;
-    unsigned long long val = 0;
+    uint64_t val = 0;
 
     if (remain >= 8) {
-      val = *reinterpret_cast<const unsigned long long *>(data + start_byte);
+      val = *reinterpret_cast<const uint64_t *>(data + start_byte);
     } else {
       for (int i = 0; i < remain; i++) {
-        val |= (static_cast<unsigned long long>(data[start_byte + i]))
+        val |= (static_cast<uint64_t>(data[start_byte + i]))
                << (i * 8);
       }
     }
@@ -550,7 +550,7 @@ __global__ void gpu_hash_kernel(const unsigned char *__restrict__ data,
     local_hash ^= __shfl_down_sync(0xFFFFFFFF, local_hash, offset);
   }
 
-  __shared__ unsigned long long shared_hash[32];
+  __shared__ uint64_t shared_hash[32];
   if (tid % 32 == 0)
     shared_hash[tid / 32] = local_hash;
   __syncthreads();
@@ -561,7 +561,7 @@ __global__ void gpu_hash_kernel(const unsigned char *__restrict__ data,
       local_hash ^= __shfl_down_sync(0xFFFFFFFF, local_hash, offset);
     }
     if (tid == 0 && local_hash != 0) {
-      atomicXor(d_hash, local_hash);
+      atomicXor(reinterpret_cast<unsigned long long *>(d_hash), (unsigned long long)local_hash);
     }
   }
 }

--- a/lz/gpucompact/kernels.cu
+++ b/lz/gpucompact/kernels.cu
@@ -275,7 +275,9 @@ __global__ void tabled_encode_kernel(const unsigned short *__restrict__ symbols,
     while (x > mx) {
       bit_buf |= ((uint64_t)(x & 1) << bit_cnt++);
       if (bit_cnt == 64) {
-        out_words[out_base + word_off++] = bit_buf;
+        if (word_off < max_words) {
+          out_words[out_base + word_off++] = bit_buf;
+        }
         bit_cnt = 0;
         bit_buf = 0;
       }
@@ -288,13 +290,18 @@ __global__ void tabled_encode_kernel(const unsigned short *__restrict__ symbols,
   for (int b = 0; b < state_bits; b++) {
     bit_buf |= ((uint64_t)((x >> b) & 1) << bit_cnt++);
     if (bit_cnt == 64) {
-      out_words[out_base + word_off++] = bit_buf;
+      if (word_off < max_words) {
+        out_words[out_base + word_off++] = bit_buf;
+      }
       bit_cnt = 0;
       bit_buf = 0;
     }
   }
-  if (bit_cnt > 0)
-    out_words[out_base + word_off++] = bit_buf;
+  if (bit_cnt > 0) {
+    if (word_off < max_words) {
+      out_words[out_base + word_off++] = bit_buf;
+    }
+  }
   bit_lengths[chunk_id] = (word_off * 64) - (64 - bit_cnt);
   if (bit_cnt == 0)
     bit_lengths[chunk_id] = word_off * 64;

--- a/lz/gpucompact/kernels.cuh
+++ b/lz/gpucompact/kernels.cuh
@@ -1,0 +1,156 @@
+/*
+ * GPUCompact
+ * Copyright (C) 2026 UDPSendToFailed
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+#include <cstdint>
+#include <cuda_runtime.h>
+#include <device_launch_parameters.h>
+
+// -------------------------------------------------------------------------
+// PTX ASYNC COPY INTRINSICS (sm_80 / sm_89 Hardware DMA)
+// -------------------------------------------------------------------------
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+__device__ inline void cp_async_16(void *smem_ptr, const void *glob_ptr) {
+  uint32_t smem_addr =
+      static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile("cp.async.cg.shared.global [%0], [%1], 16;\n" ::"r"(smem_addr),
+               "l"(glob_ptr));
+}
+
+__device__ inline void cp_async_4(void *smem_ptr, const void *glob_ptr) {
+  uint32_t smem_addr =
+      static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile("cp.async.ca.shared.global [%0], [%1], 4;\n" ::"r"(smem_addr),
+               "l"(glob_ptr));
+}
+
+__device__ inline void cp_async_commit() {
+  asm volatile("cp.async.commit_group;\n");
+}
+
+__device__ inline void cp_async_wait_all() {
+  asm volatile("cp.async.wait_group 0;\n");
+}
+#endif
+
+// -------------------------------------------------------------------------
+// HELPER UTILITY KERNEL PROTOTYPES
+// -------------------------------------------------------------------------
+__global__ void cast_uint8_to_int32_kernel(const unsigned char *__restrict__ in,
+                                           int *__restrict__ out, int n);
+
+__global__ void bit_to_word_kernel(const unsigned int *__restrict__ bits,
+                                   unsigned int *__restrict__ words, int n);
+
+__global__ void fill_sequence_kernel(int *__restrict__ out, int n);
+
+// -------------------------------------------------------------------------
+// BWT & TANS KERNEL PROTOTYPES
+// -------------------------------------------------------------------------
+__global__ void sa_key_kernel(const int *__restrict__ rank,
+                              int *__restrict__ sa,
+                              unsigned long long *__restrict__ keys, int n,
+                              int k);
+
+__global__ void
+sa_diff_kernel(const unsigned long long *__restrict__ sorted_keys,
+               int *__restrict__ diff, int n);
+
+__global__ void sa_rank_kernel(const int *__restrict__ unique_ranks,
+                               const int *__restrict__ sa_sorted,
+                               int *__restrict__ rank, int n);
+
+__global__ void extract_bwt_kernel(const int *__restrict__ sa,
+                                   const unsigned char *__restrict__ data,
+                                   unsigned char *__restrict__ bwt,
+                                   int *__restrict__ primary_idx, int n);
+
+__global__ void
+zrle_encode_kernel(const unsigned char *__restrict__ bwt,
+                   unsigned short *__restrict__ out_symbols,
+                   unsigned int *__restrict__ chunk_symbol_lengths,
+                   int total_size, int chunk_size, int threads_comp);
+
+__global__ void
+compute_histogram_kernel(const unsigned short *__restrict__ symbols,
+                         const unsigned int *__restrict__ lengths,
+                         unsigned int *__restrict__ hist, int num_chunks,
+                         int chunk_size);
+
+__global__ void build_tans_all_kernel(
+    const unsigned int *__restrict__ hist, int *__restrict__ p_out,
+    int *__restrict__ prefix_p_out, int *__restrict__ max_x,
+    int *__restrict__ symbol_spread, int *__restrict__ encoding_table,
+    int *__restrict__ decoding_table, int *__restrict__ decoding_symbol,
+    int *__restrict__ next_state, int L, int alphabet_size);
+
+__global__ void tabled_encode_kernel(const unsigned short *__restrict__ symbols,
+                                     const unsigned int *__restrict__ lengths,
+                                     unsigned long long *__restrict__ out_words,
+                                     unsigned int *__restrict__ bit_lengths,
+                                     const int *__restrict__ p,
+                                     const int *__restrict__ prefix_p,
+                                     const int *__restrict__ max_x,
+                                     const int *__restrict__ enc_table,
+                                     int num_chunks, int chunk_size,
+                                     int max_words, int L);
+
+__global__ void tabled_decode_kernel(
+    const unsigned long long *__restrict__ in_words,
+    const unsigned int *__restrict__ word_offsets,
+    const unsigned int *__restrict__ bit_lengths,
+    unsigned char *__restrict__ bwt, const int *__restrict__ dec_table,
+    const int *__restrict__ dec_symbol, int total_size, int chunk_size, int L);
+
+__global__ void dense_pack_kernel(const unsigned long long *__restrict__ in,
+                                  const unsigned int *__restrict__ offsets,
+                                  const unsigned int *__restrict__ lens,
+                                  unsigned long long *__restrict__ out, int n,
+                                  int max_w);
+
+__global__ void fill_key_kernel(const unsigned long long *__restrict__ offsets,
+                                const int *__restrict__ sizes,
+                                const unsigned char *__restrict__ bwt,
+                                unsigned long long *__restrict__ key,
+                                int num_chunks);
+
+__global__ void build_lf_kernel(const int *__restrict__ F_to_L,
+                                int *__restrict__ LF, int n);
+
+__global__ void
+jump_init_kernel(const int *__restrict__ LF,
+                 const int *__restrict__ primary_indices,
+                 const unsigned long long *__restrict__ chunk_offsets,
+                 const int *__restrict__ chunk_sizes, int *__restrict__ J,
+                 int *__restrict__ D);
+
+__global__ void jump_step_kernel(const int *__restrict__ J_in,
+                                 const int *__restrict__ D_in,
+                                 int *__restrict__ J_out,
+                                 int *__restrict__ D_out,
+                                 const unsigned long long *__restrict__ offsets,
+                                 const int *__restrict__ sizes);
+
+__global__ void jump_scatter_kernel(
+    const int *__restrict__ D, const unsigned char *__restrict__ bwt,
+    unsigned char *__restrict__ out, const int *__restrict__ primary,
+    const unsigned long long *__restrict__ offsets,
+    const int *__restrict__ sizes);
+
+__global__ void gpu_hash_kernel(const unsigned char *__restrict__ data,
+                                unsigned long long *__restrict__ d_hash,
+                                int size);

--- a/lz/gpucompact/kernels.cuh
+++ b/lz/gpucompact/kernels.cuh
@@ -63,11 +63,11 @@ __global__ void fill_sequence_kernel(int *__restrict__ out, int n);
 // -------------------------------------------------------------------------
 __global__ void sa_key_kernel(const int *__restrict__ rank,
                               int *__restrict__ sa,
-                              unsigned long long *__restrict__ keys, int n,
+                              uint64_t *__restrict__ keys, int n,
                               int k);
 
 __global__ void
-sa_diff_kernel(const unsigned long long *__restrict__ sorted_keys,
+sa_diff_kernel(const uint64_t *__restrict__ sorted_keys,
                int *__restrict__ diff, int n);
 
 __global__ void sa_rank_kernel(const int *__restrict__ unique_ranks,
@@ -100,7 +100,7 @@ __global__ void build_tans_all_kernel(
 
 __global__ void tabled_encode_kernel(const unsigned short *__restrict__ symbols,
                                      const unsigned int *__restrict__ lengths,
-                                     unsigned long long *__restrict__ out_words,
+                                     uint64_t *__restrict__ out_words,
                                      unsigned int *__restrict__ bit_lengths,
                                      const int *__restrict__ p,
                                      const int *__restrict__ prefix_p,
@@ -110,22 +110,22 @@ __global__ void tabled_encode_kernel(const unsigned short *__restrict__ symbols,
                                      int max_words, int L);
 
 __global__ void tabled_decode_kernel(
-    const unsigned long long *__restrict__ in_words,
+    const uint64_t *__restrict__ in_words,
     const unsigned int *__restrict__ word_offsets,
     const unsigned int *__restrict__ bit_lengths,
     unsigned char *__restrict__ bwt, const int *__restrict__ dec_table,
     const int *__restrict__ dec_symbol, int total_size, int chunk_size, int L);
 
-__global__ void dense_pack_kernel(const unsigned long long *__restrict__ in,
+__global__ void dense_pack_kernel(const uint64_t *__restrict__ in,
                                   const unsigned int *__restrict__ offsets,
                                   const unsigned int *__restrict__ lens,
-                                  unsigned long long *__restrict__ out, int n,
+                                  uint64_t *__restrict__ out, int n,
                                   int max_w);
 
-__global__ void fill_key_kernel(const unsigned long long *__restrict__ offsets,
+__global__ void fill_key_kernel(const uint64_t *__restrict__ offsets,
                                 const int *__restrict__ sizes,
                                 const unsigned char *__restrict__ bwt,
-                                unsigned long long *__restrict__ key,
+                                uint64_t *__restrict__ key,
                                 int num_chunks);
 
 __global__ void build_lf_kernel(const int *__restrict__ F_to_L,
@@ -134,7 +134,7 @@ __global__ void build_lf_kernel(const int *__restrict__ F_to_L,
 __global__ void
 jump_init_kernel(const int *__restrict__ LF,
                  const int *__restrict__ primary_indices,
-                 const unsigned long long *__restrict__ chunk_offsets,
+                 const uint64_t *__restrict__ chunk_offsets,
                  const int *__restrict__ chunk_sizes, int *__restrict__ J,
                  int *__restrict__ D);
 
@@ -142,15 +142,15 @@ __global__ void jump_step_kernel(const int *__restrict__ J_in,
                                  const int *__restrict__ D_in,
                                  int *__restrict__ J_out,
                                  int *__restrict__ D_out,
-                                 const unsigned long long *__restrict__ offsets,
+                                 const uint64_t *__restrict__ offsets,
                                  const int *__restrict__ sizes);
 
 __global__ void jump_scatter_kernel(
     const int *__restrict__ D, const unsigned char *__restrict__ bwt,
     unsigned char *__restrict__ out, const int *__restrict__ primary,
-    const unsigned long long *__restrict__ offsets,
+    const uint64_t *__restrict__ offsets,
     const int *__restrict__ sizes);
 
 __global__ void gpu_hash_kernel(const unsigned char *__restrict__ data,
-                                unsigned long long *__restrict__ d_hash,
+                                uint64_t *__restrict__ d_hash,
                                 int size);

--- a/lz/gpucompact/kernels.cuh
+++ b/lz/gpucompact/kernels.cuh
@@ -107,7 +107,8 @@ __global__ void tabled_encode_kernel(const unsigned short *__restrict__ symbols,
                                      const int *__restrict__ max_x,
                                      const int *__restrict__ enc_table,
                                      int num_chunks, int chunk_size,
-                                     int max_words, int L);
+                                     int max_words, int L,
+                                     uint32_t *__restrict__ d_overflow_flag);
 
 __global__ void tabled_decode_kernel(
     const uint64_t *__restrict__ in_words,


### PR DESCRIPTION
GPUCompact is a custom GPU codec aimed at being usable as a generic archiver.

Results on silesia.tar, tested on a RTX 4090:

```
.\lzbench.exe "-i10,10" -egpucompact ..\silesia.tar
lzbench 2.3 | MSVC 1944 | 64-bit Windows | 

Compressor name         Compress. Decompress. Compr. size  Ratio Filename
gpucompact 1.0 -1         308 MB/s  1026 MB/s    70972388  33.49 silesia.tar
gpucompact 1.0 -2         286 MB/s   942 MB/s    65883868  31.08 silesia.tar
gpucompact 1.0 -3         285 MB/s   944 MB/s    64143548  30.26 silesia.tar
gpucompact 1.0 -4         203 MB/s   602 MB/s    59837932  28.23 silesia.tar
gpucompact 1.0 -5         124 MB/s   322 MB/s    58040212  27.38 silesia.tar
[Params] cIters=10 dIters=10 cTime=1.0 dTime=2.0 chunkSize=0KB cSpeed=0MB
```

```
.\lzbench.exe "-i10,10" -p3 -egpucompact ..\silesia.tar
lzbench 2.3 | MSVC 1944 | 64-bit Windows | 

Compressor name         Compress. Decompress. Compr. size  Ratio Filename
gpucompact 1.0 -1         307 MB/s  1015 MB/s    70972388  33.49 silesia.tar
gpucompact 1.0 -2         285 MB/s   934 MB/s    65883868  31.08 silesia.tar
gpucompact 1.0 -3         284 MB/s   934 MB/s    64143548  30.26 silesia.tar
gpucompact 1.0 -4         203 MB/s   598 MB/s    59837932  28.23 silesia.tar
gpucompact 1.0 -5         124 MB/s   321 MB/s    58040212  27.38 silesia.tar
[Params] cIters=10 dIters=10 cTime=1.0 dTime=2.0 chunkSize=0KB cSpeed=0MB
```

Build command, as the make system seems to be broken on Windows with newer CUDA toolkit versions: 

```
nvcc -O3 -std=c++17 -arch=sm_89 -DBENCH_HAS_CUDA -DBENCH_REMOVE_SKIM -DBENCH_REMOVE_ACEAPEX -DBENCH_REMOVE_MEMLZ -DBENCH_REMOVE_BRIEFLZ -DBENCH_REMOVE_BROTLI -DBENCH_REMOVE_CRUSH -DBENCH_REMOVE_FASTLZ -DBENCH_REMOVE_FASTLZMA2 -DBENCH_REMOVE_KANZI -DBENCH_REMOVE_LIBDEFLATE -DBENCH_REMOVE_LIZARD -DBENCH_REMOVE_LZ4 -DBENCH_REMOVE_LZF -DBENCH_REMOVE_LZFSE -DBENCH_REMOVE_LZG -DBENCH_REMOVE_LZHAM -DBENCH_REMOVE_LZLIB -DBENCH_REMOVE_LZMA -DBENCH_REMOVE_LZO -DBENCH_REMOVE_LZSSE -DBENCH_REMOVE_QUICKLZ -DBENCH_REMOVE_OPENZL -DBENCH_REMOVE_SLZ -DBENCH_REMOVE_SNAPPY -DBENCH_REMOVE_TORNADO -DBENCH_REMOVE_UCL -DBENCH_REMOVE_XZ -DBENCH_REMOVE_ZLIB -DBENCH_REMOVE_ZLIB_NG -DBENCH_REMOVE_ZLING -DBENCH_REMOVE_ZSTD -DBENCH_REMOVE_ZXC -DBENCH_REMOVE_BSC -DBENCH_REMOVE_BZIP2 -DBENCH_REMOVE_BZIP3 -DBENCH_REMOVE_PPMD -DBENCH_REMOVE_GLZA -DBENCH_REMOVE_LZJB -DBENCH_REMOVE_TAMP -DBENCH_REMOVE_ZPAQ -DBENCH_REMOVE_CSC -DBENCH_REMOVE_DENSITY -DBENCH_REMOVE_GIPFELI -DBENCH_REMOVE_LZMAT -DBENCH_REMOVE_LZRW -DBENCH_REMOVE_WFLZ -DBENCH_REMOVE_YAPPY -DBENCH_REMOVE_NVCOMP -I. -Ibench -Ilz/gpucompact -ccbin "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.44.35207\bin\Hostx64\x64\cl.exe" -Xcompiler "/O2 /MD /EHsc /Zc:preprocessor" -o lzbench.exe bench/lzbench.cpp bench/lz_codecs.cpp bench/misc_codecs.cpp bench/symmetric_codecs.cpp bench/buggy_codecs.cpp bench/threadpool.cpp lz/gpucompact/kernels.cu lz/gpucompact/context.cu lz/gpucompact/gpucompact_lzbench.cpp
```

Sources: https://github.com/UDPSendToFailed/gpucompact
