### PR TITLE
gpucompact: Speed improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 v2.x.y (work-in-progress)
+- updated GPUCompact to 1.1 (by @UDPSendToFailed)
 - fix: codecs whose init() fails are now skipped instead of being benchmarked with a
        NULL work_mem, which used to SEGFAULT (e.g. "lzbench -eCUDA" without a GPU)
 - added misa77 0.6.0 (by @welcome-to-the-sunny-side)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Notes column says otherwise.
 | [fastlz 0.5.0](https://github.com/ariya/FastLZ) | 2020-02-02 | |
 | [fast-lzma2 1.0.1](https://github.com/conor42/fast-lzma2) | 2019-05-06 | |
 | [glza 0.12](https://encode.su/threads/2427-GLZA) | 2026-03-23 | |
-| [gpucompact 1.0](https://github.com/UDPSendToFailed/gpucompact) | 2026-07-27 | CUDA only |
+| [gpucompact 1.1](https://github.com/UDPSendToFailed/gpucompact) | 2026-08-14 | CUDA only |
 | [kanzi 2.5.3](https://github.com/flanglet/kanzi-cpp) | 2026-04-22 | |
 | [libdeflate v1.25](https://github.com/ebiggers/libdeflate) | 2025-11-01 | |
 | [lizard v2.1](https://github.com/inikep/lizard) | 2025-01-26 | |

--- a/bench/lzbench.h
+++ b/bench/lzbench.h
@@ -201,7 +201,7 @@ static const compressor_desc_t comp_desc[] =
     { "gipfeli",    "gipfeli 2016-07-13",      0,   0,    0,  BENCH_POOL_MT, lzbench_gipfeli_compress,    lzbench_gipfeli_decompress,    NULL,                    NULL },
     { "glza",       "glza 0.12",               0,   0,    0,   NO_THREADING, lzbench_glza_compress,       lzbench_glza_decompress,       NULL,                    NULL },
 #if !defined(BENCH_REMOVE_GPUCOMPACT) && defined(BENCH_HAS_CUDA)
-    { "gpucompact", "gpucompact 1.0",          1,   5,    0,  NO_THREADING,  lzbench_gpucompact_compress, lzbench_gpucompact_decompress, lzbench_gpucompact_init,  lzbench_gpucompact_deinit },
+    { "gpucompact", "gpucompact 1.1",          1,   5,    0,  NO_THREADING,  lzbench_gpucompact_compress, lzbench_gpucompact_decompress, lzbench_gpucompact_init,  lzbench_gpucompact_deinit },
 #endif
     { "kanzi",      "kanzi 2.5.3",             1,   9,    0, FULL_THREADING, lzbench_kanzi_compress,      lzbench_kanzi_decompress,      NULL,                    NULL },
     { "libdeflate", "libdeflate 1.25",         1,  12,    0,  BENCH_POOL_MT, lzbench_libdeflate_compress, lzbench_libdeflate_decompress, NULL,                    NULL },

--- a/lz/gpucompact/context.cu
+++ b/lz/gpucompact/context.cu
@@ -23,6 +23,7 @@
 #include <cub/cub.cuh>
 #include <iostream>
 #include <stdexcept>
+#include <string>
 
 #define CUDA_CHECK(call)                                                       \
   do {                                                                         \
@@ -85,7 +86,6 @@ CompressionContext::CompressionContext(int macro_bytes, int mini_bytes,
       cudaMalloc(&d_dense_words, max_chunks * max_words * sizeof(uint64_t)));
 
   CUDA_CHECK(cudaMalloc(&d_payload, payload_alloc_size));
-  CUDA_CHECK(cudaMalloc(&d_gpu_hash, sizeof(uint64_t)));
   CUDA_CHECK(cudaMalloc(&d_overflow_flag, sizeof(uint32_t)));
   CUDA_CHECK(cudaMallocHost(&host_overflow_flag, sizeof(uint32_t)));
 
@@ -139,7 +139,6 @@ CompressionContext::~CompressionContext() {
   cudaFree(d_word_offsets);
   cudaFree(d_dense_words);
   cudaFree(d_payload);
-  cudaFree(d_gpu_hash);
   cudaFree(d_overflow_flag);
   cudaFreeHost(host_overflow_flag);
   cudaFree(d_temp_storage);
@@ -171,52 +170,92 @@ void CompressionContext::compress_chunk(int threads_comp, int mini_chunk_size) {
       cudaMemcpyAsync(d_data, host_in, n, cudaMemcpyHostToDevice, stream));
 
   int blocks = (n + 255) / 256;
-  cast_uint8_to_int32_kernel<<<blocks, 256, 0, stream>>>(d_data, d_rank, n);
-
-  int k = 1;
-  int max_iter = (int)std::ceil(std::log2(n)) + 2;
+  int rank_bits = (int)std::ceil(std::log2((double)n));
+  int key_bits = std::min(64, rank_bits * 2);
 
   cub::DoubleBuffer<uint64_t> d_keys_db(d_keys, d_keys_alt);
   cub::DoubleBuffer<int> d_sa_db(d_sa, d_sa_alt);
 
-  // ASYNC SA DOUBLING WITH PINNED MEMORY EARLY EXIT CHECK
-  for (int iter = 0; iter < max_iter; iter++) {
-    sa_key_kernel<<<blocks, 256, 0, stream>>>(d_rank, d_sa_db.Current(),
-                                              d_keys_db.Current(), n, k);
+  // PASS 0: 4-Byte Coarse Jumpstart (32-bit single-pass sort)
+  // Packs 4 consecutive cyclic bytes into uint32_t and sorts in one 32-bit pass
+  cub::DoubleBuffer<uint32_t> d_keys32_db(
+      reinterpret_cast<uint32_t *>(d_keys),
+      reinterpret_cast<uint32_t *>(d_keys_alt));
+  sa_4byte_keys_kernel<<<blocks, 256, 0, stream>>>(
+      d_data, d_keys32_db.Current(), d_sa_db.Current(), n);
 
-    size_t t_bytes = temp_storage_bytes;
-    cub::DeviceRadixSort::SortPairs(d_temp_storage, t_bytes, d_keys_db, d_sa_db,
-                                    n, 0, 64, stream);
+  size_t t_bytes = temp_storage_bytes;
+  cub::DeviceRadixSort::SortPairs(d_temp_storage, t_bytes, d_keys32_db,
+                                  d_sa_db, n, 0, 32, stream);
 
-    sa_diff_kernel<<<blocks, 256, 0, stream>>>(d_keys_db.Current(), d_diff, n);
+  sa_diff_32_kernel<<<blocks, 256, 0, stream>>>(d_keys32_db.Current(), d_diff, n);
 
-    t_bytes = temp_storage_bytes;
-    cub::DeviceScan::InclusiveSum(d_temp_storage, t_bytes, d_diff,
-                                  d_unique_ranks, n, stream);
+  t_bytes = temp_storage_bytes;
+  cub::DeviceScan::InclusiveSum(d_temp_storage, t_bytes, d_diff,
+                                d_unique_ranks, n, stream);
 
-    sa_rank_kernel<<<blocks, 256, 0, stream>>>(d_unique_ranks,
-                                               d_sa_db.Current(), d_rank, n);
+  sa_rank_kernel<<<blocks, 256, 0, stream>>>(d_unique_ranks,
+                                             d_sa_db.Current(), d_rank, n);
 
-    // Asynchronous transfer to pinned memory + stream synchronization
+  bool sorted = false;
+  if (n <= 1024) {
     CUDA_CHECK(cudaMemcpyAsync(host_last_rank, d_unique_ranks + n - 1,
                                sizeof(int), cudaMemcpyDeviceToHost, stream));
     CUDA_CHECK(cudaStreamSynchronize(stream));
-
-    if (*host_last_rank == n) {
-      break; // Early exit when Suffix Array is 100% sorted
-    }
-
-    k *= 2;
+    if (*host_last_rank == n)
+      sorted = true;
   }
 
-  if (*host_last_rank < n) {
+  // If 4-byte prefixes are not unique, continue doubling from k = 4 (skips k=1, 2)
+  if (!sorted) {
+    int k = 4;
+    int max_iter = rank_bits + 2;
+    for (int iter = 0; iter < max_iter; iter++) {
+      sa_key_kernel<<<blocks, 256, 0, stream>>>(d_rank, d_sa_db.Current(),
+                                                d_keys_db.Current(), n, k,
+                                                rank_bits);
+
+      t_bytes = temp_storage_bytes;
+      cub::DeviceRadixSort::SortPairs(d_temp_storage, t_bytes, d_keys_db, d_sa_db,
+                                      n, 0, key_bits, stream);
+
+      sa_diff_kernel<<<blocks, 256, 0, stream>>>(d_keys_db.Current(), d_diff, n);
+
+      t_bytes = temp_storage_bytes;
+      cub::DeviceScan::InclusiveSum(d_temp_storage, t_bytes, d_diff,
+                                    d_unique_ranks, n, stream);
+
+      sa_rank_kernel<<<blocks, 256, 0, stream>>>(d_unique_ranks,
+                                                 d_sa_db.Current(), d_rank, n);
+
+      // Only synchronize and poll for early exit starting at round 3 (effective prefix >= 64 bytes)
+      // or on the final iteration, allowing the GPU to queue early rounds back-to-back without CPU stalls.
+      if (iter >= 3 || n <= 1024 || iter == max_iter - 1) {
+        CUDA_CHECK(cudaMemcpyAsync(host_last_rank, d_unique_ranks + n - 1,
+                                   sizeof(int), cudaMemcpyDeviceToHost, stream));
+        CUDA_CHECK(cudaStreamSynchronize(stream));
+
+        if (*host_last_rank == n) {
+          sorted = true;
+          break; // Early exit when Suffix Array is 100% sorted
+        }
+      }
+
+      k *= 2;
+    }
+  }
+
+  if (!sorted) {
     // Input is strictly periodic (period P < n), so suffix ranks cannot be unique.
     // Inverse BWT pointer jumping requires a single cycle of length n, so fall back to raw mode.
     is_raw = 1;
     comp_size = n;
     std::memcpy(host_out, host_in, n);
+    CUDA_CHECK(cudaEventRecord(e_end, stream));
+    cudaStreamSynchronize(stream);
     return;
   }
+
 
   extract_bwt_kernel<<<blocks, 256, 0, stream>>>(d_sa_db.Current(), d_data,
                                                  d_bwt, d_primary_idx, n);
@@ -228,10 +267,10 @@ void CompressionContext::compress_chunk(int threads_comp, int mini_chunk_size) {
 
   CUDA_CHECK(cudaMemsetAsync(d_hist, 0, 257 * sizeof(uint32_t), stream));
 
-  zrle_encode_kernel<<<z_blocks, threads_comp, threads_comp * 260, stream>>>(
-      d_bwt, d_out_symbols, d_chunk_sym_lens, n, mini_chunk_size, threads_comp);
-  compute_histogram_kernel<<<z_blocks, threads_comp, 0, stream>>>(
-      d_out_symbols, d_chunk_sym_lens, d_hist, num_chunks, mini_chunk_size);
+  size_t zrle_smem = (size_t)threads_comp * 260;
+  zrle_encode_kernel<<<z_blocks, threads_comp, zrle_smem, stream>>>(
+      d_bwt, d_out_symbols, d_chunk_sym_lens, d_hist, n, mini_chunk_size,
+      threads_comp);
   build_tans_all_kernel<<<1, 257, 0, stream>>>(
       d_hist, d_p, d_prefix_p, d_max_x, d_symbol_spread, d_enc_table,
       d_dec_table, d_dec_symbol, d_next_state, L, 257);
@@ -246,6 +285,7 @@ void CompressionContext::compress_chunk(int threads_comp, int mini_chunk_size) {
   CUDA_CHECK(cudaStreamSynchronize(stream));
 
   if (*host_overflow_flag != 0) {
+    // Bitstream overflow detected -> Fallback to Raw Mode
     is_raw = 1;
     comp_size = n;
     std::memcpy(host_out, host_in, n);
@@ -259,7 +299,7 @@ void CompressionContext::compress_chunk(int threads_comp, int mini_chunk_size) {
       d_chunk_bit_lens, d_chunk_word_lens, num_chunks);
 
   CUDA_CHECK(cudaMemsetAsync(d_word_offsets, 0, sizeof(uint32_t), stream));
-  size_t t_bytes = temp_storage_bytes;
+  t_bytes = temp_storage_bytes;
   cub::DeviceScan::InclusiveSum(d_temp_storage, t_bytes, d_chunk_word_lens,
                                 d_word_offsets + 1, num_chunks, stream);
 
@@ -339,7 +379,6 @@ DecompressionContext::DecompressionContext(int macro_bytes, int mini_bytes,
 
   CUDA_CHECK(cudaMallocHost(&host_in, payload_alloc_size));
   CUDA_CHECK(cudaMallocHost(&host_out, macro_size));
-  CUDA_CHECK(cudaMallocHost(&host_calc_hash, sizeof(uint64_t)));
 
   // Pinned host scalars for async copy safety
   CUDA_CHECK(cudaMallocHost(&host_uncomp_size, sizeof(int)));
@@ -352,10 +391,8 @@ DecompressionContext::DecompressionContext(int macro_bytes, int mini_bytes,
   CUDA_CHECK(cudaMalloc(&d_primary_idx, sizeof(int)));
 
   CUDA_CHECK(cudaMalloc(&d_global_LF, macro_size * sizeof(int)));
-  CUDA_CHECK(cudaMalloc(&d_J_in, macro_size * sizeof(int)));
-  CUDA_CHECK(cudaMalloc(&d_D_in, macro_size * sizeof(int)));
-  CUDA_CHECK(cudaMalloc(&d_J_out, macro_size * sizeof(int)));
-  CUDA_CHECK(cudaMalloc(&d_D_out, macro_size * sizeof(int)));
+  CUDA_CHECK(cudaMalloc(&d_JD_in, macro_size * sizeof(int2)));
+  CUDA_CHECK(cudaMalloc(&d_JD_out, macro_size * sizeof(int2)));
 
   CUDA_CHECK(cudaMalloc(&d_chunk_bit_lengths, max_chunks * sizeof(uint32_t)));
   CUDA_CHECK(cudaMalloc(&d_chunk_word_lens, max_chunks * sizeof(uint32_t)));
@@ -373,11 +410,11 @@ DecompressionContext::DecompressionContext(int macro_bytes, int mini_bytes,
   CUDA_CHECK(cudaMalloc(&d_sizes, sizeof(int)));
 
   CUDA_CHECK(cudaMalloc(&d_payload, payload_alloc_size));
-  CUDA_CHECK(cudaMalloc(&d_gpu_hash, sizeof(uint64_t)));
 
   size_t sort_bytes = 0, scan_bytes = 0;
   cub::DoubleBuffer<uint64_t> d_keys_db(d_keys, d_keys_alt);
-  cub::DoubleBuffer<int> d_sa_db(d_J_in, d_J_out);
+  cub::DoubleBuffer<int> d_sa_db(reinterpret_cast<int *>(d_JD_in),
+                                 reinterpret_cast<int *>(d_JD_out));
   cub::DeviceRadixSort::SortPairs(nullptr, sort_bytes, d_keys_db, d_sa_db,
                                   macro_size, 0, 64, stream);
   cub::DeviceScan::InclusiveSum(nullptr, scan_bytes, d_chunk_word_lens,
@@ -387,8 +424,10 @@ DecompressionContext::DecompressionContext(int macro_bytes, int mini_bytes,
   CUDA_CHECK(cudaMalloc(&d_temp_storage, temp_storage_bytes));
 
 #if CUDART_VERSION >= 11000
-  if (cudaDeviceGetLimit(&orig_l2_limit, cudaLimitPersistingL2CacheSize) == cudaSuccess &&
-      cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, dec_bytes) == cudaSuccess) {
+  if (cudaDeviceGetLimit(&orig_l2_limit, cudaLimitPersistingL2CacheSize) ==
+          cudaSuccess &&
+      cudaDeviceSetLimit(cudaLimitPersistingL2CacheSize, dec_bytes) ==
+          cudaSuccess) {
     l2_modified = true;
     cudaStreamAttrValue attr;
     std::memset(&attr, 0, sizeof(attr));
@@ -397,7 +436,8 @@ DecompressionContext::DecompressionContext(int macro_bytes, int mini_bytes,
     attr.accessPolicyWindow.hitRatio = 1.0f; // 100% L2 Persistence Preference
     attr.accessPolicyWindow.hitProp = cudaAccessPropertyPersisting;
     attr.accessPolicyWindow.missProp = cudaAccessPropertyStreaming;
-    if (cudaStreamSetAttribute(stream, cudaStreamAttributeAccessPolicyWindow, &attr) != cudaSuccess) {
+    if (cudaStreamSetAttribute(stream, cudaStreamAttributeAccessPolicyWindow,
+                               &attr) != cudaSuccess) {
       cudaGetLastError();
     }
   } else {
@@ -424,36 +464,40 @@ DecompressionContext::DecompressionContext(int macro_bytes, int mini_bytes,
     CUDA_CHECK(cudaMemcpyAsync(d_primary_idx, host_primary_idx, sizeof(int),
                                cudaMemcpyHostToDevice, stream));
 
+    int rank_bits = (int)std::ceil(std::log2((double)macro_size));
+    int key_bits = std::min(64, 8 + rank_bits);
+
     dim3 grid_k(blocks_u, 1);
     fill_key_kernel<<<grid_k, 256, 0, stream>>>(d_offsets, d_sizes, d_bwt,
-                                                d_keys, 1);
-    fill_sequence_kernel<<<blocks_u, 256, 0, stream>>>(d_J_in, macro_size);
+                                                d_keys, 1, rank_bits);
+    fill_sequence_kernel<<<blocks_u, 256, 0, stream>>>(
+        reinterpret_cast<int *>(d_JD_in), macro_size);
 
     cub::DoubleBuffer<uint64_t> keys_db(d_keys, d_keys_alt);
-    cub::DoubleBuffer<int> f_to_l_db(d_J_in, d_J_out);
+    cub::DoubleBuffer<int> f_to_l_db(reinterpret_cast<int *>(d_JD_in),
+                                     reinterpret_cast<int *>(d_JD_out));
     size_t t_bytes = temp_storage_bytes;
     cub::DeviceRadixSort::SortPairs(d_temp_storage, t_bytes, keys_db, f_to_l_db,
-                                    macro_size, 0, 64, stream);
+                                    macro_size, 0, key_bits, stream);
 
     build_lf_kernel<<<blocks_u, 256, 0, stream>>>(f_to_l_db.Current(),
                                                   d_global_LF, macro_size);
 
     dim3 grid_p(blocks_u, 1);
     dim3 block_p(256, 1);
-    jump_init_kernel<<<grid_p, block_p, 0, stream>>>(
-        d_global_LF, d_primary_idx, d_offsets, d_sizes, d_J_in, d_D_in);
+    jump_init_vec_kernel<<<grid_p, block_p, 0, stream>>>(
+        d_global_LF, d_primary_idx, d_offsets, d_sizes, d_JD_in);
 
-    int *curr_J = d_J_in, *curr_D = d_D_in;
-    int *next_J = d_J_out, *next_D = d_D_out;
+    int2 *curr_JD = d_JD_in;
+    int2 *next_JD = d_JD_out;
     for (int s = 0; s < steps; s++) {
-      jump_step_kernel<<<grid_p, block_p, 0, stream>>>(
-          curr_J, curr_D, next_J, next_D, d_offsets, d_sizes);
-      std::swap(curr_J, next_J);
-      std::swap(curr_D, next_D);
+      jump_step_vec_kernel<<<grid_p, block_p, 0, stream>>>(
+          curr_JD, next_JD, d_offsets, d_sizes);
+      std::swap(curr_JD, next_JD);
     }
 
-    jump_scatter_kernel<<<grid_p, block_p, 0, stream>>>(
-        curr_D, d_bwt, d_data, d_primary_idx, d_offsets, d_sizes);
+    jump_scatter_vec_kernel<<<grid_p, block_p, 0, stream>>>(
+        curr_JD, d_bwt, d_data, d_primary_idx, d_offsets, d_sizes);
 
     CUDA_CHECK(cudaStreamEndCapture(stream, &graph));
 #if CUDART_VERSION >= 11040
@@ -493,7 +537,6 @@ DecompressionContext::~DecompressionContext() {
 
   cudaFreeHost(host_in);
   cudaFreeHost(host_out);
-  cudaFreeHost(host_calc_hash);
   cudaFreeHost(host_uncomp_size);
   cudaFreeHost(host_primary_idx);
 
@@ -503,10 +546,8 @@ DecompressionContext::~DecompressionContext() {
   cudaFree(d_keys_alt);
   cudaFree(d_primary_idx);
   cudaFree(d_global_LF);
-  cudaFree(d_J_in);
-  cudaFree(d_D_in);
-  cudaFree(d_J_out);
-  cudaFree(d_D_out);
+  cudaFree(d_JD_in);
+  cudaFree(d_JD_out);
   cudaFree(d_chunk_bit_lengths);
   cudaFree(d_chunk_word_lens);
   cudaFree(d_decoding_table);
@@ -515,7 +556,6 @@ DecompressionContext::~DecompressionContext() {
   cudaFree(d_offsets);
   cudaFree(d_sizes);
   cudaFree(d_payload);
-  cudaFree(d_gpu_hash);
   cudaFree(d_temp_storage);
 
   cudaEventDestroy(e_start);
@@ -578,8 +618,6 @@ bool DecompressionContext::decompress_chunk(int threads_decomp,
       }
 
       int blocks = (num_chunks + threads_decomp - 1) / threads_decomp;
-      // DYNAMIC SMEM SIZE: (2 * L * sizeof(int)) + (threads_decomp * 256 bytes)
-      // for alphabet
       size_t smem_size = (2 * L * sizeof(int)) + (size_t)threads_decomp * 256;
 
       if (smem_size > 49152) {
@@ -595,54 +633,54 @@ bool DecompressionContext::decompress_chunk(int threads_decomp,
   }
 
   if (is_raw == 0) {
-    // Write scalars into pinned memory BEFORE graph launch reads them
     *host_uncomp_size = uncomp_size;
     *host_primary_idx = primary_idx;
 
     if (uncomp_size == macro_size && graph_exec) {
-      // CUDA GRAPH FAST PATH: Replay pre-captured inverse BWT graph
       CUDA_CHECK(cudaGraphLaunch(graph_exec, stream));
     } else {
-      // FALLBACK PATH: Inline launches for partial/last macro chunk
       CUDA_CHECK(cudaMemcpyAsync(d_sizes, host_uncomp_size, sizeof(int),
                                  cudaMemcpyHostToDevice, stream));
       CUDA_CHECK(cudaMemcpyAsync(d_primary_idx, host_primary_idx, sizeof(int),
                                  cudaMemcpyHostToDevice, stream));
 
+      int rank_bits = (int)std::ceil(std::log2((double)uncomp_size));
+      int key_bits = std::min(64, 8 + rank_bits);
       int blocks_u = (uncomp_size + 255) / 256;
 
       dim3 grid_k(blocks_u, 1);
       fill_key_kernel<<<grid_k, 256, 0, stream>>>(d_offsets, d_sizes, d_bwt,
-                                                  d_keys, 1);
-      fill_sequence_kernel<<<blocks_u, 256, 0, stream>>>(d_J_in, uncomp_size);
+                                                  d_keys, 1, rank_bits);
+      fill_sequence_kernel<<<blocks_u, 256, 0, stream>>>(
+          reinterpret_cast<int *>(d_JD_in), uncomp_size);
 
       cub::DoubleBuffer<uint64_t> keys_db(d_keys, d_keys_alt);
-      cub::DoubleBuffer<int> f_to_l_db(d_J_in, d_J_out);
+      cub::DoubleBuffer<int> f_to_l_db(reinterpret_cast<int *>(d_JD_in),
+                                       reinterpret_cast<int *>(d_JD_out));
       size_t t_bytes = temp_storage_bytes;
       cub::DeviceRadixSort::SortPairs(d_temp_storage, t_bytes, keys_db,
-                                      f_to_l_db, uncomp_size, 0, 64, stream);
+                                      f_to_l_db, uncomp_size, 0, key_bits, stream);
 
       build_lf_kernel<<<blocks_u, 256, 0, stream>>>(f_to_l_db.Current(),
                                                     d_global_LF, uncomp_size);
 
       dim3 grid_p(blocks_u, 1);
       dim3 block_p(256, 1);
-      jump_init_kernel<<<grid_p, block_p, 0, stream>>>(
-          d_global_LF, d_primary_idx, d_offsets, d_sizes, d_J_in, d_D_in);
+      jump_init_vec_kernel<<<grid_p, block_p, 0, stream>>>(
+          d_global_LF, d_primary_idx, d_offsets, d_sizes, d_JD_in);
 
-      int *curr_J = d_J_in, *curr_D = d_D_in;
-      int *next_J = d_J_out, *next_D = d_D_out;
+      int2 *curr_JD = d_JD_in;
+      int2 *next_JD = d_JD_out;
       int steps = (int)std::ceil(std::log2(uncomp_size));
 
       for (int s = 0; s < steps; s++) {
-        jump_step_kernel<<<grid_p, block_p, 0, stream>>>(
-            curr_J, curr_D, next_J, next_D, d_offsets, d_sizes);
-        std::swap(curr_J, next_J);
-        std::swap(curr_D, next_D);
+        jump_step_vec_kernel<<<grid_p, block_p, 0, stream>>>(
+            curr_JD, next_JD, d_offsets, d_sizes);
+        std::swap(curr_JD, next_JD);
       }
 
-      jump_scatter_kernel<<<grid_p, block_p, 0, stream>>>(
-          curr_D, d_bwt, d_data, d_primary_idx, d_offsets, d_sizes);
+      jump_scatter_vec_kernel<<<grid_p, block_p, 0, stream>>>(
+          curr_JD, d_bwt, d_data, d_primary_idx, d_offsets, d_sizes);
     }
   }
 

--- a/lz/gpucompact/context.cuh
+++ b/lz/gpucompact/context.cuh
@@ -70,7 +70,6 @@ public:
   uint64_t *d_dense_words = nullptr;
 
   uint8_t *d_payload = nullptr;
-  uint64_t *d_gpu_hash = nullptr;
   uint32_t *d_overflow_flag = nullptr;
 
   uint32_t *host_overflow_flag = nullptr;
@@ -85,7 +84,6 @@ public:
   int num_chunks = 0;
   int total_words = 0;
   int primary_idx = 0;
-  uint64_t gpu_hash = 0;
   int comp_size = 0;
 
   CompressionContext(int macro_bytes, int mini_bytes, int state_L);
@@ -110,7 +108,6 @@ public:
 
   unsigned char *host_in = nullptr;
   unsigned char *host_out = nullptr;
-  uint64_t *host_calc_hash = nullptr;
 
   // Pinned Host Buffers for Async Copy Safety
   int *host_uncomp_size = nullptr;
@@ -123,10 +120,8 @@ public:
   int *d_primary_idx = nullptr;
 
   int *d_global_LF = nullptr;
-  int *d_J_in = nullptr;
-  int *d_D_in = nullptr;
-  int *d_J_out = nullptr;
-  int *d_D_out = nullptr;
+  int2 *d_JD_in = nullptr;
+  int2 *d_JD_out = nullptr;
 
   uint32_t *d_chunk_bit_lengths = nullptr;
   uint32_t *d_chunk_word_lens = nullptr;
@@ -139,7 +134,6 @@ public:
   int *d_sizes = nullptr;
 
   uint8_t *d_payload = nullptr;
-  uint64_t *d_gpu_hash = nullptr;
 
   void *d_temp_storage = nullptr;
   size_t temp_storage_bytes = 0;
@@ -150,7 +144,6 @@ public:
   int num_chunks = 0;
   int total_words = 0;
   int primary_idx = 0;
-  uint64_t gpu_hash = 0;
   size_t orig_l2_limit = 0;
   bool l2_modified = false;
 

--- a/lz/gpucompact/kernels.cu
+++ b/lz/gpucompact/kernels.cu
@@ -17,13 +17,6 @@
  */
 #include "kernels.cuh"
 
-__global__ void cast_uint8_to_int32_kernel(const unsigned char *__restrict__ in,
-                                           int *__restrict__ out, int n) {
-  int idx = blockIdx.x * blockDim.x + threadIdx.x;
-  if (idx < n)
-    out[idx] = (int)in[idx];
-}
-
 __global__ void bit_to_word_kernel(const unsigned int *__restrict__ bits,
                                    unsigned int *__restrict__ words, int n) {
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -37,22 +30,45 @@ __global__ void fill_sequence_kernel(int *__restrict__ out, int n) {
     out[idx] = idx;
 }
 
-__global__ void sa_key_kernel(const int *__restrict__ rank,
-                              int *__restrict__ sa,
-                              uint64_t *__restrict__ keys, int n,
-                              int k) {
+__global__ void sa_4byte_keys_kernel(const unsigned char *__restrict__ T,
+                                     uint32_t *__restrict__ keys,
+                                     int *__restrict__ sa, int n) {
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx >= n)
     return;
-  uint64_t r1 = rank[idx];
-  uint64_t r2 = rank[(idx + k) % n];
-  keys[idx] = (r1 << 32) | r2;
+  uint32_t c0 = (uint32_t)T[idx];
+  uint32_t c1 = (uint32_t)T[(idx + 1) % n];
+  uint32_t c2 = (uint32_t)T[(idx + 2) % n];
+  uint32_t c3 = (uint32_t)T[(idx + 3) % n];
+  keys[idx] = (c0 << 24) | (c1 << 16) | (c2 << 8) | c3;
   sa[idx] = idx;
 }
 
-__global__ void
-sa_diff_kernel(const uint64_t *__restrict__ sorted_keys,
-               int *__restrict__ diff, int n) {
+__global__ void sa_diff_32_kernel(const uint32_t *__restrict__ sorted_keys,
+                                  int *__restrict__ diff, int n) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= n)
+    return;
+  if (idx == 0)
+    diff[idx] = 1;
+  else
+    diff[idx] = (sorted_keys[idx] != sorted_keys[idx - 1]) ? 1 : 0;
+}
+
+__global__ void sa_key_kernel(const int *__restrict__ rank,
+                              int *__restrict__ sa, uint64_t *__restrict__ keys,
+                              int n, int k, int rank_shift) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= n)
+    return;
+  uint64_t r1 = (uint32_t)rank[idx];
+  uint64_t r2 = (uint32_t)rank[(idx + k) % n];
+  keys[idx] = (r1 << rank_shift) | r2;
+  sa[idx] = idx;
+}
+
+__global__ void sa_diff_kernel(const uint64_t *__restrict__ sorted_keys,
+                               int *__restrict__ diff, int n) {
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx >= n)
     return;
@@ -88,78 +104,91 @@ __global__ void
 zrle_encode_kernel(const unsigned char *__restrict__ bwt,
                    unsigned short *__restrict__ out_symbols,
                    unsigned int *__restrict__ chunk_symbol_lengths,
+                   uint32_t *__restrict__ hist,
                    int total_size, int chunk_size, int threads_comp) {
+  __shared__ uint32_t s_block_hist[257];
+  for (int i = threadIdx.x; i < 257; i += blockDim.x) {
+    s_block_hist[i] = 0;
+  }
+  __syncthreads();
+
   int chunk_id = blockIdx.x * blockDim.x + threadIdx.x;
   int start = chunk_id * chunk_size;
-  if (start >= total_size)
-    return;
   int end = start + chunk_size;
   if (end > total_size)
     end = total_size;
 
-  extern __shared__ unsigned char s_alphabet[];
-  unsigned char *alphabet = &s_alphabet[threadIdx.x * 260];
-  for (int i = 0; i < 256; i++)
-    alphabet[i] = (unsigned char)i;
-
-  int zero_run = 0, sym_offset = 0, out_base = chunk_id * chunk_size;
-  for (int i = start; i < end; i++) {
-    unsigned char c = bwt[i], idx = 0;
-    for (int j = 0; j < 256; j++) {
-      if (alphabet[j] == c) {
-        idx = (unsigned char)j;
-        break;
-      }
+  if (start < total_size) {
+    extern __shared__ unsigned char s_alphabet[];
+    unsigned char *alphabet = &s_alphabet[threadIdx.x * 260];
+    for (int i = 0; i < 256; i++) {
+      alphabet[i] = (unsigned char)i;
     }
-    for (int j = idx; j > 0; j--)
-      alphabet[j] = alphabet[j - 1];
-    alphabet[0] = c;
 
-    if (idx == 0) {
-      zero_run++;
-    } else {
-      if (zero_run > 0) {
-        int temp = zero_run;
-        while (temp > 0) {
-          if (temp % 2 == 1) {
-            out_symbols[out_base + sym_offset++] = 0;
-            temp = (temp - 1) / 2;
-          } else {
-            out_symbols[out_base + sym_offset++] = 1;
-            temp = (temp - 2) / 2;
-          }
+    int zero_run = 0, sym_offset = 0, out_base = chunk_id * chunk_size;
+    for (int i = start; i < end; i++) {
+      unsigned char c = bwt[i], idx = 0;
+      for (int j = 0; j < 256; j++) {
+        if (alphabet[j] == c) {
+          idx = (unsigned char)j;
+          break;
         }
-        zero_run = 0;
       }
-      out_symbols[out_base + sym_offset++] = idx + 1;
-    }
-  }
-  if (zero_run > 0) {
-    int temp = zero_run;
-    while (temp > 0) {
-      if (temp % 2 == 1) {
-        out_symbols[out_base + sym_offset++] = 0;
-        temp = (temp - 1) / 2;
-      } else {
-        out_symbols[out_base + sym_offset++] = 1;
-        temp = (temp - 2) / 2;
-      }
-    }
-  }
-  chunk_symbol_lengths[chunk_id] = sym_offset;
-}
 
-__global__ void
-compute_histogram_kernel(const unsigned short *__restrict__ symbols,
-                         const unsigned int *__restrict__ lengths,
-                         unsigned int *__restrict__ hist, int num_chunks,
-                         int chunk_size) {
-  int chunk_id = blockIdx.x * blockDim.x + threadIdx.x;
-  if (chunk_id >= num_chunks)
-    return;
-  int length = lengths[chunk_id], base = chunk_id * chunk_size;
-  for (int i = 0; i < length; i++) {
-    atomicAdd(&hist[symbols[base + i]], 1);
+      if (idx == 0) {
+        zero_run++;
+      } else {
+        if (zero_run > 0) {
+          int temp = zero_run;
+          while (temp > 0) {
+            if (temp % 2 == 1) {
+              out_symbols[out_base + sym_offset++] = 0;
+              atomicAdd(&s_block_hist[0], 1);
+              temp = (temp - 1) / 2;
+            } else {
+              out_symbols[out_base + sym_offset++] = 1;
+              atomicAdd(&s_block_hist[1], 1);
+              temp = (temp - 2) / 2;
+            }
+          }
+          zero_run = 0;
+        }
+        out_symbols[out_base + sym_offset++] = idx + 1;
+        atomicAdd(&s_block_hist[idx + 1], 1);
+      }
+
+      // MTF-1 Adaptive Ranking: prevents thrashing on alternating 2-symbol runs
+      if (idx == 1) {
+        alphabet[1] = alphabet[0];
+        alphabet[0] = c;
+      } else if (idx > 1) {
+        for (int j = idx; j > 0; j--)
+          alphabet[j] = alphabet[j - 1];
+        alphabet[0] = c;
+      }
+    }
+    if (zero_run > 0) {
+      int temp = zero_run;
+      while (temp > 0) {
+        if (temp % 2 == 1) {
+          out_symbols[out_base + sym_offset++] = 0;
+          atomicAdd(&s_block_hist[0], 1);
+          temp = (temp - 1) / 2;
+        } else {
+          out_symbols[out_base + sym_offset++] = 1;
+          atomicAdd(&s_block_hist[1], 1);
+          temp = (temp - 2) / 2;
+        }
+      }
+    }
+    chunk_symbol_lengths[chunk_id] = sym_offset;
+  }
+
+  __syncthreads();
+  for (int i = threadIdx.x; i < 257; i += blockDim.x) {
+    if (s_block_hist[i] > 0) {
+      atomicAdd(&hist[i], s_block_hist[i]);
+    }
   }
 }
 
@@ -217,7 +246,9 @@ __global__ void build_tans_all_kernel(
 
   int step = (L / 2) + 3;
   for (int k = 0; k < s_p[tid]; k++) {
-    symbol_spread[((prefix + k) * step) % L] = tid;
+    int spread_idx = ((prefix + k) * step) % L;
+    if (spread_idx >= 0 && spread_idx < L)
+      symbol_spread[spread_idx] = tid;
   }
   __syncthreads();
 
@@ -226,26 +257,27 @@ __global__ void build_tans_all_kernel(
       next_state[i] = s_p[i];
     for (int x = L; x < 2 * L; x++) {
       int s = symbol_spread[x - L];
-      decoding_symbol[x - L] = s;
-      int state = next_state[s];
-      decoding_table[x - L] = state;
-      encoding_table[prefix_p_out[s] + state - s_p[s]] = x;
-      next_state[s] = state + 1;
+      int dec_idx = x - L;
+      if (dec_idx >= 0 && dec_idx < L) {
+        decoding_symbol[dec_idx] = s;
+        int state = next_state[s];
+        decoding_table[dec_idx] = state;
+        int enc_idx = prefix_p_out[s] + state - s_p[s];
+        if (enc_idx >= 0 && enc_idx < L)
+          encoding_table[enc_idx] = x;
+        next_state[s] = state + 1;
+      }
     }
   }
 }
 
-__global__ void tabled_encode_kernel(const unsigned short *__restrict__ symbols,
-                                     const unsigned int *__restrict__ lengths,
-                                     uint64_t *__restrict__ out_words,
-                                     unsigned int *__restrict__ bit_lengths,
-                                     const int *__restrict__ p,
-                                     const int *__restrict__ prefix_p,
-                                     const int *__restrict__ max_x,
-                                     const int *__restrict__ enc_table,
-                                     int num_chunks, int chunk_size,
-                                     int max_words, int L,
-                                     uint32_t *__restrict__ d_overflow_flag) {
+__global__ void tabled_encode_kernel(
+    const unsigned short *__restrict__ symbols,
+    const unsigned int *__restrict__ lengths, uint64_t *__restrict__ out_words,
+    unsigned int *__restrict__ bit_lengths, const int *__restrict__ p,
+    const int *__restrict__ prefix_p, const int *__restrict__ max_x,
+    const int *__restrict__ enc_table, int num_chunks, int chunk_size,
+    int max_words, int L, uint32_t *__restrict__ d_overflow_flag) {
   int chunk_id = blockIdx.x * blockDim.x + threadIdx.x;
 
   extern __shared__ unsigned char s_mem_th[];
@@ -314,18 +346,20 @@ __global__ void tabled_encode_kernel(const unsigned short *__restrict__ symbols,
     bit_lengths[chunk_id] = word_off * 64;
 }
 
+// -------------------------------------------------------------------------
+// TABLE-BASED DECODER KERNEL
+// -------------------------------------------------------------------------
+
 __global__ void tabled_decode_kernel(
     const uint64_t *__restrict__ in_words,
     const unsigned int *__restrict__ word_offsets,
-    const unsigned int *__restrict__ bit_lengths,
-    unsigned char *__restrict__ bwt, const int *__restrict__ dec_table,
-    const int *__restrict__ dec_symbol, int total_size, int chunk_size, int L) {
+    const unsigned int *__restrict__ bit_lengths, unsigned char *__restrict__ bwt,
+    const int *__restrict__ dec_table, const int *__restrict__ dec_symbol,
+    int total_size, int chunk_size, int L) {
   extern __shared__ int s_dec_mem[];
   int *s_dec_table = s_dec_mem;
   int *s_dec_symbol = &s_dec_mem[L];
 
-  // OPTIMIZATION FIX: Move MTF alphabet table from local stack (DRAM) into
-  // Shared Memory!
   unsigned char *s_alphabets = (unsigned char *)&s_dec_mem[2 * L];
   unsigned char *alphabet = &s_alphabets[threadIdx.x * 256];
 
@@ -407,12 +441,17 @@ __global__ void tabled_decode_kernel(
         power = 1;
       }
       if (out_idx < end) {
-        unsigned int mtf = s - 1;
-        unsigned char c = alphabet[mtf];
+        unsigned int idx = s - 1;
+        unsigned char c = alphabet[idx];
         bwt[out_idx++] = c;
-        for (int j = mtf; j > 0; j--)
-          alphabet[j] = alphabet[j - 1];
-        alphabet[0] = c;
+        if (idx == 1) {
+          alphabet[1] = alphabet[0];
+          alphabet[0] = c;
+        } else if (idx > 1) {
+          for (int j = idx; j > 0; j--)
+            alphabet[j] = alphabet[j - 1];
+          alphabet[0] = c;
+        }
       }
     }
   }
@@ -457,8 +496,8 @@ __global__ void dense_pack_kernel(const uint64_t *__restrict__ in,
 __global__ void fill_key_kernel(const uint64_t *__restrict__ offsets,
                                 const int *__restrict__ sizes,
                                 const unsigned char *__restrict__ bwt,
-                                uint64_t *__restrict__ key,
-                                int num_chunks) {
+                                uint64_t *__restrict__ key, int num_chunks,
+                                int rank_shift) {
   int cid = blockIdx.y;
   if (cid >= num_chunks)
     return;
@@ -469,9 +508,7 @@ __global__ void fill_key_kernel(const uint64_t *__restrict__ offsets,
     return;
 
   uint64_t off = offsets[cid];
-  key[off + lid] = (((uint64_t)cid) << 48) |
-                   (((uint64_t)bwt[off + lid]) << 32) |
-                   (uint64_t)lid;
+  key[off + lid] = (((uint64_t)bwt[off + lid]) << rank_shift) | (uint64_t)lid;
 }
 
 __global__ void build_lf_kernel(const int *__restrict__ F_to_L,
@@ -482,100 +519,61 @@ __global__ void build_lf_kernel(const int *__restrict__ F_to_L,
   }
 }
 
-__global__ void
-jump_init_kernel(const int *__restrict__ LF,
-                 const int *__restrict__ primary_indices,
-                 const uint64_t *__restrict__ chunk_offsets,
-                 const int *__restrict__ chunk_sizes, int *__restrict__ J,
-                 int *__restrict__ D) {
+__global__ void jump_init_vec_kernel(const int *__restrict__ LF,
+                                     const int *__restrict__ primary_indices,
+                                     const uint64_t *__restrict__ chunk_offsets,
+                                     const int *__restrict__ chunk_sizes,
+                                     int2 *__restrict__ JD) {
   int cid = blockIdx.y, lid = blockIdx.x * blockDim.x + threadIdx.x,
       size = chunk_sizes[cid];
   if (lid >= size)
     return;
   uint64_t off = chunk_offsets[cid];
-  int gid = off + lid, prim = off + primary_indices[cid],
-      g_target = off + LF[gid];
+  int gid = off + lid, prim = off + primary_indices[cid];
+  int lf_val = LF[gid];
+  int g_target = off + ((lf_val >= 0 && lf_val < size) ? lf_val : 0);
   if (gid == prim) {
-    J[gid] = gid;
-    D[gid] = 0;
+    JD[gid] = make_int2(gid, 0);
   } else {
-    J[gid] = g_target;
-    D[gid] = 1;
+    JD[gid] = make_int2(g_target, 1);
   }
 }
 
-__global__ void jump_step_kernel(const int *__restrict__ J_in,
-                                 const int *__restrict__ D_in,
-                                 int *__restrict__ J_out,
-                                 int *__restrict__ D_out,
-                                 const uint64_t *__restrict__ offsets,
-                                 const int *__restrict__ sizes) {
+__global__ void jump_step_vec_kernel(const int2 *__restrict__ JD_in,
+                                     int2 *__restrict__ JD_out,
+                                     const uint64_t *__restrict__ offsets,
+                                     const int *__restrict__ sizes) {
   int cid = blockIdx.y, lid = blockIdx.x * blockDim.x + threadIdx.x;
-  if (lid >= sizes[cid])
+  int size = sizes[cid];
+  if (lid >= size)
     return;
-  int gid = offsets[cid] + lid, my_J = J_in[gid];
-  J_out[gid] = J_in[my_J];
-  D_out[gid] = D_in[gid] + D_in[my_J];
+  uint64_t off = offsets[cid];
+  int gid = off + lid;
+  int2 my_jd = JD_in[gid];
+  int target_idx = my_jd.x;
+  if (target_idx >= (int)off && target_idx < (int)off + size) {
+    int2 target_jd = JD_in[target_idx];
+    JD_out[gid] = make_int2(target_jd.x, my_jd.y + target_jd.y);
+  } else {
+    JD_out[gid] = my_jd;
+  }
 }
 
-__global__ void jump_scatter_kernel(
-    const int *__restrict__ D, const unsigned char *__restrict__ bwt,
-    unsigned char *__restrict__ out, const int *__restrict__ primary,
-    const uint64_t *__restrict__ offsets,
-    const int *__restrict__ sizes) {
+__global__ void jump_scatter_vec_kernel(const int2 *__restrict__ JD,
+                                        const unsigned char *__restrict__ bwt,
+                                        unsigned char *__restrict__ out,
+                                        const int *__restrict__ primary,
+                                        const uint64_t *__restrict__ offsets,
+                                        const int *__restrict__ sizes) {
   int cid = blockIdx.y, lid = blockIdx.x * blockDim.x + threadIdx.x,
       size = sizes[cid];
   if (lid >= size)
     return;
   uint64_t off = offsets[cid];
-  int gid = off + lid, prim = off + primary[cid],
-      d_forw = (gid == prim) ? 0 : (size - D[gid]);
-  out[off + size - 1 - d_forw] = bwt[gid];
-}
-
-__global__ void gpu_hash_kernel(const unsigned char *__restrict__ data,
-                                uint64_t *__restrict__ d_hash,
-                                int size) {
-  int tid = threadIdx.x;
-  int idx = blockIdx.x * blockDim.x + tid;
-  uint64_t local_hash = 0;
-
-  int num_words = (size + 7) / 8;
-
-  if (idx < num_words) {
-    int start_byte = idx * 8;
-    int remain = size - start_byte;
-    uint64_t val = 0;
-
-    if (remain >= 8) {
-      val = *reinterpret_cast<const uint64_t *>(data + start_byte);
-    } else {
-      for (int i = 0; i < remain; i++) {
-        val |= (static_cast<uint64_t>(data[start_byte + i]))
-               << (i * 8);
-      }
-    }
-
-    local_hash = val * 0xbf58476d1ce4e5b9ULL;
-    local_hash ^= (local_hash >> 31);
-  }
-
-  for (int offset = 16; offset > 0; offset /= 2) {
-    local_hash ^= __shfl_down_sync(0xFFFFFFFF, local_hash, offset);
-  }
-
-  __shared__ uint64_t shared_hash[32];
-  if (tid % 32 == 0)
-    shared_hash[tid / 32] = local_hash;
-  __syncthreads();
-
-  if (tid < 32) {
-    local_hash = (tid < ((blockDim.x + 31) / 32)) ? shared_hash[tid] : 0;
-    for (int offset = 16; offset > 0; offset /= 2) {
-      local_hash ^= __shfl_down_sync(0xFFFFFFFF, local_hash, offset);
-    }
-    if (tid == 0 && local_hash != 0) {
-      atomicXor(reinterpret_cast<unsigned long long *>(d_hash), (unsigned long long)local_hash);
-    }
+  int gid = off + lid, prim = off + primary[cid];
+  int d_forw = (gid == prim) ? 0 : (size - JD[gid].y);
+  int target_pos = (int)off + size - 1 - d_forw;
+  if (target_pos >= (int)off && target_pos < (int)off + size) {
+    out[target_pos] = bwt[gid];
   }
 }

--- a/lz/gpucompact/kernels.cuh
+++ b/lz/gpucompact/kernels.cuh
@@ -50,9 +50,6 @@ __device__ inline void cp_async_wait_all() {
 // -------------------------------------------------------------------------
 // HELPER UTILITY KERNEL PROTOTYPES
 // -------------------------------------------------------------------------
-__global__ void cast_uint8_to_int32_kernel(const unsigned char *__restrict__ in,
-                                           int *__restrict__ out, int n);
-
 __global__ void bit_to_word_kernel(const unsigned int *__restrict__ bits,
                                    unsigned int *__restrict__ words, int n);
 
@@ -61,14 +58,19 @@ __global__ void fill_sequence_kernel(int *__restrict__ out, int n);
 // -------------------------------------------------------------------------
 // BWT & TANS KERNEL PROTOTYPES
 // -------------------------------------------------------------------------
-__global__ void sa_key_kernel(const int *__restrict__ rank,
-                              int *__restrict__ sa,
-                              uint64_t *__restrict__ keys, int n,
-                              int k);
+__global__ void sa_4byte_keys_kernel(const unsigned char *__restrict__ T,
+                                     uint32_t *__restrict__ keys,
+                                     int *__restrict__ sa, int n);
 
-__global__ void
-sa_diff_kernel(const uint64_t *__restrict__ sorted_keys,
-               int *__restrict__ diff, int n);
+__global__ void sa_diff_32_kernel(const uint32_t *__restrict__ sorted_keys,
+                                  int *__restrict__ diff, int n);
+
+__global__ void sa_key_kernel(const int *__restrict__ rank,
+                              int *__restrict__ sa, uint64_t *__restrict__ keys,
+                              int n, int k, int rank_shift);
+
+__global__ void sa_diff_kernel(const uint64_t *__restrict__ sorted_keys,
+                               int *__restrict__ diff, int n);
 
 __global__ void sa_rank_kernel(const int *__restrict__ unique_ranks,
                                const int *__restrict__ sa_sorted,
@@ -83,13 +85,8 @@ __global__ void
 zrle_encode_kernel(const unsigned char *__restrict__ bwt,
                    unsigned short *__restrict__ out_symbols,
                    unsigned int *__restrict__ chunk_symbol_lengths,
+                   uint32_t *__restrict__ hist,
                    int total_size, int chunk_size, int threads_comp);
-
-__global__ void
-compute_histogram_kernel(const unsigned short *__restrict__ symbols,
-                         const unsigned int *__restrict__ lengths,
-                         unsigned int *__restrict__ hist, int num_chunks,
-                         int chunk_size);
 
 __global__ void build_tans_all_kernel(
     const unsigned int *__restrict__ hist, int *__restrict__ p_out,
@@ -98,17 +95,13 @@ __global__ void build_tans_all_kernel(
     int *__restrict__ decoding_table, int *__restrict__ decoding_symbol,
     int *__restrict__ next_state, int L, int alphabet_size);
 
-__global__ void tabled_encode_kernel(const unsigned short *__restrict__ symbols,
-                                     const unsigned int *__restrict__ lengths,
-                                     uint64_t *__restrict__ out_words,
-                                     unsigned int *__restrict__ bit_lengths,
-                                     const int *__restrict__ p,
-                                     const int *__restrict__ prefix_p,
-                                     const int *__restrict__ max_x,
-                                     const int *__restrict__ enc_table,
-                                     int num_chunks, int chunk_size,
-                                     int max_words, int L,
-                                     uint32_t *__restrict__ d_overflow_flag);
+__global__ void tabled_encode_kernel(
+    const unsigned short *__restrict__ symbols,
+    const unsigned int *__restrict__ lengths, uint64_t *__restrict__ out_words,
+    unsigned int *__restrict__ bit_lengths, const int *__restrict__ p,
+    const int *__restrict__ prefix_p, const int *__restrict__ max_x,
+    const int *__restrict__ enc_table, int num_chunks, int chunk_size,
+    int max_words, int L, uint32_t *__restrict__ d_overflow_flag);
 
 __global__ void tabled_decode_kernel(
     const uint64_t *__restrict__ in_words,
@@ -120,38 +113,31 @@ __global__ void tabled_decode_kernel(
 __global__ void dense_pack_kernel(const uint64_t *__restrict__ in,
                                   const unsigned int *__restrict__ offsets,
                                   const unsigned int *__restrict__ lens,
-                                  uint64_t *__restrict__ out, int n,
-                                  int max_w);
+                                  uint64_t *__restrict__ out, int n, int max_w);
 
 __global__ void fill_key_kernel(const uint64_t *__restrict__ offsets,
                                 const int *__restrict__ sizes,
                                 const unsigned char *__restrict__ bwt,
-                                uint64_t *__restrict__ key,
-                                int num_chunks);
+                                uint64_t *__restrict__ key, int num_chunks,
+                                int rank_shift);
 
 __global__ void build_lf_kernel(const int *__restrict__ F_to_L,
                                 int *__restrict__ LF, int n);
 
-__global__ void
-jump_init_kernel(const int *__restrict__ LF,
-                 const int *__restrict__ primary_indices,
-                 const uint64_t *__restrict__ chunk_offsets,
-                 const int *__restrict__ chunk_sizes, int *__restrict__ J,
-                 int *__restrict__ D);
+__global__ void jump_init_vec_kernel(const int *__restrict__ LF,
+                                     const int *__restrict__ primary_indices,
+                                     const uint64_t *__restrict__ chunk_offsets,
+                                     const int *__restrict__ chunk_sizes,
+                                     int2 *__restrict__ JD);
 
-__global__ void jump_step_kernel(const int *__restrict__ J_in,
-                                 const int *__restrict__ D_in,
-                                 int *__restrict__ J_out,
-                                 int *__restrict__ D_out,
-                                 const uint64_t *__restrict__ offsets,
-                                 const int *__restrict__ sizes);
+__global__ void jump_step_vec_kernel(const int2 *__restrict__ JD_in,
+                                     int2 *__restrict__ JD_out,
+                                     const uint64_t *__restrict__ offsets,
+                                     const int *__restrict__ sizes);
 
-__global__ void jump_scatter_kernel(
-    const int *__restrict__ D, const unsigned char *__restrict__ bwt,
-    unsigned char *__restrict__ out, const int *__restrict__ primary,
-    const uint64_t *__restrict__ offsets,
-    const int *__restrict__ sizes);
-
-__global__ void gpu_hash_kernel(const unsigned char *__restrict__ data,
-                                uint64_t *__restrict__ d_hash,
-                                int size);
+__global__ void jump_scatter_vec_kernel(const int2 *__restrict__ JD,
+                                        const unsigned char *__restrict__ bwt,
+                                        unsigned char *__restrict__ out,
+                                        const int *__restrict__ primary,
+                                        const uint64_t *__restrict__ offsets,
+                                        const int *__restrict__ sizes);


### PR DESCRIPTION
Before (from initial PR):

```
.\lzbench.exe "-i10,10" -egpucompact ..\silesia.tar
lzbench 2.3 | MSVC 1944 | 64-bit Windows | 

Compressor name         Compress. Decompress. Compr. size  Ratio Filename
gpucompact 1.0 -1         308 MB/s  1026 MB/s    70972388  33.49 silesia.tar
gpucompact 1.0 -2         286 MB/s   942 MB/s    65883868  31.08 silesia.tar
gpucompact 1.0 -3         285 MB/s   944 MB/s    64143548  30.26 silesia.tar
gpucompact 1.0 -4         203 MB/s   602 MB/s    59837932  28.23 silesia.tar
gpucompact 1.0 -5         124 MB/s   322 MB/s    58040212  27.38 silesia.tar
[Params] cIters=10 dIters=10 cTime=1.0 dTime=2.0 chunkSize=0KB cSpeed=0MB
```
After:

```
.\lzbench.exe "-i10,10" -egpucompact ..\silesia.tar
lzbench 2.3.1 | MSVC 1944 | 64-bit Windows |

Compressor name         Compress. Decompress. Compr. size  Ratio Filename
gpucompact 1.1 -1         416 MB/s  1492 MB/s    70971980  33.49 silesia.tar
gpucompact 1.1 -2         371 MB/s  1315 MB/s    65883460  31.08 silesia.tar
gpucompact 1.1 -3         369 MB/s  1308 MB/s    64143140  30.26 silesia.tar
gpucompact 1.1 -4         232 MB/s   727 MB/s    59837524  28.23 silesia.tar
gpucompact 1.1 -5         133 MB/s   345 MB/s    58040004  27.38 silesia.tar
[Params] cIters=10 dIters=10 cTime=1.0 dTime=2.0 chunkSize=0KB cSpeed=0MB
```

Tested on an RTX 4090 on Windows 11.