### PR TITLE
Fix the memory leak issue in the lz_codecs.cpp file

### DIFF
--- a/bench/lz_codecs.cpp
+++ b/bench/lz_codecs.cpp
@@ -325,8 +325,10 @@ int64_t lzbench_libdeflate_decompress(char *inbuf, size_t insize, char *outbuf, 
         return 0;
     size_t res = 0;
     if (libdeflate_deflate_decompress(decompressor, inbuf, insize, outbuf, outsize, &res) != LIBDEFLATE_SUCCESS) {
+        libdeflate_free_decompressor(decompressor);
         return 0;
     }
+    libdeflate_free_decompressor(decompressor);
     return res;
 }
 #endif


### PR DESCRIPTION
Problem description：The lzbench_libdeflate_decompress function in the lz_codecs.cpp file allocates the decompressor using libdeflate_alloc_decompressor(), but it does not call libdeflate_free_decompressor() to release it on either of the two exit paths.
Hazard statement：During the stress testing, each decompression call will leak a decompressor object. Long-term stress testing will significantly consume memory.
Repair solution: Add release calls before both return paths.
