### PR TITLE
Update misa77 to 0.6.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@ v2.x.y
 - updated lzav to 5.16 (thanks to @avaneev)
 - updated nvcomp to support CUDA 13 and cccl 3 (thanks to @fwyzard)
 - updated zxc to 0.13.1 (thanks to @hellobertrand)
-- added misa77 0.5.0 (by @welcome-to-the-sunny-side)
+- added misa77 0.6.0 (by @welcome-to-the-sunny-side)
 
 v2.3 (Jun 15, 2026)
 - improvement: Reorganized compressor alias groups by type — ALL is now a composite of LZ /

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Notes column says otherwise.
 | [lzo 2.10](http://www.oberhumer.com/opensource/lzo) | 2017-03-01 | |
 | [lzsse 2019-04-18 (1847c3e827)](https://github.com/ConorStokes/LZSSE) | 2019-04-18 | 64-bit x86 only — requires SSE4.1 (Windows: MinGW-w64 only); lzsse8fast has a [bug](https://github.com/ConorStokes/LZSSE/issues/14) |
 | [memlz 0.2 beta](https://github.com/rrrlasse/memlz) | 2025-11-03 | Disabled on 32-bit ARM — unaligned access faults (SIGBUS) |
-| [misa77 0.5.0](https://github.com/welcome-to-the-sunny-side/misa77) | 2026-07-27 | Little-endian 64-bit only — needs a C++20 compiler (GCC 10+, Clang 12+); skipped automatically |
+| [misa77 0.6.0](https://github.com/welcome-to-the-sunny-side/misa77) | 2026-07-30 | Little-endian 64-bit only — needs a C++20 compiler (GCC 10+, Clang 12+); skipped automatically |
 | [nvcomp 2.2.0](https://github.com/NVIDIA/nvcomp) | 2022-02-07 | CUDA only — built with `make ENABLE_CUDA=1`; not in the default CI matrix |
 | [openzl 0.2.0](https://openzl.org/) | 2026-05-07 | 64-bit only — upstream does not support 32-bit builds |
 | [ppmd8 26.01](http://7-zip.org) | 2026-04-27 | |

--- a/bench/lz_codecs.cpp
+++ b/bench/lz_codecs.cpp
@@ -62,13 +62,14 @@ int64_t lzbench_memlz_decompress(char* inbuf, size_t insize, char* outbuf, size_
 
 int64_t lzbench_misa77_compress(char* inbuf, size_t insize, char* outbuf, size_t outsize, codec_options_t* codec_options)
 {
-    // level 0 = fastest decompression, level 1 = best ratio (the library default),
-    // level 2 = "heavy" format (better ratio still, slow compression)
-    return (int64_t)misa77::compress((const uint8_t*)inbuf, insize, (uint8_t*)outbuf, outsize, misa77::config((uint8_t)codec_options->level));
+    // Levels run -1..4 and are monotone in ratio and (inversely) in compression speed:
+    // -1 and 0 = fast compression, 1 = fastest decompression (the library default),
+    // 2 = better ratio, 3 = optimal parse, 4 = "heavy" format (best ratio, slowest compression).
+    return (int64_t)misa77::compress((const uint8_t*)inbuf, insize, (uint8_t*)outbuf, outsize, misa77::config((int8_t)codec_options->level));
 }
 
-// The decompressor detects the format (light for levels 0-1, heavy for level 2) from the
-// stream itself. misa77_safe stops at level 1 because the heavy format has no safe decoder
+// The decompressor detects the format (light for levels -1..3, heavy for level 4) from the
+// stream itself. misa77_safe stops at level 3 because the heavy format has no safe decoder
 // yet (misa77::decompress with dconfig(true) rejects heavy streams by returning 0).
 int64_t lzbench_misa77_decompress(char* inbuf, size_t insize, char* outbuf, size_t outsize, codec_options_t* codec_options)
 {

--- a/bench/lzbench.h
+++ b/bench/lzbench.h
@@ -236,8 +236,8 @@ static const compressor_desc_t comp_desc[] =
     { "lzsse8fast", "lzsse8fast 2019-04-18",   0,   0,    0,  BENCH_POOL_MT, lzbench_lzsse8fast_compress, lzbench_lzsse8_decompress,     lzbench_lzsse8fast_init, lzbench_lzsse8fast_deinit },
     { "lzvn",       "lzvn 2017-03-08",         0,   0,    0,  BENCH_POOL_MT, lzbench_lzvn_compress,       lzbench_lzvn_decompress,       lzbench_lzvn_init,       lzbench_lzvn_deinit },
     { "memlz",      "memlz 0.2 beta",          0,   0,    0,  BENCH_POOL_MT, lzbench_memlz_compress,      lzbench_memlz_decompress,      lzbench_memlz_init,      lzbench_memlz_deinit },
-    { "misa77",      "misa77 0.5.0",           0,   2,    0,  BENCH_POOL_MT, lzbench_misa77_compress,     lzbench_misa77_decompress,      NULL, NULL },
-    { "misa77_safe", "misa77 0.5.0 safe",      0,   1,    0,  BENCH_POOL_MT, lzbench_misa77_compress,     lzbench_misa77_safe_decompress, NULL, NULL },
+    { "misa77",      "misa77 0.6.0",          -1,   4,    0,  BENCH_POOL_MT, lzbench_misa77_compress,     lzbench_misa77_decompress,      NULL, NULL },
+    { "misa77_safe", "misa77 0.6.0 safe",     -1,   3,    0,  BENCH_POOL_MT, lzbench_misa77_compress,     lzbench_misa77_safe_decompress, NULL, NULL },
     { "nvcomp_lz4", "nvcomp_lz4 2.2.0",        0,   7,    0,  BENCH_POOL_MT, lzbench_nvcomp_compress,     lzbench_nvcomp_decompress,     lzbench_nvcomp_init,     lzbench_nvcomp_deinit },
     { "openzl_u8",  "openzl 0.2.0 -p u8",       0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(uint8_t),  lzbench_openzl_deinit },
     { "openzl_i8",  "openzl 0.2.0 -p i8",       0,   0,    0,  BENCH_POOL_MT, lzbench_openzl_compress,     lzbench_openzl_decompress,     lzbench_openzl_init_integer(int8_t),  lzbench_openzl_deinit },
@@ -296,7 +296,7 @@ static const alias_desc_t alias_desc[] =
               "lizard,10,12,15,19,20,22,25,29,30,32,35,39,40,42,45,49/lz4fast,17,9,3/lz4/lz4hc,1,4,9,12/lzav/" \
               "lzf,0,1/lzfse/lzg,1,4,6,8/lzham,0,1/lzlib,0,3,6,9/lzma,0,2,4,6,9/" \
               "lzo1/lzo1a/lzo1b,1,3,6,9,99,999/lzo1c,1,3,6,9,99,999/lzo1f/lzo1x/lzo1y/lzo1z/lzo2a/" \
-              "lzsse2,1,6,12,16/lzsse4fast/lzsse4,1,6,12,16/lzsse8,1,6,12,16/lzvn/memlz/misa77,0,1,2/misa77_safe,0,1/quicklz,1,2,3/" \
+              "lzsse2,1,6,12,16/lzsse4fast/lzsse4,1,6,12,16/lzsse8,1,6,12,16/lzvn/memlz/misa77,-1,0,1,2,3,4/misa77_safe,-1,0,1,2,3/quicklz,1,2,3/" \
               "slz_gzip/snappy/ucl_nrv2b,1,6,9/ucl_nrv2d,1,6,9/ucl_nrv2e,1,6,9/" \
               "xz,1,3,5,7,9/yalz77,1,6,12/zlib,1,6,9/zlib-ng,1,6,9/zstd_fast,-5,-3,-1/zstd,1,2,5,8,11,15,18,22/zxc,1,3,6" },
     { "SYMMETRIC", "Includes compressors with similar compression and decompression speeds.",

--- a/lz/misa77/README.md
+++ b/lz/misa77/README.md
@@ -1,27 +1,21 @@
-# misa77 (0.5.0)
+# misa77 (0.6.0)
 
 misa77 is an LZ-based codec that targets the write-once, read-many niche. In particular, it aims to satisfy the following criteria:
 
 - Extremely high decompression throughput (single-threaded).
 - Modest compression ratios (LZ4 at high effort levels is a good reference point).
-- Constant memory use during compression, regardless of input size (5-16 MB for levels 0-1, ~160 MB for level 2). Decompression uses no extra memory.
+- Constant memory use during compression, regardless of input size (under 3 MB for levels -1 to 2, 29 MB for level 3, 176 MB for level 4). Decompression uses no extra memory.
 
 Slow compression is the obvious tradeoff that one makes to achieve the above.
 
-In addition, misa77 has a somewhat synergizing tendency to decompress highly compressed files faster. This makes high-effort compression particularly attractive for misa77, and inspires some experimental compression modes (refer to [src/experimental/](src/experimental/)) that aim to spend more effort at compression time to produce a compressed stream that is friendlier to the microarchitectures of most CPUs when decompressing said streams.
-
-misa77 has three compression effort levels as of v0.5.0:
-
-- level 0: offers better decode throughput, slightly worse ratio, similar encode throughput
-- level 1 (default): offers slightly worse decode throughput, better ratio, similar encode throughput
-- level 2: offers similar decode throughput to level 1, the best ratio (slightly better than `lz4hc -12`), very low encode throughput
+misa77 has six compression effort levels as of v0.6.0. For most shapes of data, encode time increases and ratio decreases with increasing level, but decompression throughput is *not* similarly monotonic. In general, level 1 offers the fastest decode throughput. More information about effort levels can be found [here](#levels).
 
 There are two decompressor modes:
 
 - unsafe: passing invalid input to this mode is UB.
-- safe: guaranteed to exit gracefully (ie. provably terminate, and not access out-of-bounds memory or engage in any other UB) in the case of corrupt/malicious input, is 2-4% slower than unsafe.
+- safe: guaranteed to exit gracefully (ie. provably terminate, and not access out-of-bounds memory or engage in any other UB) in the case of corrupt/malicious input, is typically ~5% slower than unsafe.
 
-Note: as of now, level 2 doesn't have a safe decompressor. It will be added soon.
+Note: As of now, level 4 doesn't have a safe decompressor. It will be added soon.
 
 ## Benchmarks
 
@@ -29,7 +23,7 @@ Detailed results are listed ahead, but here's a terse summary:
 
 - misa77 lies on the pareto frontier for decompression throughput vs compression ratio on most shapes of data.
 - It very frequently decompresses faster even when competitors have a significantly worse ratio.
-- It is quite slow at compression.
+- It is somewhat slow at compression.
 - Performance is a bit sensitive to codegen, but even with the worst possible codegen I saw in my testing, misa77 was significantly faster than other codecs.
 
 Let's first see some cross-platform results for the [Silesia Corpus](https://sun.aei.polsl.pl//~sdeor/corpus/silesia.zip).
@@ -37,8 +31,9 @@ Let's first see some cross-platform results for the [Silesia Corpus](https://sun
 Note:
 
 1. "Ratio" ahead is equal to `((compressed size)/(original)) * 100` (so lower is better).
-2. The benchmarking harness is a public fork of lzbench, and can be accessed [here](https://github.com/welcome-to-the-sunny-side/lzbench/tree/add-misa77-0.4.0).
-3. In the tables ahead, rows are sorted by decompression speed.
+2. misa77 has been merged into [lzbench](https://github.com/inikep/lzbench/) and [TurboBench](https://github.com/powturbo/TurboBench). The results below have been produced using lzbench, and can be reproduced through both benchmarking harnesses.
+3. In the tables ahead, rows are grouped by codec family, and ordered from lowest to highest effort level within each family. The misa77 default level (1) is in bold.
+4. The tables show unsafe (trusted-input) decompression. The safe decoder costs about 3% of decode throughput on the x86-64 setup and 1-2% on the M3 for these files.
 
 ---
 
@@ -50,25 +45,26 @@ Details:
 - Single threaded, pinned to a single performance core.
 - CPU governor set to `performance`.
 
-| Compressor name       | Compression | Decompress. |  Ratio | Filename    |
-| --------------------- | ----------- | ----------- | ------ | ----------- |
-| misa77 0.5.0 -0       |   54.3 MB/s |   5359 MB/s |  42.64 | silesia.tar |
-| misa77 0.5.0 safe -0  |   54.1 MB/s |   5216 MB/s |  42.64 | silesia.tar |
-| misa77 0.5.0 -2       |   7.01 MB/s |   4470 MB/s |  35.51 | silesia.tar |
-| misa77 0.5.0 -1       |   51.2 MB/s |   4378 MB/s |  39.65 | silesia.tar |
-| misa77 0.5.0 safe -1  |   51.2 MB/s |   4252 MB/s |  39.65 | silesia.tar |
-| zxc 0.13.1 -3         |    116 MB/s |   2838 MB/s |  45.46 | silesia.tar |
-| zxc 0.13.1 -4         |   81.2 MB/s |   2726 MB/s |  42.63 | silesia.tar |
-| lzsse8fast 2019-04-18 |    183 MB/s |   2663 MB/s |  44.80 | silesia.tar |
-| zxc 0.13.1 -5         |   48.4 MB/s |   2602 MB/s |  40.25 | silesia.tar |
-| lz4hc 1.10.0 -12      |   7.31 MB/s |   2531 MB/s |  36.45 | silesia.tar |
-| lzsse4fast 2019-04-18 |    187 MB/s |   2525 MB/s |  45.26 | silesia.tar |
-| lz4 1.10.0            |    371 MB/s |   2506 MB/s |  47.59 | silesia.tar |
-| lz4hc 1.10.0 -9       |   22.0 MB/s |   2454 MB/s |  36.75 | silesia.tar |
-| lzav 5.11 -2          |   58.4 MB/s |   1729 MB/s |  34.97 | silesia.tar |
-| zxc 0.13.1 -7         |   4.27 MB/s |   1645 MB/s |  33.00 | silesia.tar |
-| zstd 1.5.7 -1         |    297 MB/s |    903 MB/s |  34.54 | silesia.tar |
-| snappy 1.2.2          |    376 MB/s |    858 MB/s |  47.89 | silesia.tar |
+| Compressor name       | Compression | Decompress. | Ratio | Filename    |
+| --------------------- | ----------- | ----------- | ----- | ----------- |
+| misa77 0.6.0 --1      |    232 MB/s |   3846 MB/s | 46.74 | silesia.tar |
+| misa77 0.6.0 -0       |    170 MB/s |   4593 MB/s | 44.60 | silesia.tar |
+| **misa77 0.6.0 -1**       |   **54.2 MB/s** |   **5376 MB/s** | **42.64** | silesia.tar |
+| misa77 0.6.0 -2       |   41.5 MB/s |   4689 MB/s | 40.33 | silesia.tar |
+| misa77 0.6.0 -3       |   10.7 MB/s |   4635 MB/s | 37.76 | silesia.tar |
+| misa77 0.6.0 -4       |   6.97 MB/s |   4366 MB/s | 35.51 | silesia.tar |
+| lz4 1.10.0            |    371 MB/s |   2514 MB/s | 47.59 | silesia.tar |
+| lz4hc 1.10.0 -9       |   22.0 MB/s |   2457 MB/s | 36.75 | silesia.tar |
+| lz4hc 1.10.0 -12      |   7.31 MB/s |   2536 MB/s | 36.45 | silesia.tar |
+| lzsse4fast 2019-04-18 |    187 MB/s |   2540 MB/s | 45.26 | silesia.tar |
+| lzsse8fast 2019-04-18 |    183 MB/s |   2671 MB/s | 44.80 | silesia.tar |
+| zxc 0.13.1 -3         |    114 MB/s |   2840 MB/s | 45.46 | silesia.tar |
+| zxc 0.13.1 -4         |   80.6 MB/s |   2731 MB/s | 42.63 | silesia.tar |
+| zxc 0.13.1 -5         |   48.2 MB/s |   2597 MB/s | 40.25 | silesia.tar |
+| zxc 0.13.1 -7         |   4.26 MB/s |   1642 MB/s | 33.00 | silesia.tar |
+| zstd 1.5.7 -1         |    297 MB/s |    903 MB/s | 34.54 | silesia.tar |
+| lzav 5.16 -2          |   62.6 MB/s |   1675 MB/s | 34.85 | silesia.tar |
+| snappy 1.2.2          |    375 MB/s |    858 MB/s | 47.89 | silesia.tar |
 
 ---
 
@@ -78,23 +74,23 @@ Details:
 
 - CPU: Apple M3
 
-| Compressor name      | Compression | Decompress. |  Ratio | Filename    |
-| -------------------- | ----------- | ----------- | ------ | ----------- |
-| misa77 0.5.0 -0      |    134 MB/s |  12660 MB/s |  42.64 | silesia.tar |
-| misa77 0.5.0 safe -0 |    134 MB/s |  12484 MB/s |  42.64 | silesia.tar |
-| misa77 0.5.0 -1      |    127 MB/s |  10270 MB/s |  39.65 | silesia.tar |
-| misa77 0.5.0 safe -1 |    127 MB/s |  10100 MB/s |  39.65 | silesia.tar |
-| misa77 0.5.0 -2      |   13.6 MB/s |   9935 MB/s |  35.51 | silesia.tar |
-| zxc 0.13.1 -3        |    279 MB/s |   8030 MB/s |  45.77 | silesia.tar |
-| zxc 0.13.1 -4        |    193 MB/s |   7663 MB/s |  43.20 | silesia.tar |
-| zxc 0.13.1 -5        |    115 MB/s |   7166 MB/s |  40.30 | silesia.tar |
-| lz4 1.10.0           |    882 MB/s |   5166 MB/s |  47.59 | silesia.tar |
-| lz4hc 1.10.0 -9      |   53.2 MB/s |   4885 MB/s |  36.74 | silesia.tar |
-| lz4hc 1.10.0 -12     |   17.0 MB/s |   4883 MB/s |  36.45 | silesia.tar |
-| zxc 0.13.1 -7        |   9.78 MB/s |   4310 MB/s |  33.01 | silesia.tar |
-| lzav 5.11 -2         |    175 MB/s |   4261 MB/s |  34.97 | silesia.tar |
-| snappy 1.2.2         |    967 MB/s |   3438 MB/s |  47.91 | silesia.tar |
-| zstd 1.5.7 -1        |    722 MB/s |   1615 MB/s |  34.54 | silesia.tar |
+| Compressor name  | Compression | Decompress. | Ratio | Filename    |
+| ---------------- | ----------- | ----------- | ----- | ----------- |
+| misa77 0.6.0 --1 |    541 MB/s |   9739 MB/s | 46.74 | silesia.tar |
+| misa77 0.6.0 -0  |    385 MB/s |  11777 MB/s | 44.60 | silesia.tar |
+| **misa77 0.6.0 -1**  |    **135 MB/s** |  **12638 MB/s** | **42.64** | silesia.tar |
+| misa77 0.6.0 -2  |    103 MB/s |  10868 MB/s | 40.33 | silesia.tar |
+| misa77 0.6.0 -3  |   19.5 MB/s |  10280 MB/s | 37.76 | silesia.tar |
+| misa77 0.6.0 -4  |   13.5 MB/s |   9925 MB/s | 35.51 | silesia.tar |
+| lz4 1.10.0       |    882 MB/s |   5195 MB/s | 47.59 | silesia.tar |
+| lz4hc 1.10.0 -9  |   53.0 MB/s |   4899 MB/s | 36.74 | silesia.tar |
+| lz4hc 1.10.0 -12 |   17.0 MB/s |   4887 MB/s | 36.45 | silesia.tar |
+| zxc 0.13.1 -3    |    278 MB/s |   8022 MB/s | 45.77 | silesia.tar |
+| zxc 0.13.1 -4    |    193 MB/s |   7642 MB/s | 43.20 | silesia.tar |
+| zxc 0.13.1 -5    |    114 MB/s |   7162 MB/s | 40.30 | silesia.tar |
+| zstd 1.5.7 -1    |    722 MB/s |   1615 MB/s | 34.54 | silesia.tar |
+| lzav 5.16 -2     |    185 MB/s |   4243 MB/s | 34.85 | silesia.tar |
+| snappy 1.2.2     |    967 MB/s |   3439 MB/s | 47.91 | silesia.tar |
 
 ---
 
@@ -102,22 +98,40 @@ As misa77's performance is quite "spiky" (depending on the shape of the data bei
 
 Note: 
 
-- The visuals that follow are derived from the benchmark results at [misc/lzbench-results-archive/0.5.0/intel.txt](misc/lzbench-results-archive/0.5.0/intel.txt)
+- The visuals that follow are derived from the benchmark results at [misc/lzbench-results-archive/0.6.0/intel.txt](misc/lzbench-results-archive/0.6.0/intel.txt)
 - These results are with the same x86-64 (Intel) setup mentioned previously.
 
 ### Decode speed relative to lz4
 
-At level 0, misa77 decodes faster than lz4 on all 12 files (some by huge margins). Levels 1 and 2 decode faster on 11/12 files each, while compressing substantially better than lz4 everywhere. The exception is `x-ray`, which is highly incompressible (lz4 has a ratio of nearly 1.0 on this file and essentially devolves to a `memcpy`).
+At level 1, misa77 decodes faster than lz4 on all 12 files (some by huge margins). 
 
-![misa77 per-file decode speed vs lz4, levels 0-2, Silesia (Intel)](misc/lzbench-results-archive/0.5.0/speedup_vs_lz4.png)
+![misa77 per-file decode speed vs lz4, levels -1 to 4, Silesia (Intel)](misc/lzbench-results-archive/0.6.0/speedup_vs_lz4.png)
 
 ### Throughput vs ratio, against popular fast-decode codecs
 
-On the compressible files, misa77 sits on the decode-throughput/ratio Pareto frontier: it decodes fastest while ~matching or beating the ratio of the other fast-LZ codecs. `x-ray` is an exception once again.
+On the compressible files, misa77 sits on the decode-throughput/ratio Pareto frontier: it decodes fastest while ~matching or beating the ratio of the other fast-LZ codecs. (`x-ray` and `sao` are exceptions as most compressors have a ratio near 1, and their decode essentially devolves to a `memcpy`).
 
 To spot misa77 in these graphs, just look for the circles near the top :)
 
-![misa77 vs other codecs: per-file decode throughput vs ratio, Silesia (Intel), levels 0-2](misc/lzbench-results-archive/0.5.0/pareto_silesia.png)
+![misa77 vs other codecs: per-file decode throughput vs ratio, Silesia (Intel), levels -1 to 4](misc/lzbench-results-archive/0.6.0/pareto_silesia.png)
+
+## Levels
+
+Levels are ordered by compression effort. For most shapes of data, encode time increases and ratio decreases with increasing level, but decompression throughput is *not* similarly monotonic.
+
+| Level | Description                                             | Ratio | Encode vs L1 | Decode vs L1 | Encoder memory | Format |
+| ----- | ------------------------------------------------------- | ----- | ------------ | ------------ | -------------- | ------ |
+| -1    | fastest compression (not recommended as slow to decode) | 46.74 | 4.0-4.3x     | 72-77%       | 1 MB           | light  |
+| 0     | fast compression, lz4-class ratio                       | 44.60 | 2.9-3.1x     | 85-93%       | 1 MB           | light  |
+| **1**     | **default, fastest decode**                                 | 42.64 | 1x           | 100%         | 3 MB           | light  |
+| 2     | better ratio, still cheap to encode                     | 40.33 | 0.76-0.77x   | 86-87%       | 3 MB           | light  |
+| 3     | best ratio in the light format                          | 37.76 | 0.14-0.20x   | 81-86%       | 29 MB          | light  |
+| 4     | best ratio overall, prefer on inputs above ~1 MB        | 35.51 | 0.10-0.13x   | 79-81%       | 176 MB         | heavy  |
+
+- `Ratio` is measured on `silesia.tar` in the [Intel run](#intel-x86-64).
+- The `Encode`/`Decode vs L1` columns are relative to level 1, given as the range spanned by the Intel and M3 runs.
+- `Encoder memory` is the compressor's own working state (disjoint from the caller's input and output buffers). Decompression needs no working memory at all.
+- Levels -1 to 3 emit the light format (see [`docs/format.md`](docs/format.md)) and have a safe decoder. Level 4 emits the heavy format, which does not have one yet.
 
 ## Requirements
 
@@ -161,7 +175,7 @@ Sample usage:
 #include <misa77/misa77.h>
 #include <vector>
 
-// compress (pick a level with misa77::config(0/1/2); default is 1), returns 0 on failure
+// compress (pick a level with misa77::config(N) with N in [-1, 4], default is 1), returns 0 on failure
 misa77::config cfg;
 std::vector<uint8_t> compressed(misa77::compress_bound(input_size, cfg));
 uint64_t csize = misa77::compress(input, input_size, compressed.data(), compressed.size(), cfg);
@@ -178,44 +192,29 @@ Three things to keep in mind:
 
 - You must size the destination buffers with `compress_bound` / `decompressed_buffer_bound`, passing `compress_bound` the same `config` you compress with (the bound depends on the level's format).
 - You must pass `misa77::dconfig(true)` to `misa77::decompress` if you want the decompressor to exit gracefully on invalid input.
-- Safe decompression does not support level-2 streams yet: `decompress` with `dconfig(true)` returns 0 for them (the unsafe path decodes them fine).
+- Safe decompression does not support level-4 streams yet: `decompress` with `dconfig(true)` returns 0 for them (the unsafe path decodes them fine).
 
 The experimental modes are declared in `misa77/experimental.h`, with usage documented in comments (these keep changing frequently so I don't wanna "formally" document them here just yet).
 
 ## CLI Usage
 
-`misa` is a single, dependency-free binary with three file-based subcommands. It operates on single files only (there's no directory or pipe support, so `tar` first if you need those).
+`misa` is a single, dependency-free binary with two file-based subcommands. It operates on single files only (there's no directory or pipe support, so `tar` first if you need those).
 
 ```sh
 misa compress   FILE          # -> FILE.misa77
 misa decompress FILE.misa77   # -> FILE
-misa suggest    FILE          # -> FILE.misap  (tuned params)
 ```
 
-`misa compress` takes `-l N` / `--level N` to pick the compression level (default is 1).
-
-There are also some experimental compression modes (at most one at a time, not combinable with `--level`):
-
-| Flag | Effect |
-| ---- | ------ |
-| `--adaptive` | autotune the compressor based on the input for decode speed (only use this with homogeneous data) |
-| `--params F.misap` | compress with a vector from `misa suggest` |
-| `--yolo` | high-effort, decode-optimized |
-
-`--adaptive` and `suggest` also take `--tune loose` / `--tune tight` (similar tradeoffs as `level 0/1`, and the default is loose) and `--sample MB` (how much input to sample when picking params, default is 2 MB). Everywhere, `-o PATH` sets the output path and `-f` overwrites without asking.
+`misa compress` takes `-l N` / `--level N` to pick the compression level (default is 1). Everywhere, `-o PATH` sets the output path and `-f` overwrites without asking.
 
 ```sh
-misa compress -l 0 enwik8                # enwik8 -> enwik8.misa77, fastest-decode level
-misa decompress enwik8.misa77            # back to enwik8
-
-# tune on a sample, then reuse the params:
-misa suggest --tune tight data.bin       # -> data.misap
-misa compress --params data.misap data.bin
+misa compress -l 0 enwik8                # enwik8 -> enwik8.misa77
+misa decompress enwik8.misa77 -f         # back to enwik8
 ```
 
 ## Documentation
 
-The underlying stream format (used by the library functions) and the container format for `.misa77` files (produced by the CLI) can be found in [`docs/`](docs/).
+The underlying stream formats (used by the library functions) and the container format for `.misa77` files (produced by the CLI) can be found in [`docs/`](docs/).
 
 ## Status
 
@@ -232,7 +231,11 @@ Inspiration has been taken from:
 - [zxc](https://github.com/hellobertrand/zxc)
 - [lizard](https://github.com/inikep/lizard)
 
-Lastly, Claude Fable 5 and Opus 4.8 helped a *lot* with orchestrating experiments, scripting, tooling, and building the CLI. Without their assistance, development would have been far slower, and I would likely not have explored all the paths that I did end up exploring (some of which were productive and some of which weren't).
+Lastly, the following models helped a *lot* with orchestrating experiments, scripting, tooling, and building the CLI. Without their assistance, development would have been far slower, and I would likely not have explored all the paths that I did end up exploring (some of which were productive and some of which weren't).
+
+- Claude Fable 5
+- Claude Opus 5
+- Claude Opus 4.8
 
 ## License
 

--- a/lz/misa77/include/misa77/misa77.h
+++ b/lz/misa77/include/misa77/misa77.h
@@ -8,7 +8,7 @@
 
 // Library version
 #define MISA77_VERSION_MAJOR 0
-#define MISA77_VERSION_MINOR 5
+#define MISA77_VERSION_MINOR 6
 #define MISA77_VERSION_PATCH 0
 #define MISA77_VERSION_NUMBER                                                                      \
     (MISA77_VERSION_MAJOR * 10000 + MISA77_VERSION_MINOR * 100 + MISA77_VERSION_PATCH)
@@ -27,17 +27,18 @@ namespace misa77
     class config
     {
     public:
-        // Only integers in [0, max_level] are valid levels
-        static constexpr uint8_t max_level = 2;
-        static constexpr uint8_t default_level = 1;
-        static_assert(default_level <= max_level);
+        // Only integers in [min_level, max_level] are valid levels
+        static constexpr int8_t min_level = -1;
+        static constexpr int8_t max_level = 4;
+        static constexpr int8_t default_level = 1;
+        static_assert(min_level <= default_level and default_level <= max_level);
 
-        // Light levels in [0, heavy_lb), heavy levels in [heavy_lb, max_level]
-        static constexpr uint8_t heavy_lb = 2;
+        // Light levels in [min_level, heavy_lb), heavy levels in [heavy_lb, max_level]
+        static constexpr int8_t heavy_lb = 4;
 
-        uint8_t level;
+        int8_t level;
         config() : level(default_level) {}
-        explicit config(uint8_t l) : level(l) {}
+        explicit config(int8_t l) : level(l) {}
     };
 
     // decompressor config
@@ -60,7 +61,8 @@ namespace misa77
     // Returns number of bytes written to `dst`, and 0 on failure.
     // `cfg.level` selects the compressor to be used. Levels below `config::heavy_lb` emit the
     // light format, levels at or above it emit the heavy format.
-    // PRECONDITION: `src_size <= max_src_size` and `0 <= cfg.level <= config::max_level`
+    // PRECONDITION: `src_size <= max_src_size` and
+    // `config::min_level <= cfg.level <= config::max_level`
     uint64_t compress(const uint8_t* __restrict src,
                       uint64_t src_size,
                       uint8_t* __restrict dst,

--- a/lz/misa77/src/compressor_zoo/heavy_optimal_cimpl.h
+++ b/lz/misa77/src/compressor_zoo/heavy_optimal_cimpl.h
@@ -17,7 +17,7 @@
 
 namespace misa77
 {
-    namespace heavy_detail
+    namespace heavy_optimal_detail
     {
         using namespace heavy;
 
@@ -135,18 +135,18 @@ namespace misa77
                 return -1;
             }
         };
-    } // namespace heavy_detail
+    } // namespace heavy_optimal_detail
 
     // Returns number of bytes written to `dst`, and 0 on failure.
     // `isa_lib` is ISA-dependent.
     template <class isa_lib>
-    uint64_t heavy_compress_impl(const uint8_t* __restrict src,
+    uint64_t heavy_optimal_cimpl(const uint8_t* __restrict src,
                                  uint64_t src_size,
                                  uint8_t* __restrict dst,
                                  uint64_t dst_cap)
     {
         using namespace heavy;
-        using namespace heavy_detail;
+        using namespace heavy_optimal_detail;
 
         if (compress_bound(src_size, config(config::heavy_lb)) > dst_cap)
             return 0;

--- a/lz/misa77/src/compressor_zoo/light_blitz_cimpl.h
+++ b/lz/misa77/src/compressor_zoo/light_blitz_cimpl.h
@@ -1,0 +1,283 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "format.h"
+#include "misa77/misa77.h"
+#include "util.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace misa77
+{
+    namespace light_blitz_detail
+    {
+        using namespace light;
+
+        constexpr uint32_t hash_top = 16;
+        constexpr uint32_t hash_siz = 1 << hash_top;
+
+        constexpr uint64_t hash6_mul = 0x9E3779B185EBCA87; // 2^64 / phi
+
+        // Hash the low 6 bytes of an 8-byte load
+        [[gnu::always_inline]]
+        inline uint32_t hash6(const uint64_t val)
+        {
+            constexpr uint64_t mask = (uint64_t(1) << 48) - 1;
+            return uint32_t(((val & mask) * hash6_mul) >> (64 - hash_top));
+        }
+
+        // Assuming that rem contains top 3 bits of the token, emits bytes specifying `n`.
+        [[gnu::always_inline]]
+        inline void emit_length_extras(uint8_t* dst, uint64_t& dlpos, uint64_t n, uint8_t rem)
+        {
+            if (rem != uint8_t(7)) [[likely]]
+                return;
+
+            // Write this unconditionally first, if it's wrong we'll just overwrite
+            dst[dlpos] = static_cast<uint8_t>(n);
+
+            constexpr uint64_t block = 255;
+            if (n >= block) [[unlikely]]
+            {
+                while (n >= block) [[unlikely]]
+                    dst[dlpos] = block, ++dlpos, n -= block;
+                dst[dlpos] = static_cast<uint8_t>(n);
+            }
+
+            ++dlpos;
+        }
+
+        // Probe every other position. Not that detrimental to ratio because of back-extensions.
+        constexpr uint64_t probe_step = 2;
+
+        // Higher bar than the other modes
+        constexpr uint64_t accept_len = 9;
+        static_assert(accept_len >= min_match_len);
+
+        // We ideally want to keep literal length `<= fire_at`
+        constexpr uint64_t fire_at = 6;
+
+        // When you've gone `p` hashtab searches without a match, advance the pointer by `p >>
+        // skip_shift`
+        constexpr uint64_t skip_shift = 6;
+    } // namespace light_blitz_detail
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // `isa_lib` is ISA-dependent.
+    template <class isa_lib>
+    uint64_t light_blitz_cimpl(const uint8_t* __restrict src,
+                               uint64_t src_size,
+                               uint8_t* __restrict dst,
+                               uint64_t dst_cap)
+    {
+        using namespace light;
+        using namespace light_blitz_detail;
+
+        static_assert(max_match_len >= 32);
+
+        if (compress_bound(src_size, config()) > dst_cap)
+            return 0;
+
+        // Left pointer in the destination buffer (metadata and control bytes)
+        uint64_t dlpos = 0;
+
+        // Right pointer in the destination buffer (literal bytes)
+        // We've written to `[drpos, dst_cap)` at any given point of time
+        uint64_t drpos = dst_cap;
+
+        storeu8(dst, src_size);
+        dlpos += 8;
+
+        // Small source
+        if (src_size <= small_lim)
+        {
+            if (src_size != 0)
+                memcpy(dst + dlpos, src, src_size);
+            dlpos += src_size;
+            return dlpos;
+        }
+
+        uint64_t literal_suffix_pos = dlpos;
+        dlpos += 8;
+
+        // Ensure that the last `literal_suffix` bytes will be literals
+        uint64_t match_end_limit = (src_size < literal_suffix ? 0 : src_size - literal_suffix);
+
+        // Beginning of the pending literal window
+        uint64_t lit = 0;
+
+        // `[lit, pos]` corresponds to the new range from the src buffer we're going to be
+        // turning into a lit + match pair
+        uint64_t pos = 0;
+
+        // `[0, hpos)` represents the range we've written into the hashtable
+        uint64_t hpos = 0;
+
+        uint64_t miss_run = 0;
+
+        // Single-slot table (insertion stays per-byte unlike probes)
+        std::vector<uint16_t> hashtab(hash_siz);
+
+        // Last remembered match
+        uint64_t cand_pos = 0, cand_len = 0, cand_lst = 0;
+
+        while (pos + max_match_len <= match_end_limit)
+        {
+            // Reduce branch misses, `batch = 8` performs well empirically
+            constexpr uint64_t batch = 8;
+            while (pos >= hpos + hashtab_lag + batch) [[unlikely]]
+            {
+#pragma GCC unroll batch
+                for (uint64_t i = 0; i < batch; i++)
+                    hashtab[hash6(loadu8(src + hpos + i))] = uint16_t(hpos + i);
+                hpos += batch;
+            }
+
+            uint64_t lst = 0;
+            uint64_t match_len = 0;
+
+            if (pos > hashtab_lag) [[likely]]
+            {
+                // Exact cheap filter: `lcp >= min_match_len` iff the first 4 bytes agree
+                const uint32_t val4 = loadu4(src + pos);
+                uint16_t d = uint16_t(pos - hashtab[hash6(loadu8(src + pos))] - hashtab_lag - 1);
+
+                // Guaranteed to lie within `[pos - 2^16 - hashtab_lag, pos - hashtab_lag)`
+                uint64_t ilst = (pos - max_match_len - 1 - d);
+
+                if (loadu4(src + ilst) == val4)
+                {
+                    typename isa_lib::vec reg = isa_lib::loadvec(src + pos);
+                    typename isa_lib::vec ireg = isa_lib::loadvec(src + ilst);
+                    lst = ilst;
+                    match_len = isa_lib::lcp(reg, ireg);
+                }
+            }
+
+            // We've inserted stuff into the hashtable assuming this value of `pos`, so we cannot
+            // probe it for any starting position behind this one going forward. This is
+            // important as `pos` is regressed ahead.
+            uint64_t pos_safe_bound = pos;
+
+            bool accept = (match_len >= accept_len);
+
+            uint64_t pend = pos - lit;
+
+            // Fire as soon as the next probe would overshoot `fire_at`: runs stay <= 6 and
+            // the lit field never spills into extras
+            bool fire = (pend + probe_step - 1 >= fire_at);
+
+            // We don't have an ideal match
+            if (!accept)
+            {
+                if (fire)
+                {
+                    // Prefer the one ending later between this position and the last remembered one
+                    if (cand_len != 0 and
+                        (match_len < min_match_len or cand_pos + cand_len >= pos + match_len))
+                    {
+                        pos = cand_pos;
+                        lst = cand_lst;
+                        match_len = cand_len;
+                    }
+
+                    // Note that if `accept` becomes false here, pos isn't pushed back by the above
+                    // branch
+                    accept = (match_len >= min_match_len);
+                }
+                else if (match_len >= min_match_len and
+                         (cand_len == 0 or pos + match_len >= cand_pos + cand_len))
+                {
+                    // This position becomes the new candidate
+                    cand_pos = pos;
+                    cand_len = match_len;
+                    cand_lst = lst;
+                }
+            }
+
+            if (accept)
+            {
+                // Extend the match backwards (note that `dis` in `(hashtab_lag, 2^16 +
+                // hashtab_lag]` holds).
+                // Extending `pos` backwards here is safe because we're not looking into the
+                // hashtable.
+                while (pos > lit and lst > 0 and match_len < max_match_len and
+                       src[pos - 1] == src[lst - 1])
+                {
+                    --pos;
+                    --lst;
+                    ++match_len;
+                }
+
+                uint64_t norm_match_len = match_len - min_match_len + 1;
+
+                // `src[lit, pos)` are the literals
+                uint64_t lit_len = pos - lit;
+
+                // Token Byte
+                uint8_t lrem = std::min(uint64_t(7), lit_len);
+                dst[dlpos] = static_cast<uint8_t>((lrem << 5) | (norm_match_len));
+                lit_len -= lrem;
+                ++dlpos;
+
+                // 2 Distance bytes
+                uint64_t dis = pos - lst;
+                uint16_t dbytes = dis - hashtab_lag - 1;
+                storeu2(dst + dlpos, dbytes);
+                dlpos += 2;
+
+                // Extra literal length bytes
+                emit_length_extras(dst, dlpos, lit_len, lrem);
+
+                // Literal bytes
+                if (lit < pos)
+                {
+                    uint64_t lit_cnt = pos - lit;
+                    drpos -= lit_cnt;
+
+                    // Fixed 16-byte copy ending at the old drpos; bytes below the run only clobber
+                    // not-yet-written literal space. The fire rule keeps runs short, so the branch
+                    // is predictable.
+                    if (lit_cnt <= 16) [[likely]]
+                        memcpy(dst + drpos + lit_cnt - 16, src + lit + lit_cnt - 16, 16);
+                    else
+                        memcpy(dst + drpos, src + lit, lit_cnt);
+                }
+
+                pos += match_len;
+                lit = pos;
+                pos = std::max(pos, pos_safe_bound);
+                cand_len = 0;
+                miss_run = 0;
+            }
+            else
+            {
+                pos += probe_step + (miss_run >> skip_shift);
+                ++miss_run;
+            }
+        }
+
+        // Close the gap between the two streams by moving the literal stream to the left
+        if (drpos < dst_cap)
+        {
+            memmove(dst + dlpos, dst + drpos, dst_cap - drpos);
+            dlpos += dst_cap - drpos;
+        }
+
+        // Just deal with the last few literals (guaranteed to be `>= literal_suffix >=
+        // vector_width` bytes)
+        uint64_t literal_suffix_cnt = src_size - lit;
+        storeu8(dst + literal_suffix_pos, literal_suffix_cnt);
+        memcpy(dst + dlpos, src + lit, literal_suffix_cnt);
+        dlpos += literal_suffix_cnt;
+
+        return dlpos;
+    }
+
+} // namespace misa77

--- a/lz/misa77/src/compressor_zoo/light_keen_cimpl.h
+++ b/lz/misa77/src/compressor_zoo/light_keen_cimpl.h
@@ -1,0 +1,347 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "format.h"
+#include "misa77/misa77.h"
+#include "util.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace misa77
+{
+    namespace light_keen_detail
+    {
+        using namespace light;
+
+        constexpr uint32_t hash_top = 16;
+        constexpr uint32_t hash_siz = 1 << hash_top;
+        constexpr uint32_t hash_mul = 2654435761;
+
+        // Size of ring buffer per hash in the hashtable. Wider than other hashtable modes to
+        // lengthen matches, which improves ratio and decode (lesser tokens).
+        inline constexpr uint64_t hashtab_wid = 20;
+
+        // Hash 4 bytes to an integer in `[0, 1 << (hash_top))`.
+        [[gnu::always_inline]]
+        inline uint32_t hash4(const uint32_t val)
+        {
+            return (val * hash_mul) >> (32 - hash_top);
+        }
+
+        // Assuming that rem contains top 3 bits of the token, emits bytes specifying `n`.
+        [[gnu::always_inline]]
+        inline void emit_length_extras(uint8_t* dst, uint64_t& dlpos, uint64_t n, uint8_t rem)
+        {
+            if (rem != uint8_t(7)) [[likely]]
+                return;
+
+            // Write this unconditionally first, if it's wrong we'll just overwrite
+            dst[dlpos] = static_cast<uint8_t>(n);
+
+            constexpr uint64_t block = 255;
+            if (n >= block) [[unlikely]]
+            {
+                while (n >= block) [[unlikely]]
+                    dst[dlpos] = block, ++dlpos, n -= block;
+                dst[dlpos] = static_cast<uint8_t>(n);
+            }
+
+            ++dlpos;
+        }
+
+        // A match must clear this bar to be taken on sight (shorter ones only get emitted through
+        // the fire rule below)
+        constexpr uint64_t accept_len = 6;
+        static_assert(accept_len >= min_match_len);
+
+        // We ideally want to keep literal length `<= fire_at`
+        constexpr uint64_t fire_at = 6;
+
+        // Don't look further ahead once you have a match `>= la_gate`
+        constexpr uint64_t la_gate = 16;
+
+        // Once you have match `>= la_pate`, only keep looking if you get gains
+        constexpr uint64_t la_pate = 8;
+
+        // When you've gone `p` hashtab searches without a match, advance the pointer by `p >>
+        // skip_shift`
+        constexpr uint64_t skip_shift = 6;
+
+        // Regime counter: an adaptive value in `[0, regime_cap]`
+        // Emits with literal length `>= lit_lim` have a vote of `+3`, others `-1`
+        // Above the threshold the accept bar falls back to `min_match_len`: extras-heavy data needs
+        // its short matches, both for ratio and for the predictable token pattern the decoder's
+        // branches learn
+        inline constexpr int64_t regime_cap = 64;
+        inline constexpr int64_t regime_threshold = 32;
+
+    } // namespace light_keen_detail
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // `isa_lib` is ISA-dependent.
+    template <class isa_lib>
+    uint64_t light_keen_cimpl(const uint8_t* __restrict src,
+                              uint64_t src_size,
+                              uint8_t* __restrict dst,
+                              uint64_t dst_cap)
+    {
+        using namespace light;
+        using namespace light_keen_detail;
+
+        static_assert(max_match_len >= 32);
+
+        if (compress_bound(src_size, config()) > dst_cap)
+            return 0;
+
+        // Left pointer in the destination buffer (metadata and control bytes)
+        uint64_t dlpos = 0;
+
+        // Right pointer in the destination buffer (literal bytes)
+        // We've written to `[drpos, dst_cap)` at any given point of time
+        uint64_t drpos = dst_cap;
+
+        storeu8(dst, src_size);
+        dlpos += 8;
+
+        // Small source
+        if (src_size <= small_lim)
+        {
+            if (src_size != 0)
+                memcpy(dst + dlpos, src, src_size);
+            dlpos += src_size;
+            return dlpos;
+        }
+
+        uint64_t literal_suffix_pos = dlpos;
+        dlpos += 8;
+
+        // Ensure that the last `literal_suffix` bytes will be literals
+        uint64_t match_end_limit = (src_size < literal_suffix ? 0 : src_size - literal_suffix);
+
+        // Beginning of the pending literal window
+        uint64_t lit = 0;
+
+        // `[lit, pos]` corresponds to the new range from the src buffer we're going to be
+        // turning into a lit + match pair
+        uint64_t pos = 0;
+
+        // `[0, hpos)` represents the range we've written into the hashtable
+        uint64_t hpos = 0;
+
+        uint64_t miss_run = 0;
+
+        std::vector<std::array<uint16_t, hashtab_wid>> hashtab(hash_siz);
+        std::vector<uint8_t> hashtab_idx(hash_siz);
+
+        // Last remembered below-threshold match
+        uint64_t cand_pos = 0, cand_len = 0, cand_lst = 0;
+
+        // Adaptive variable that reflects values of lit_len we've been getting for recent blocks
+        int64_t regime = 0;
+
+        while (pos + max_match_len <= match_end_limit)
+        {
+            // Reduce branch misses, `batch = 8` performs well empirically
+            constexpr uint64_t batch = 8;
+            while (pos >= hpos + hashtab_lag + batch) [[unlikely]]
+            {
+#pragma GCC unroll batch
+                for (uint64_t i = 0; i < batch; i++)
+                {
+                    uint32_t hsh = hash4(loadu4(src + hpos + i));
+                    hashtab[hsh][hashtab_idx[hsh]] =
+                        uint16_t(hpos + i); // We just store the lowest 2 bytes
+                    hashtab_idx[hsh] =
+                        (hashtab_idx[hsh] == hashtab_wid - 1
+                             ? uint8_t(0)
+                             : hashtab_idx[hsh] + 1); // Just cycle the pointer in the ring buffer
+                }
+                hpos += batch;
+            }
+
+            uint32_t val = loadu4(src + pos);
+            uint32_t hsh = hash4(val);
+
+            uint64_t lst = 0;
+            uint64_t match_len = 0;
+
+            typename isa_lib::vec reg = isa_lib::loadvec(src + pos);
+
+            if (pos > hashtab_lag) [[likely]]
+            {
+// MLP
+#pragma GCC unroll hashtab_wid
+                for (uint8_t i = 0; i < hashtab_wid; i++)
+                {
+                    uint16_t d = uint16_t(pos - hashtab[hsh][i] - hashtab_lag - 1);
+
+                    // Guaranteed to lie within `[pos - 2^16 - hashtab_lag, pos - hashtab_lag)`
+                    uint64_t ilst = (pos - max_match_len - 1 - d);
+
+                    typename isa_lib::vec ireg = isa_lib::loadvec(src + ilst);
+                    uint32_t imatch_len = isa_lib::lcp(reg, ireg);
+                    lst = (imatch_len > match_len ? ilst : lst);
+                    match_len = (imatch_len > match_len ? imatch_len : match_len);
+                }
+            }
+
+            // We've inserted stuff into the hashtable assuming this value of `pos`, so we cannot
+            // probe it for any starting position behind this one going forward. This is
+            // important as `pos` is regressed ahead.
+            uint64_t pos_safe_bound = pos;
+
+            bool accept =
+                (match_len >= (regime >= regime_threshold ? uint64_t(min_match_len) : accept_len));
+
+            if (accept)
+            {
+                for (uint64_t npos = pos + 1;
+                     npos <= pos + lookahead and npos + max_match_len <= match_end_limit and
+                     match_len < la_gate;
+                     npos++)
+                {
+                    uint64_t nlst = 0;
+                    uint64_t nmatch_len = 0;
+
+                    uint32_t val = loadu4(src + npos);
+                    uint32_t hsh = hash4(val);
+                    typename isa_lib::vec reg = isa_lib::loadvec(src + npos);
+#pragma GCC unroll hashtab_wid
+                    for (uint8_t i = 0; i < hashtab_wid; i++)
+                    {
+                        uint16_t d = uint16_t(npos - hashtab[hsh][i] - hashtab_lag - 1);
+
+                        // Guaranteed to lie within `[npos - 2^16 - hashtab_lag, npos -
+                        // hashtab_lag)`
+                        uint64_t ilst = (npos - max_match_len - 1 - d);
+
+                        typename isa_lib::vec ireg = isa_lib::loadvec(src + ilst);
+                        uint32_t imatch_len = isa_lib::lcp(reg, ireg);
+
+                        nlst = (imatch_len > nmatch_len ? ilst : nlst);
+                        nmatch_len = (imatch_len > nmatch_len ? imatch_len : nmatch_len);
+                    }
+
+                    bool improved = (nmatch_len > match_len);
+                    pos = (improved ? npos : pos);
+                    lst = (improved ? nlst : lst);
+                    match_len = (improved ? nmatch_len : match_len);
+
+                    if (!improved and match_len >= la_pate)
+                        break;
+                }
+            }
+            else
+            {
+                uint64_t pend = pos - lit;
+
+                if (pend >= fire_at)
+                {
+                    // Prefer the one ending later between this position and the last
+                    // remembered one
+                    if (cand_len != 0 and
+                        (match_len < min_match_len or cand_pos + cand_len >= pos + match_len))
+                    {
+                        pos = cand_pos;
+                        lst = cand_lst;
+                        match_len = cand_len;
+                    }
+
+                    // Note that if `accept` becomes false here, pos isn't pushed back by the
+                    // above branch
+                    accept = (match_len >= min_match_len);
+                }
+                else if (match_len >= min_match_len and
+                         (cand_len == 0 or pos + match_len >= cand_pos + cand_len))
+                {
+                    // This position becomes the new candidate
+                    cand_pos = pos;
+                    cand_len = match_len;
+                    cand_lst = lst;
+                }
+            }
+
+            if (accept)
+            {
+                // Extend the match backwards (note that `dis` in `(hashtab_lag, 2^16 +
+                // hashtab_lag]` holds).
+                // Extending `pos` backwards here is safe because we're not looking into the
+                // hashtable.
+                while (pos > lit and lst > 0 and match_len < max_match_len and
+                       src[pos - 1] == src[lst - 1])
+                {
+                    --pos;
+                    --lst;
+                    ++match_len;
+                }
+
+                uint64_t norm_match_len = match_len - min_match_len + 1;
+
+                // `src[lit, pos)` are the literals
+                uint64_t lit_len = pos - lit;
+
+                // regime vote
+                regime += (lit_len >= lit_lim ? 3 : -1);
+                regime = std::clamp<int64_t>(regime, 0, regime_cap);
+
+                // Token Byte
+                uint8_t lrem = std::min(uint64_t(7), lit_len);
+                dst[dlpos] = static_cast<uint8_t>((lrem << 5) | (norm_match_len));
+                lit_len -= lrem;
+                ++dlpos;
+
+                // 2 Distance bytes
+                uint64_t dis = pos - lst;
+                uint16_t dbytes = dis - hashtab_lag - 1;
+                storeu2(dst + dlpos, dbytes);
+                dlpos += 2;
+
+                // Extra literal length bytes
+                emit_length_extras(dst, dlpos, lit_len, lrem);
+
+                // Literal bytes
+                if (lit < pos)
+                {
+                    uint64_t lit_cnt = pos - lit;
+                    drpos -= lit_cnt;
+                    memcpy(dst + drpos, src + lit, lit_cnt);
+                }
+
+                pos += match_len;
+                lit = pos;
+                pos = std::max(pos, pos_safe_bound);
+                cand_len = 0;
+                miss_run = 0;
+            }
+            else
+            {
+                pos += 1 + (miss_run >> skip_shift);
+                ++miss_run;
+            }
+        }
+
+        // Close the gap between the two streams by moving the literal stream to the left
+        if (drpos < dst_cap)
+        {
+            memmove(dst + dlpos, dst + drpos, dst_cap - drpos);
+            dlpos += dst_cap - drpos;
+        }
+
+        // Just deal with the last few literals (guaranteed to be `>= literal_suffix >=
+        // vector_width` bytes)
+        uint64_t literal_suffix_cnt = src_size - lit;
+        storeu8(dst + literal_suffix_pos, literal_suffix_cnt);
+        memcpy(dst + dlpos, src + lit, literal_suffix_cnt);
+        dlpos += literal_suffix_cnt;
+
+        return dlpos;
+    }
+
+} // namespace misa77

--- a/lz/misa77/src/compressor_zoo/light_loose_cimpl.h
+++ b/lz/misa77/src/compressor_zoo/light_loose_cimpl.h
@@ -16,7 +16,7 @@
 
 namespace misa77
 {
-    namespace default_detail
+    namespace light_loose_detail
     {
         using namespace light;
 
@@ -55,27 +55,34 @@ namespace misa77
             ++dlpos;
         }
 
-        // Don't look further ahead once you have a match `>= la_gate`
-        constexpr uint64_t la_gate = 16;
+        // Preferable lowerbound for match length (derived from the YOLO vector for now)
+        constexpr uint64_t accept_len = 7;
+        static_assert(accept_len >= min_match_len);
 
-        // Once you have match `>= la_pate`, only keep looking if you get gains
-        constexpr uint64_t la_pate = 8;
+        // We ideally want to keep literal length `<= fire_at`
+        constexpr uint64_t fire_at = 6;
 
         // When you've gone `p` hashtab searches without a match, advance the pointer by `p >>
         // skip_shift`
         constexpr uint64_t skip_shift = 6;
-    } // namespace default_detail
+
+        // Regime counter: an adaptive value in `[0, regime_cap]`
+        // Runs with literal length in `[7, 32]` have a vote of `+2`, others `-1`
+        inline constexpr int64_t regime_cap = 64;
+        inline constexpr int64_t regime_threshold = 32;
+
+    } // namespace light_loose_detail
 
     // Returns number of bytes written to `dst`, and 0 on failure.
     // `isa_lib` is ISA-dependent.
     template <class isa_lib>
-    uint64_t default_compress_impl(const uint8_t* __restrict src,
-                                   uint64_t src_size,
-                                   uint8_t* __restrict dst,
-                                   uint64_t dst_cap)
+    uint64_t light_loose_cimpl(const uint8_t* __restrict src,
+                               uint64_t src_size,
+                               uint8_t* __restrict dst,
+                               uint64_t dst_cap)
     {
         using namespace light;
-        using namespace default_detail;
+        using namespace light_loose_detail;
 
         static_assert(max_match_len >= 32);
 
@@ -121,6 +128,13 @@ namespace misa77
 
         std::vector<std::array<uint16_t, hashtab_wid>> hashtab(hash_siz);
         std::vector<uint8_t> hashtab_idx(hash_siz);
+
+        // Last remembered match
+        uint64_t cand_pos = 0, cand_len = 0, cand_lst = 0;
+
+        // Adaptive variable that reflects values of lit_len we've been getting for recent blocks
+        int64_t regime = 0;
+
         while (pos + max_match_len <= match_end_limit)
         {
             // Reduce branch misses, `batch = 8` performs well empirically
@@ -159,7 +173,6 @@ namespace misa77
 
                     // Guaranteed to lie within `[pos - 2^16 - hashtab_lag, pos - hashtab_lag)`
                     uint64_t ilst = (pos - max_match_len - 1 - d);
-
                     typename isa_lib::vec ireg = isa_lib::loadvec(src + ilst);
                     uint32_t imatch_len = isa_lib::lcp(reg, ireg);
                     lst = (imatch_len > match_len ? ilst : lst);
@@ -167,48 +180,66 @@ namespace misa77
                 }
             }
 
-            if (match_len >= min_match_len)
+            // We've inserted stuff into the hashtable assuming this value of `pos`, so we cannot
+            // probe the hashtable for any starting position behind this one going forward. This is
+            // important as `pos` is regressed ahead.
+            uint64_t pos_safe_bound = pos;
+
+            bool accept = (match_len >= accept_len);
+
+            uint64_t pend = pos - lit;
+            bool fire = (regime >= regime_threshold ? pend >= fire_at : pend == fire_at);
+
+            // We don't have an ideal match
+            if (!accept)
             {
-                for (uint64_t npos = pos + 1;
-                     npos <= pos + lookahead and npos + max_match_len <= match_end_limit and
-                     match_len < la_gate;
-                     npos++)
+                if (fire)
                 {
-                    uint64_t nlst = 0;
-                    uint64_t nmatch_len = 0;
-
-                    uint32_t val = loadu4(src + npos);
-                    uint32_t hsh = hash4(val);
-                    typename isa_lib::vec reg = isa_lib::loadvec(src + npos);
-#pragma GCC unroll hashtab_wid
-                    for (uint8_t i = 0; i < hashtab_wid; i++)
+                    // Prefer the one ending later between this position and the last remembered one
+                    if (cand_len != 0 and
+                        (match_len < min_match_len or cand_pos + cand_len >= pos + match_len))
                     {
-                        uint16_t d = uint16_t(npos - hashtab[hsh][i] - hashtab_lag - 1);
-
-                        // Guaranteed to lie within `[npos - 2^16 - hashtab_lag, npos -
-                        // hashtab_lag)`
-                        uint64_t ilst = (npos - max_match_len - 1 - d);
-
-                        typename isa_lib::vec ireg = isa_lib::loadvec(src + ilst);
-                        uint32_t imatch_len = isa_lib::lcp(reg, ireg);
-
-                        nlst = (imatch_len > nmatch_len ? ilst : nlst);
-                        nmatch_len = (imatch_len > nmatch_len ? imatch_len : nmatch_len);
+                        pos = cand_pos;
+                        lst = cand_lst;
+                        match_len = cand_len;
                     }
 
-                    bool improved = (nmatch_len > match_len);
-                    pos = (improved ? npos : pos);
-                    lst = (improved ? nlst : lst);
-                    match_len = (improved ? nmatch_len : match_len);
+                    // Note that if `accept` becomes false here, pos isn't pushed back by the above
+                    // branch
+                    accept = (match_len >= min_match_len);
+                }
+                else if (match_len >= min_match_len and
+                         (cand_len == 0 or pos + match_len >= cand_pos + cand_len))
+                {
+                    // This position becomes the new candidate
+                    cand_pos = pos;
+                    cand_len = match_len;
+                    cand_lst = lst;
+                }
+            }
 
-                    if (!improved and match_len >= la_pate)
-                        break;
+            if (accept)
+            {
+                // Extend the match backwards (note that `dis` in `(hashtab_lag, 2^16 +
+                // hashtab_lag]` holds).
+                // Extending `pos` backwards here is safe because we're not looking into the
+                // hashtable.
+                while (pos > lit and lst > 0 and match_len < max_match_len and
+                       src[pos - 1] == src[lst - 1])
+                {
+                    --pos;
+                    --lst;
+                    ++match_len;
                 }
 
                 uint64_t norm_match_len = match_len - min_match_len + 1;
 
                 // `src[lit, pos)` are the literals
                 uint64_t lit_len = pos - lit;
+
+                // regime vote
+                regime += (7 <= lit_len and lit_len <= 32 ? 2 : -1);
+                regime = std::clamp<int64_t>(regime, 0, regime_cap);
 
                 // Token Byte
                 uint8_t lrem = std::min(uint64_t(7), lit_len);
@@ -235,6 +266,8 @@ namespace misa77
 
                 pos += match_len;
                 lit = pos;
+                pos = std::max(pos, pos_safe_bound);
+                cand_len = 0;
                 miss_run = 0;
             }
             else

--- a/lz/misa77/src/compressor_zoo/light_optimal_cimpl.h
+++ b/lz/misa77/src/compressor_zoo/light_optimal_cimpl.h
@@ -1,0 +1,446 @@
+// misa77 - A codec optimized for decompression throughput
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Shreyas Ghildiyal <nonadhocproblems@gmail.com>
+
+#pragma once
+
+#include "format.h"
+#include "misa77/misa77.h"
+#include "suffix/sais.h"
+#include "util.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <vector>
+
+namespace misa77
+{
+    namespace light_optimal_detail
+    {
+        using namespace light;
+
+        // 384 KB blocks, empirically derived.
+        constexpr uint64_t block_size = uint64_t(3) << 17;
+
+        // segments can extend past block boundaries
+        constexpr uint64_t pad_len = max_match_len + 1;
+
+        constexpr uint64_t dp_inf = std::numeric_limits<uint64_t>::max();
+
+        [[gnu::always_inline]]
+        inline uint64_t lit_extras(uint64_t run)
+        {
+            return run < lit_lim ? 0 : 1 + (run - lit_lim) / 255;
+        }
+
+        // 3-level bitset that maintains the positions of the alive suffixes inside the match
+        // window
+        struct liveset
+        {
+            std::vector<uint64_t> l0, l1, l2;
+
+            // live iff sa[r] < lim
+            void build(const int32_t* sa, uint64_t m, uint32_t lim)
+            {
+                l0.assign((m + 63) / 64, 0);
+                l1.assign((l0.size() + 63) / 64, 0);
+                l2.assign((l1.size() + 63) / 64, 0);
+                for (uint64_t w = 0; w < l0.size(); ++w)
+                {
+                    const uint64_t base = w << 6;
+                    const uint64_t top = std::min<uint64_t>(64, m - base);
+                    uint64_t bits = 0;
+                    for (uint64_t j = 0; j < top; ++j)
+                        bits |= uint64_t(uint32_t(sa[base + j]) < lim) << j;
+                    l0[w] = bits;
+                }
+                for (uint64_t w = 0; w < l0.size(); ++w)
+                    if (l0[w])
+                        l1[w >> 6] |= uint64_t(1) << (w & 63);
+                for (uint64_t w = 0; w < l1.size(); ++w)
+                    if (l1[w])
+                        l2[w >> 6] |= uint64_t(1) << (w & 63);
+            }
+
+            void set(uint64_t i)
+            {
+                l0[i >> 6] |= uint64_t(1) << (i & 63);
+                l1[i >> 12] |= uint64_t(1) << ((i >> 6) & 63);
+                l2[i >> 18] |= uint64_t(1) << ((i >> 12) & 63);
+            }
+
+            void clear(uint64_t i)
+            {
+                if ((l0[i >> 6] &= ~(uint64_t(1) << (i & 63))) == 0)
+                    if ((l1[i >> 12] &= ~(uint64_t(1) << ((i >> 6) & 63))) == 0)
+                        l2[i >> 18] &= ~(uint64_t(1) << ((i >> 12) & 63));
+            }
+
+            // largest live index < i, or -1
+            int64_t prev(uint64_t i) const
+            {
+                uint64_t w = i >> 6;
+                uint64_t mask = (i & 63) ? (uint64_t(1) << (i & 63)) - 1 : 0;
+                if (uint64_t v = l0[w] & mask)
+                    return int64_t((w << 6) + 63 - uint64_t(__builtin_clzll(v)));
+                uint64_t w1 = w >> 6;
+                uint64_t m1 = (w & 63) ? (uint64_t(1) << (w & 63)) - 1 : 0;
+                if (uint64_t v = l1[w1] & m1)
+                {
+                    w = (w1 << 6) + 63 - uint64_t(__builtin_clzll(v));
+                    return int64_t((w << 6) + 63 - uint64_t(__builtin_clzll(l0[w])));
+                }
+                uint64_t w2 = w1 >> 6;
+                uint64_t m2 = (w1 & 63) ? (uint64_t(1) << (w1 & 63)) - 1 : 0;
+                for (int64_t t = int64_t(w2); t >= 0; --t)
+                {
+                    uint64_t v2 = l2[t] & (t == int64_t(w2) ? m2 : ~uint64_t(0));
+                    if (!v2)
+                        continue;
+                    uint64_t a = (uint64_t(t) << 6) + 63 - uint64_t(__builtin_clzll(v2));
+                    uint64_t b = (a << 6) + 63 - uint64_t(__builtin_clzll(l1[a]));
+                    return int64_t((b << 6) + 63 - uint64_t(__builtin_clzll(l0[b])));
+                }
+                return -1;
+            }
+
+            // smallest live index > i, or -1
+            int64_t next(uint64_t i) const
+            {
+                uint64_t w = i >> 6;
+                uint64_t mask = (i & 63) == 63 ? 0 : ~((uint64_t(2) << (i & 63)) - 1);
+                if (uint64_t v = l0[w] & mask)
+                    return int64_t((w << 6) + uint64_t(__builtin_ctzll(v)));
+                uint64_t w1 = w >> 6;
+                uint64_t m1 = (w & 63) == 63 ? 0 : ~((uint64_t(2) << (w & 63)) - 1);
+                if (uint64_t v = l1[w1] & m1)
+                {
+                    w = (w1 << 6) + uint64_t(__builtin_ctzll(v));
+                    return int64_t((w << 6) + uint64_t(__builtin_ctzll(l0[w])));
+                }
+                uint64_t w2 = w1 >> 6;
+                uint64_t m2 = (w1 & 63) == 63 ? 0 : ~((uint64_t(2) << (w1 & 63)) - 1);
+                for (uint64_t t = w2; t < l2.size(); ++t)
+                {
+                    uint64_t v2 = l2[t] & (t == w2 ? m2 : ~uint64_t(0));
+                    if (!v2)
+                        continue;
+                    uint64_t a = (t << 6) + uint64_t(__builtin_ctzll(v2));
+                    uint64_t b = (a << 6) + uint64_t(__builtin_ctzll(l1[a]));
+                    return int64_t((b << 6) + uint64_t(__builtin_ctzll(l0[b])));
+                }
+                return -1;
+            }
+        };
+    } // namespace light_optimal_detail
+
+    // Returns number of bytes written to `dst`, and 0 on failure.
+    // `isa_lib` is ISA-dependent.
+    template <class isa_lib>
+    uint64_t light_optimal_cimpl(const uint8_t* __restrict src,
+                                 uint64_t src_size,
+                                 uint8_t* __restrict dst,
+                                 uint64_t dst_cap)
+    {
+        using namespace light;
+        using namespace light_optimal_detail;
+
+        if (compress_bound(src_size, config()) > dst_cap)
+            return 0;
+
+        auto lcp_long = [&](const uint8_t* a, const uint8_t* b, uint32_t max_len) -> uint32_t
+        {
+            uint32_t i = 0;
+            while (i + vector_width <= max_len)
+            {
+                uint32_t len = isa_lib::lcp(isa_lib::loadvec(a + i), isa_lib::loadvec(b + i));
+                i += len;
+                if (len < vector_width)
+                    return i;
+            }
+            while (i < max_len and a[i] == b[i])
+                ++i;
+            return i;
+        };
+
+        // Left pointer in the destination buffer (metadata and control bytes)
+        uint64_t dlpos = 0;
+
+        // Right pointer in the destination buffer (literal bytes)
+        // We've written to `[drpos, dst_cap)` at any given point of time
+        uint64_t drpos = dst_cap;
+
+        // The top byte stays clear, which is what marks the stream as light
+        storeu8(dst, src_size);
+        dlpos += 8;
+
+        if (src_size <= small_lim)
+        {
+            if (src_size != 0)
+                memcpy(dst + dlpos, src, src_size);
+            dlpos += src_size;
+            return dlpos;
+        }
+
+        uint64_t literal_suffix_pos = dlpos;
+        dlpos += 8;
+
+        // Ensure that the last `literal_suffix` bytes will be literals
+        uint64_t match_end_limit = (src_size < literal_suffix ? 0 : src_size - literal_suffix);
+
+        // Beginning of the pending literal window
+        uint64_t lit = 0;
+
+        auto emit_token = [&](uint64_t match_start, uint32_t match_len, uint32_t match_dis)
+        {
+            uint64_t lit_len = match_start - lit;
+            uint32_t lrem = lit_len < lit_lim ? uint32_t(lit_len) : uint32_t(lit_lim);
+            dst[dlpos] = uint8_t((lrem << 5) | (match_len - min_match_len + 1));
+            ++dlpos;
+            storeu2(dst + dlpos, uint16_t(match_dis - min_dis));
+            dlpos += 2;
+            if (lrem == lit_lim)
+            {
+                uint64_t e = lit_len - lit_lim;
+                while (e >= 255)
+                {
+                    dst[dlpos++] = 255;
+                    e -= 255;
+                }
+                dst[dlpos++] = uint8_t(e);
+            }
+            if (lit_len)
+            {
+                drpos -= lit_len;
+                memcpy(dst + drpos, src + lit, lit_len);
+            }
+            lit = match_start + match_len;
+        };
+
+        // Per-block state, reused across blocks
+        sais_chan sorter_chan;
+        std::vector<int32_t> sa, rank;
+        liveset live;
+        std::vector<uint8_t> max_len;    // longest in-window match at each block position
+        std::vector<uint32_t> match_dis; // its distance
+        std::vector<uint64_t> dp;        // exact cost of the cheapest parse ending at boundary i
+
+        struct arrival
+        {
+            uint32_t dis;
+            uint32_t len;
+            uint64_t lit_run; // literals immediately before the match
+        };
+        std::vector<arrival> arr;
+
+        struct token_rec
+        {
+            uint64_t match_start;
+            uint32_t len;
+            uint32_t dis;
+        };
+        std::vector<token_rec> block_tokens;
+
+        // Last committed parse boundary and its exact total cost
+        uint64_t qstar = 0;
+        uint64_t qstar_cost = 16; // header
+
+        for (uint64_t bs = 0; bs < src_size; bs += block_size)
+        {
+            const uint64_t be = std::min(bs + block_size, src_size);
+            const uint64_t blen = be - bs;
+
+            // Suffix array and rank over [history | block | pad]
+            const uint64_t seg0 = bs > max_dis ? bs - max_dis : 0;
+            const uint64_t seg_end = std::min(src_size, be + pad_len);
+            const uint32_t m = uint32_t(seg_end - seg0);
+            sa.resize(m);
+            rank.resize(m);
+            sorter_chan.sa(src + seg0, m, sa.data(), rank.data());
+
+            // Longest in-window match per position, clipped at the block end
+            max_len.assign(blen, 0);
+            match_dis.assign(blen, 0);
+
+            // Matches must end within the block AND BEFORE the raw suffix
+            const uint64_t hard = std::min(be, match_end_limit);
+            const uint32_t init_lim =
+                bs >= min_dis and bs - min_dis >= seg0 ? uint32_t(bs - min_dis - seg0 + 1) : 0;
+            live.build(sa.data(), m, init_lim);
+
+            uint64_t carry_len = 0;
+            uint32_t carry_dis = 0;
+            for (uint64_t p = bs; p < be; ++p)
+            {
+                // Slide the source window [p - max_dis, p - min_dis]
+                if (p >= min_dis and p - min_dis >= seg0)
+                    live.set(uint64_t(rank[p - min_dis - seg0]));
+                if (p > max_dis and p - max_dis - 1 >= seg0)
+                    live.clear(uint64_t(rank[p - max_dis - 1 - seg0]));
+
+                if (p + min_match_len > hard)
+                    continue;
+                const uint32_t limit = uint32_t(std::min<uint64_t>(max_match_len, hard - p));
+
+                // Skip the queries, make use of carry
+                if (carry_len >= limit)
+                {
+                    max_len[p - bs] = uint8_t(limit);
+                    match_dis[p - bs] = carry_dis;
+                    --carry_len;
+                    continue;
+                }
+
+                const uint64_t r = uint64_t(rank[p - seg0]);
+                uint32_t best = 0;
+                uint32_t best_dis = 0;
+                auto consider = [&](int64_t q)
+                {
+                    if (q < 0)
+                        return;
+                    const uint64_t s = seg0 + uint64_t(sa[q]);
+                    const uint32_t l = lcp_long(src + p, src + s, limit);
+                    if (l > best)
+                    {
+                        best = l;
+                        best_dis = uint32_t(p - s);
+                    }
+                };
+                consider(live.prev(r));
+                consider(live.next(r));
+
+                if (best >= min_match_len)
+                {
+                    max_len[p - bs] = uint8_t(best);
+                    match_dis[p - bs] = best_dis;
+                    if (best >= limit)
+                    {
+                        // Extend past the clamp to seed the carry for upcoming positions
+                        const uint64_t room = src_size - (p + limit);
+                        const uint32_t ext = lcp_long(src + p + limit,
+                                                      src + (p - best_dis) + limit,
+                                                      uint32_t(std::min<uint64_t>(room, dis_lim)));
+                        carry_len = uint64_t(limit) + ext - 1;
+                        carry_dis = best_dis;
+                    }
+                    else
+                    {
+                        carry_len = best - 1;
+                        carry_dis = best_dis;
+                    }
+                }
+                else
+                    carry_len -= uint64_t(carry_len > 0);
+            }
+
+            // Exact DP over boundaries [bs, be]
+            dp.assign(blen + 1, dp_inf);
+            arr.resize(blen + 1);
+
+            // G-state = cheapest known "boundary + all literals since" arrival
+            uint64_t g_run = bs - qstar;
+            uint64_t g_cost = qstar_cost + g_run + lit_extras(g_run);
+
+            // Next run length at which the extras byte count grows
+            uint64_t g_next = g_run < lit_lim ? lit_lim : g_run + 255 - (g_run - lit_lim) % 255;
+            if (bs == 0)
+                dp[0] = qstar_cost;
+            for (uint64_t p = bs; p <= be; ++p)
+            {
+                const uint64_t i = p - bs;
+                if (p > bs)
+                {
+                    ++g_run;
+                    if (g_run >= g_next) [[unlikely]]
+                    {
+                        ++g_cost;
+                        g_next = g_run + 255;
+                    }
+                    ++g_cost;
+                    if (dp[i] <= g_cost)
+                    {
+                        g_cost = dp[i];
+                        g_run = 0;
+                        g_next = lit_lim;
+                    }
+                }
+                const uint32_t lmax = i < blen ? max_len[i] : 0;
+                if (lmax >= min_match_len)
+                {
+                    // Every token is 3 bytes regardless of length, and every length up to
+                    // `lmax` is representable, so these are `lmax - min_match_len + 1` edges
+                    // of equal weight
+                    const uint64_t c = g_cost + 3;
+                    for (uint32_t len = min_match_len; len <= lmax; ++len)
+                    {
+                        const uint64_t q = i + len;
+                        if (c < dp[q])
+                        {
+                            dp[q] = c;
+                            arr[q] = {match_dis[i], len, g_run};
+                        }
+                    }
+                }
+            }
+
+            // Commit at the seam
+            uint64_t commit;
+            uint64_t commit_cost;
+            if (be < src_size)
+            {
+                commit = be - g_run;
+                commit_cost = g_cost - g_run - lit_extras(g_run);
+            }
+            else
+            {
+                // Final block, so minimize cost + terminal literals
+                // Raw suffix obviously doesn't contribute
+                uint64_t best_total = qstar_cost + (src_size - qstar);
+                commit = qstar;
+                commit_cost = qstar_cost;
+                for (uint64_t p = bs; p <= be; ++p)
+                    if (dp[p - bs] != dp_inf and dp[p - bs] + (src_size - p) < best_total)
+                    {
+                        best_total = dp[p - bs] + (src_size - p);
+                        commit = p;
+                        commit_cost = dp[p - bs];
+                    }
+            }
+
+            // backtrack commit, then emit forward...
+            block_tokens.clear();
+            for (uint64_t i = commit; i > qstar;)
+            {
+                const arrival& a = arr[i - bs];
+                const uint64_t next = i - a.len - a.lit_run;
+                if (a.len < min_match_len or (next < bs and next != qstar))
+                    return 0; // sommething went wrong
+                block_tokens.push_back({i - a.len, a.len, a.dis});
+                i = next;
+            }
+            for (uint64_t k = block_tokens.size(); k-- > 0;)
+                emit_token(block_tokens[k].match_start, block_tokens[k].len, block_tokens[k].dis);
+
+            qstar = commit;
+            qstar_cost = commit_cost;
+        }
+
+        // Close the gap between the two streams by moving the literal stream to the left
+        if (drpos < dst_cap)
+        {
+            memmove(dst + dlpos, dst + drpos, dst_cap - drpos);
+            dlpos += dst_cap - drpos;
+        }
+
+        // Just deal with the last few literals (guaranteed to be `>= literal_suffix >=
+        // vector_width` bytes)
+        uint64_t literal_suffix_cnt = src_size - lit;
+        storeu8(dst + literal_suffix_pos, literal_suffix_cnt);
+        memcpy(dst + dlpos, src + lit, literal_suffix_cnt);
+        dlpos += literal_suffix_cnt;
+
+        return dlpos;
+    }
+} // namespace misa77

--- a/lz/misa77/src/compressor_zoo/light_swift_cimpl.h
+++ b/lz/misa77/src/compressor_zoo/light_swift_cimpl.h
@@ -9,14 +9,13 @@
 #include "util.h"
 
 #include <algorithm>
-#include <array>
 #include <cstdint>
 #include <cstring>
 #include <vector>
 
 namespace misa77
 {
-    namespace loose_detail
+    namespace light_swift_detail
     {
         using namespace light;
 
@@ -24,14 +23,21 @@ namespace misa77
         constexpr uint32_t hash_siz = 1 << hash_top;
         constexpr uint32_t hash_mul = 2654435761;
 
-        // Size of ring buffer per hash in the hashtable.
-        inline constexpr uint64_t hashtab_wid = 16;
-
-        // Hash 4 bytes to an integer in `[0, 1 << (hash_top))`.
+        // Hash 4 bytes to an integer in `[0, 1 << hash_top)` (for the fallback table).
         [[gnu::always_inline]]
         inline uint32_t hash4(const uint32_t val)
         {
             return (val * hash_mul) >> (32 - hash_top);
+        }
+
+        constexpr uint64_t hash6_mul = 0x9E3779B185EBCA87; // 2^64 / phi
+
+        // Hash the low 6 bytes of an 8-byte load (for the primary table)
+        [[gnu::always_inline]]
+        inline uint32_t hash6(const uint64_t val)
+        {
+            constexpr uint64_t mask = (uint64_t(1) << 48) - 1;
+            return uint32_t(((val & mask) * hash6_mul) >> (64 - hash_top));
         }
 
         // Assuming that rem contains top 3 bits of the token, emits bytes specifying `n`.
@@ -55,7 +61,7 @@ namespace misa77
             ++dlpos;
         }
 
-        // Preferable lowerbound for match length (derived from the YOLO vector for now)
+        // A match must save enough bytes to pay for its token
         constexpr uint64_t accept_len = 7;
         static_assert(accept_len >= min_match_len);
 
@@ -71,18 +77,18 @@ namespace misa77
         inline constexpr int64_t regime_cap = 64;
         inline constexpr int64_t regime_threshold = 32;
 
-    } // namespace loose_detail
+    } // namespace light_swift_detail
 
     // Returns number of bytes written to `dst`, and 0 on failure.
     // `isa_lib` is ISA-dependent.
     template <class isa_lib>
-    uint64_t loose_compress_impl(const uint8_t* __restrict src,
-                                 uint64_t src_size,
-                                 uint8_t* __restrict dst,
-                                 uint64_t dst_cap)
+    uint64_t light_swift_cimpl(const uint8_t* __restrict src,
+                               uint64_t src_size,
+                               uint8_t* __restrict dst,
+                               uint64_t dst_cap)
     {
         using namespace light;
-        using namespace loose_detail;
+        using namespace light_swift_detail;
 
         static_assert(max_match_len >= 32);
 
@@ -121,13 +127,15 @@ namespace misa77
         // turning into a lit + match pair
         uint64_t pos = 0;
 
-        // `[0, hpos)` represents the range we've written into the hashtable
+        // `[0, hpos)` represents the range we've written into the hashtables
         uint64_t hpos = 0;
 
         uint64_t miss_run = 0;
 
-        std::vector<std::array<uint16_t, hashtab_wid>> hashtab(hash_siz);
-        std::vector<uint8_t> hashtab_idx(hash_siz);
+        // Two single-slot tables. `hashtab6` is for match quality, `hashtab4` exists to
+        // prevent too long literal lengths.
+        std::vector<uint16_t> hashtab6(hash_siz);
+        std::vector<uint16_t> hashtab4(hash_siz);
 
         // Last remembered match
         uint64_t cand_pos = 0, cand_len = 0, cand_lst = 0;
@@ -144,44 +152,47 @@ namespace misa77
 #pragma GCC unroll batch
                 for (uint64_t i = 0; i < batch; i++)
                 {
-                    uint32_t hsh = hash4(loadu4(src + hpos + i));
-                    hashtab[hsh][hashtab_idx[hsh]] =
-                        uint16_t(hpos + i); // We just store the lowest 2 bytes
-                    hashtab_idx[hsh] =
-                        (hashtab_idx[hsh] == hashtab_wid - 1
-                             ? uint8_t(0)
-                             : hashtab_idx[hsh] + 1); // Just cycle the pointer in the ring buffer
+                    hashtab6[hash6(loadu8(src + hpos + i))] = uint16_t(hpos + i);
+
+                    // The fallback table only needs recency, so half density suffices
+                    if ((hpos + i) % 2 == 0)
+                        hashtab4[hash4(loadu4(src + hpos + i))] = uint16_t(hpos + i);
                 }
                 hpos += batch;
             }
 
-            uint32_t val = loadu4(src + pos);
-            uint32_t hsh = hash4(val);
-
             uint64_t lst = 0;
             uint64_t match_len = 0;
 
-            typename isa_lib::vec reg = isa_lib::loadvec(src + pos);
-
             if (pos > hashtab_lag) [[likely]]
             {
-// MLP
-#pragma GCC unroll hashtab_wid
-                for (uint8_t i = 0; i < hashtab_wid; i++)
-                {
-                    uint16_t d = uint16_t(pos - hashtab[hsh][i] - hashtab_lag - 1);
+                // Exact cheap filter: `lcp >= min_match_len` iff the first 4 bytes agree
+                const uint32_t val4 = loadu4(src + pos);
+                uint16_t d = uint16_t(pos - hashtab6[hash6(loadu8(src + pos))] - hashtab_lag - 1);
 
-                    // Guaranteed to lie within `[pos - 2^16 - hashtab_lag, pos - hashtab_lag)`
-                    uint64_t ilst = (pos - max_match_len - 1 - d);
+                // Guaranteed to lie within `[pos - 2^16 - hashtab_lag, pos - hashtab_lag)`
+                uint64_t ilst = (pos - max_match_len - 1 - d);
+                bool hit = (loadu4(src + ilst) == val4);
+
+                // Only look at the fallback table when the remembered-candidate slot is empty
+                if (!hit and cand_len == 0)
+                {
+                    uint16_t d4 = uint16_t(pos - hashtab4[hash4(val4)] - hashtab_lag - 1);
+                    ilst = (pos - max_match_len - 1 - d4);
+                    hit = (loadu4(src + ilst) == val4);
+                }
+
+                if (hit)
+                {
+                    typename isa_lib::vec reg = isa_lib::loadvec(src + pos);
                     typename isa_lib::vec ireg = isa_lib::loadvec(src + ilst);
-                    uint32_t imatch_len = isa_lib::lcp(reg, ireg);
-                    lst = (imatch_len > match_len ? ilst : lst);
-                    match_len = (imatch_len > match_len ? imatch_len : match_len);
+                    lst = ilst;
+                    match_len = isa_lib::lcp(reg, ireg);
                 }
             }
 
-            // We've inserted stuff into the hashtable assuming this value of `pos`, so we cannot
-            // probe the hashtable for any starting position behind this one going forward. This is
+            // We've inserted stuff into the hashtables assuming this value of `pos`, so we cannot
+            // probe them for any starting position behind this one going forward. This is
             // important as `pos` is regressed ahead.
             uint64_t pos_safe_bound = pos;
 
@@ -223,7 +234,7 @@ namespace misa77
                 // Extend the match backwards (note that `dis` in `(hashtab_lag, 2^16 +
                 // hashtab_lag]` holds).
                 // Extending `pos` backwards here is safe because we're not looking into the
-                // hashtable.
+                // hashtables.
                 while (pos > lit and lst > 0 and match_len < max_match_len and
                        src[pos - 1] == src[lst - 1])
                 {
@@ -261,7 +272,14 @@ namespace misa77
                 {
                     uint64_t lit_cnt = pos - lit;
                     drpos -= lit_cnt;
-                    memcpy(dst + drpos, src + lit, lit_cnt);
+
+                    // Fixed 16-byte copy ending at the old drpos; bytes below the run only clobber
+                    // not-yet-written literal space. The fire rule keeps runs short, so the branch
+                    // is predictable.
+                    if (lit_cnt <= 16) [[likely]]
+                        memcpy(dst + drpos + lit_cnt - 16, src + lit + lit_cnt - 16, 16);
+                    else
+                        memcpy(dst + drpos, src + lit, lit_cnt);
                 }
 
                 pos += match_len;

--- a/lz/misa77/src/decompressor_zoo/heavy_safe_dimpl.h
+++ b/lz/misa77/src/decompressor_zoo/heavy_safe_dimpl.h
@@ -16,10 +16,10 @@ namespace misa77
     // Returns number of bytes written to `dst`, and 0 on failure.
     // `isa_lib` is ISA-dependent.
     template <class isa_lib>
-    uint64_t heavy_safe_decompress_impl(const uint8_t* __restrict src,
-                                        uint64_t src_size,
-                                        uint8_t* __restrict dst,
-                                        uint64_t dst_cap)
+    uint64_t heavy_safe_dimpl(const uint8_t* __restrict src,
+                              uint64_t src_size,
+                              uint8_t* __restrict dst,
+                              uint64_t dst_cap)
     {
         using namespace heavy;
         // support will be added in the future

--- a/lz/misa77/src/decompressor_zoo/heavy_unsafe_dimpl.h
+++ b/lz/misa77/src/decompressor_zoo/heavy_unsafe_dimpl.h
@@ -115,10 +115,10 @@ namespace misa77
     // Returns number of bytes written to `dst`, and 0 on failure.
     // `isa_lib` is ISA-dependent.
     template <class isa_lib>
-    uint64_t heavy_unsafe_decompress_impl(const uint8_t* __restrict src,
-                                          uint64_t src_size,
-                                          uint8_t* __restrict dst,
-                                          uint64_t dst_cap)
+    uint64_t heavy_unsafe_dimpl(const uint8_t* __restrict src,
+                                uint64_t src_size,
+                                uint8_t* __restrict dst,
+                                uint64_t dst_cap)
     {
         using namespace heavy;
 

--- a/lz/misa77/src/decompressor_zoo/light_safe_dimpl.h
+++ b/lz/misa77/src/decompressor_zoo/light_safe_dimpl.h
@@ -16,10 +16,10 @@ namespace misa77
     // Returns number of bytes written to `dst`, and 0 on failure.
     // `isa_lib` is ISA-dependent.
     template <class isa_lib>
-    uint64_t safe_decompress_impl(const uint8_t* __restrict src,
-                                  uint64_t src_size,
-                                  uint8_t* __restrict dst,
-                                  uint64_t dst_cap)
+    uint64_t light_safe_dimpl(const uint8_t* __restrict src,
+                              uint64_t src_size,
+                              uint8_t* __restrict dst,
+                              uint64_t dst_cap)
     {
         using namespace light;
 

--- a/lz/misa77/src/decompressor_zoo/light_unsafe_dimpl.h
+++ b/lz/misa77/src/decompressor_zoo/light_unsafe_dimpl.h
@@ -16,10 +16,10 @@ namespace misa77
     // Returns number of bytes written to `dst`, and 0 on failure.
     // `isa_lib` is ISA-dependent.
     template <class isa_lib>
-    uint64_t unsafe_decompress_impl(const uint8_t* __restrict src,
-                                    uint64_t src_size,
-                                    uint8_t* __restrict dst,
-                                    uint64_t dst_cap)
+    uint64_t light_unsafe_dimpl(const uint8_t* __restrict src,
+                                uint64_t src_size,
+                                uint8_t* __restrict dst,
+                                uint64_t dst_cap)
     {
         using namespace light;
 

--- a/lz/misa77/src/format.h
+++ b/lz/misa77/src/format.h
@@ -15,7 +15,7 @@ namespace misa77
     // formats.
     inline constexpr uint64_t vector_width = 32;
 
-    // light format, used by levels in [0, config::heavy_lb)
+    // light format, used by levels in [config::min_level, config::heavy_lb)
     namespace light
     {
         // (`raw file size <= small_lim`) => small mode, we just write the raw bytes.
@@ -37,6 +37,12 @@ namespace misa77
         // We have exactly 2 bytes to indicate distance.
         static_assert(dis_lim <= (1 << 16));
 
+        // The two distance bytes hold `dis - min_dis`, so the window is exactly [min_dis, max_dis].
+        inline constexpr uint32_t min_dis = uint32_t(hashtab_lag + 1);
+        inline constexpr uint32_t max_dis = uint32_t(hashtab_lag + dis_lim);
+        static_assert(max_dis - min_dis == dis_lim - 1);
+        static_assert(dis_lim - 1 <= UINT16_MAX);
+
         inline constexpr uint32_t min_match_len = 4;
 
         // `min_match_len >= 4` is needed for the compression bound to hold.
@@ -46,6 +52,12 @@ namespace misa77
 
         // One `cyccpy` call should deal with the entire match.
         static_assert(max_match_len <= vector_width);
+
+        // Every length in [min_match_len, max_match_len] should be exactly representable.
+        static_assert(max_match_len - min_match_len + 1 <= (uint32_t(1) << 5) - 1);
+
+        inline constexpr uint64_t lit_lim = 7;
+        static_assert(lit_lim == (uint64_t(1) << 3) - 1);
 
         // Lowerbound for the number of literals in the final raw suffix.
         // This MUST be >= `vector_width` because:

--- a/lz/misa77/src/isa/target_avx2.cpp
+++ b/lz/misa77/src/isa/target_avx2.cpp
@@ -7,14 +7,17 @@
 // AVX2 support.
 
 #include "compress_dispatch.h"
-#include "compressor_zoo/default_compress_impl.h"
-#include "compressor_zoo/heavy_compress_impl.h"
-#include "compressor_zoo/loose_compress_impl.h"
+#include "compressor_zoo/heavy_optimal_cimpl.h"
+#include "compressor_zoo/light_blitz_cimpl.h"
+#include "compressor_zoo/light_keen_cimpl.h"
+#include "compressor_zoo/light_loose_cimpl.h"
+#include "compressor_zoo/light_optimal_cimpl.h"
+#include "compressor_zoo/light_swift_cimpl.h"
 #include "decompress_dispatch.h"
-#include "decompressor_zoo/heavy_safe_decompress_impl.h"
-#include "decompressor_zoo/heavy_unsafe_decompress_impl.h"
-#include "decompressor_zoo/safe_decompress_impl.h"
-#include "decompressor_zoo/unsafe_decompress_impl.h"
+#include "decompressor_zoo/heavy_safe_dimpl.h"
+#include "decompressor_zoo/heavy_unsafe_dimpl.h"
+#include "decompressor_zoo/light_safe_dimpl.h"
+#include "decompressor_zoo/light_unsafe_dimpl.h"
 #include "isa/lib_avx2.h"
 
 #include <cstdint>
@@ -27,12 +30,18 @@ namespace misa77
                            uint64_t dst_cap,
                            config cfg)
     {
-        if (cfg.level == 0)
-            return loose_compress_impl<lib_avx2>(src, src_size, dst, dst_cap);
+        if (cfg.level == -1)
+            return light_blitz_cimpl<lib_avx2>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 0)
+            return light_swift_cimpl<lib_avx2>(src, src_size, dst, dst_cap);
         else if (cfg.level == 1)
-            return default_compress_impl<lib_avx2>(src, src_size, dst, dst_cap);
+            return light_loose_cimpl<lib_avx2>(src, src_size, dst, dst_cap);
         else if (cfg.level == 2)
-            return heavy_compress_impl<lib_avx2>(src, src_size, dst, dst_cap);
+            return light_keen_cimpl<lib_avx2>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 3)
+            return light_optimal_cimpl<lib_avx2>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 4)
+            return heavy_optimal_cimpl<lib_avx2>(src, src_size, dst, dst_cap);
         return 0;
     }
 
@@ -46,13 +55,13 @@ namespace misa77
         {
             // heavy
             if (dcfg.safe)
-                return heavy_safe_decompress_impl<lib_avx2>(src, src_size, dst, dst_cap);
-            return heavy_unsafe_decompress_impl<lib_avx2>(src, src_size, dst, dst_cap);
+                return heavy_safe_dimpl<lib_avx2>(src, src_size, dst, dst_cap);
+            return heavy_unsafe_dimpl<lib_avx2>(src, src_size, dst, dst_cap);
         }
 
         // light
         if (dcfg.safe)
-            return safe_decompress_impl<lib_avx2>(src, src_size, dst, dst_cap);
-        return unsafe_decompress_impl<lib_avx2>(src, src_size, dst, dst_cap);
+            return light_safe_dimpl<lib_avx2>(src, src_size, dst, dst_cap);
+        return light_unsafe_dimpl<lib_avx2>(src, src_size, dst, dst_cap);
     }
 } // namespace misa77

--- a/lz/misa77/src/isa/target_neon.cpp
+++ b/lz/misa77/src/isa/target_neon.cpp
@@ -5,14 +5,17 @@
 // Baseline for AArch64 (NEON/AdvSIMD support is guaranteed in the ISA).
 
 #include "compress_dispatch.h"
-#include "compressor_zoo/default_compress_impl.h"
-#include "compressor_zoo/heavy_compress_impl.h"
-#include "compressor_zoo/loose_compress_impl.h"
+#include "compressor_zoo/heavy_optimal_cimpl.h"
+#include "compressor_zoo/light_blitz_cimpl.h"
+#include "compressor_zoo/light_keen_cimpl.h"
+#include "compressor_zoo/light_loose_cimpl.h"
+#include "compressor_zoo/light_optimal_cimpl.h"
+#include "compressor_zoo/light_swift_cimpl.h"
 #include "decompress_dispatch.h"
-#include "decompressor_zoo/heavy_safe_decompress_impl.h"
-#include "decompressor_zoo/heavy_unsafe_decompress_impl.h"
-#include "decompressor_zoo/safe_decompress_impl.h"
-#include "decompressor_zoo/unsafe_decompress_impl.h"
+#include "decompressor_zoo/heavy_safe_dimpl.h"
+#include "decompressor_zoo/heavy_unsafe_dimpl.h"
+#include "decompressor_zoo/light_safe_dimpl.h"
+#include "decompressor_zoo/light_unsafe_dimpl.h"
 #include "isa/lib_neon.h"
 
 #include <cstdint>
@@ -25,12 +28,18 @@ namespace misa77
                            uint64_t dst_cap,
                            config cfg)
     {
-        if (cfg.level == 0)
-            return loose_compress_impl<lib_neon>(src, src_size, dst, dst_cap);
+        if (cfg.level == -1)
+            return light_blitz_cimpl<lib_neon>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 0)
+            return light_swift_cimpl<lib_neon>(src, src_size, dst, dst_cap);
         else if (cfg.level == 1)
-            return default_compress_impl<lib_neon>(src, src_size, dst, dst_cap);
+            return light_loose_cimpl<lib_neon>(src, src_size, dst, dst_cap);
         else if (cfg.level == 2)
-            return heavy_compress_impl<lib_neon>(src, src_size, dst, dst_cap);
+            return light_keen_cimpl<lib_neon>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 3)
+            return light_optimal_cimpl<lib_neon>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 4)
+            return heavy_optimal_cimpl<lib_neon>(src, src_size, dst, dst_cap);
         return 0;
     }
 
@@ -44,13 +53,13 @@ namespace misa77
         {
             // heavy
             if (dcfg.safe)
-                return heavy_safe_decompress_impl<lib_neon>(src, src_size, dst, dst_cap);
-            return heavy_unsafe_decompress_impl<lib_neon>(src, src_size, dst, dst_cap);
+                return heavy_safe_dimpl<lib_neon>(src, src_size, dst, dst_cap);
+            return heavy_unsafe_dimpl<lib_neon>(src, src_size, dst, dst_cap);
         }
 
         // light
         if (dcfg.safe)
-            return safe_decompress_impl<lib_neon>(src, src_size, dst, dst_cap);
-        return unsafe_decompress_impl<lib_neon>(src, src_size, dst, dst_cap);
+            return light_safe_dimpl<lib_neon>(src, src_size, dst, dst_cap);
+        return light_unsafe_dimpl<lib_neon>(src, src_size, dst, dst_cap);
     }
 } // namespace misa77

--- a/lz/misa77/src/isa/target_portable.cpp
+++ b/lz/misa77/src/isa/target_portable.cpp
@@ -5,14 +5,17 @@
 // Built on every target.
 
 #include "compress_dispatch.h"
-#include "compressor_zoo/default_compress_impl.h"
-#include "compressor_zoo/heavy_compress_impl.h"
-#include "compressor_zoo/loose_compress_impl.h"
+#include "compressor_zoo/heavy_optimal_cimpl.h"
+#include "compressor_zoo/light_blitz_cimpl.h"
+#include "compressor_zoo/light_keen_cimpl.h"
+#include "compressor_zoo/light_loose_cimpl.h"
+#include "compressor_zoo/light_optimal_cimpl.h"
+#include "compressor_zoo/light_swift_cimpl.h"
 #include "decompress_dispatch.h"
-#include "decompressor_zoo/heavy_safe_decompress_impl.h"
-#include "decompressor_zoo/heavy_unsafe_decompress_impl.h"
-#include "decompressor_zoo/safe_decompress_impl.h"
-#include "decompressor_zoo/unsafe_decompress_impl.h"
+#include "decompressor_zoo/heavy_safe_dimpl.h"
+#include "decompressor_zoo/heavy_unsafe_dimpl.h"
+#include "decompressor_zoo/light_safe_dimpl.h"
+#include "decompressor_zoo/light_unsafe_dimpl.h"
 #include "isa/lib_portable.h"
 
 #include <cstdint>
@@ -25,12 +28,18 @@ namespace misa77
                                uint64_t dst_cap,
                                config cfg)
     {
-        if (cfg.level == 0)
-            return loose_compress_impl<lib_portable>(src, src_size, dst, dst_cap);
+        if (cfg.level == -1)
+            return light_blitz_cimpl<lib_portable>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 0)
+            return light_swift_cimpl<lib_portable>(src, src_size, dst, dst_cap);
         else if (cfg.level == 1)
-            return default_compress_impl<lib_portable>(src, src_size, dst, dst_cap);
+            return light_loose_cimpl<lib_portable>(src, src_size, dst, dst_cap);
         else if (cfg.level == 2)
-            return heavy_compress_impl<lib_portable>(src, src_size, dst, dst_cap);
+            return light_keen_cimpl<lib_portable>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 3)
+            return light_optimal_cimpl<lib_portable>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 4)
+            return heavy_optimal_cimpl<lib_portable>(src, src_size, dst, dst_cap);
         return 0;
     }
 
@@ -44,13 +53,13 @@ namespace misa77
         {
             // heavy
             if (dcfg.safe)
-                return heavy_safe_decompress_impl<lib_portable>(src, src_size, dst, dst_cap);
-            return heavy_unsafe_decompress_impl<lib_portable>(src, src_size, dst, dst_cap);
+                return heavy_safe_dimpl<lib_portable>(src, src_size, dst, dst_cap);
+            return heavy_unsafe_dimpl<lib_portable>(src, src_size, dst, dst_cap);
         }
 
         // light
         if (dcfg.safe)
-            return safe_decompress_impl<lib_portable>(src, src_size, dst, dst_cap);
-        return unsafe_decompress_impl<lib_portable>(src, src_size, dst, dst_cap);
+            return light_safe_dimpl<lib_portable>(src, src_size, dst, dst_cap);
+        return light_unsafe_dimpl<lib_portable>(src, src_size, dst, dst_cap);
     }
 } // namespace misa77

--- a/lz/misa77/src/isa/target_sse2.cpp
+++ b/lz/misa77/src/isa/target_sse2.cpp
@@ -5,14 +5,17 @@
 // Baseline for x86-64 (SSE2 support is guaranteed in the ISA).
 
 #include "compress_dispatch.h"
-#include "compressor_zoo/default_compress_impl.h"
-#include "compressor_zoo/heavy_compress_impl.h"
-#include "compressor_zoo/loose_compress_impl.h"
+#include "compressor_zoo/heavy_optimal_cimpl.h"
+#include "compressor_zoo/light_blitz_cimpl.h"
+#include "compressor_zoo/light_keen_cimpl.h"
+#include "compressor_zoo/light_loose_cimpl.h"
+#include "compressor_zoo/light_optimal_cimpl.h"
+#include "compressor_zoo/light_swift_cimpl.h"
 #include "decompress_dispatch.h"
-#include "decompressor_zoo/heavy_safe_decompress_impl.h"
-#include "decompressor_zoo/heavy_unsafe_decompress_impl.h"
-#include "decompressor_zoo/safe_decompress_impl.h"
-#include "decompressor_zoo/unsafe_decompress_impl.h"
+#include "decompressor_zoo/heavy_safe_dimpl.h"
+#include "decompressor_zoo/heavy_unsafe_dimpl.h"
+#include "decompressor_zoo/light_safe_dimpl.h"
+#include "decompressor_zoo/light_unsafe_dimpl.h"
 #include "isa/lib_sse2.h"
 
 #include <cstdint>
@@ -25,12 +28,18 @@ namespace misa77
                            uint64_t dst_cap,
                            config cfg)
     {
-        if (cfg.level == 0)
-            return loose_compress_impl<lib_sse2>(src, src_size, dst, dst_cap);
+        if (cfg.level == -1)
+            return light_blitz_cimpl<lib_sse2>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 0)
+            return light_swift_cimpl<lib_sse2>(src, src_size, dst, dst_cap);
         else if (cfg.level == 1)
-            return default_compress_impl<lib_sse2>(src, src_size, dst, dst_cap);
+            return light_loose_cimpl<lib_sse2>(src, src_size, dst, dst_cap);
         else if (cfg.level == 2)
-            return heavy_compress_impl<lib_sse2>(src, src_size, dst, dst_cap);
+            return light_keen_cimpl<lib_sse2>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 3)
+            return light_optimal_cimpl<lib_sse2>(src, src_size, dst, dst_cap);
+        else if (cfg.level == 4)
+            return heavy_optimal_cimpl<lib_sse2>(src, src_size, dst, dst_cap);
         return 0;
     }
 
@@ -44,14 +53,14 @@ namespace misa77
         {
             // heavy
             if (dcfg.safe)
-                return heavy_safe_decompress_impl<lib_sse2>(src, src_size, dst, dst_cap);
-            return heavy_unsafe_decompress_impl<lib_sse2>(src, src_size, dst, dst_cap);
+                return heavy_safe_dimpl<lib_sse2>(src, src_size, dst, dst_cap);
+            return heavy_unsafe_dimpl<lib_sse2>(src, src_size, dst, dst_cap);
         }
 
         // light
         if (dcfg.safe)
-            return safe_decompress_impl<lib_sse2>(src, src_size, dst, dst_cap);
-        return unsafe_decompress_impl<lib_sse2>(src, src_size, dst, dst_cap);
+            return light_safe_dimpl<lib_sse2>(src, src_size, dst, dst_cap);
+        return light_unsafe_dimpl<lib_sse2>(src, src_size, dst, dst_cap);
     }
 
 } // namespace misa77


### PR DESCRIPTION
Updates misa77 from 0.5.0 to [v0.6.0](https://github.com/welcome-to-the-sunny-side/misa77/releases/tag/v0.6.0).

### Library Changes

- New levels added.
- Old levels have been remapped.

### lzbench-side changes

- Codec rows: `misa77` now spans levels -1..4 and `misa77_safe` levels -1..3. Negative levels follow the existing `zstd_fast` precedent.
- The `LZ` alias covers all levels of both variants. `FASTEST` uses level 0.
- README + CHANGELOG entries updated.
- No Makefile changes needed.

### Results (silesia.tar, Intel i7-14650HX (@2.2 GHz), single core, turbo disabled)

| Compressor name          | Compression | Decompress. |  Ratio |
| ------------------------ | ----------- | ----------- | ------ |
| misa77 0.6.0 --1         |    232 MB/s |   3846 MB/s |  46.74 |
| misa77 0.6.0 -0          |    170 MB/s |   4593 MB/s |  44.60 |
| misa77 0.6.0 -1          |   54.2 MB/s |   5376 MB/s |  42.64 |
| misa77 0.6.0 -2          |   41.5 MB/s |   4689 MB/s |  40.33 |
| misa77 0.6.0 -3          |   10.7 MB/s |   4635 MB/s |  37.76 |
| misa77 0.6.0 -4          |   6.97 MB/s |   4366 MB/s |  35.51 |
| zxc 0.13.1 -3            |    114 MB/s |   2840 MB/s |  45.46 |
| lzsse8fast 2019-04-18    |    183 MB/s |   2671 MB/s |  44.80 |
| lz4hc 1.10.0 -12         |   7.31 MB/s |   2536 MB/s |  36.45 |
| lz4 1.10.0               |    371 MB/s |   2514 MB/s |  47.59 |
| lzav 5.16 -2             |   62.6 MB/s |   1675 MB/s |  34.85 |
| zstd 1.5.7 -1            |    297 MB/s |    903 MB/s |  34.54 |

(misa77 rows first, then competitors sorted by decompression speed)