### PR TITLE
Update zxc to v0.14.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,7 @@ v2.x.y (work-in-progress)
 - updated aceapex to 1.0.1 (thanks to @yasha1971-coder)
 - updated lzav to 5.16 (thanks to @avaneev)
 - updated nvcomp to support CUDA 13 and cccl 3 (thanks to @fwyzard)
-- updated zxc to 0.13.3 (thanks to @hellobertrand)
+- updated zxc to 0.14.0 (thanks to @hellobertrand)
 
 v2.3 (Jun 15, 2026)
 - improvement: Reorganized compressor alias groups by type — ALL is now a composite of LZ /

--- a/bench/lzbench.h
+++ b/bench/lzbench.h
@@ -279,7 +279,7 @@ static const compressor_desc_t comp_desc[] =
     { "zstd24LDM",  "zstd 1.5.7 --long -d24", 16,  22,   24, FULL_THREADING, lzbench_zstd_LDM_compress,   lzbench_zstd_decompress,       lzbench_zstd_LDM_init,   lzbench_zstd_deinit },
     { "zstdLDM",    "zstd 1.5.7 --long",       1,  22,    0, FULL_THREADING, lzbench_zstd_LDM_compress,   lzbench_zstd_decompress,       lzbench_zstd_LDM_init,   lzbench_zstd_deinit },
     { "zstd_fast",  "zstd 1.5.7 --fast",      -5,  -1,    0, FULL_THREADING, lzbench_zstd_compress,       lzbench_zstd_decompress,       lzbench_zstd_init,       lzbench_zstd_deinit },
-    { "zxc",        "zxc 0.13.2",              1,   7,    0, BENCH_POOL_MT,  lzbench_zxc_compress,        lzbench_zxc_decompress,        lzbench_zxc_init,        lzbench_zxc_deinit },
+    { "zxc",        "zxc 0.14.0",              1,   7,    0, BENCH_POOL_MT,  lzbench_zxc_compress,        lzbench_zxc_decompress,        lzbench_zxc_init,        lzbench_zxc_deinit },
 };
 
 const long int LZBENCH_COMPRESSOR_COUNT = sizeof(comp_desc)/sizeof(comp_desc[0]);

--- a/lz/zxc/include/zxc_buffer.h
+++ b/lz/zxc/include/zxc_buffer.h
@@ -108,8 +108,6 @@ ZXC_EXPORT uint64_t zxc_compress_bound(const size_t input_size);
  * @param[out] dst          Destination buffer.
  * @param[in]  dst_capacity Capacity of @p dst.
  * @param[in]  opts         Compression options, or NULL for defaults.
- *                           @c n_threads and the progress callback are ignored
- *                          (this call is single-threaded and blocking).
  *
  * @note @p src and @p dst must not overlap (same contract as memcpy).
  * @note Levels above @ref ZXC_LEVEL_ULTRA are silently clamped to it;
@@ -133,8 +131,6 @@ ZXC_EXPORT int64_t zxc_compress(const void* src, const size_t src_size, void* ds
  * @param[out] dst          Destination buffer.
  * @param[in]  dst_capacity Capacity of @p dst.
  * @param[in]  opts         Decompression options, or NULL for defaults.
- *                          @c n_threads and the progress callback are ignored
- *                         (this call is single-threaded and blocking).
  *
  * @note @p src and @p dst must not overlap (same contract as memcpy).
  *
@@ -456,6 +452,9 @@ ZXC_EXPORT int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* src, size_t src
 
 /**
  * @brief Creates a reusable decompression context.
+ *
+ * Only the handle is allocated here: the working buffers are sized from the
+ * archive header, so they come on the first decode. Free with zxc_free_dctx().
  *
  * @return New context, or @c NULL on allocation failure.
  */

--- a/lz/zxc/include/zxc_constants.h
+++ b/lz/zxc/include/zxc_constants.h
@@ -25,9 +25,9 @@
 /** @brief Major version number. */
 #define ZXC_VERSION_MAJOR 0
 /** @brief Minor version number. */
-#define ZXC_VERSION_MINOR 13
+#define ZXC_VERSION_MINOR 14
 /** @brief Patch version number. */
-#define ZXC_VERSION_PATCH 3
+#define ZXC_VERSION_PATCH 0
 
 /** @cond INTERNAL */
 #define ZXC_STR_HELPER(x) #x
@@ -35,7 +35,7 @@
 /** @endcond */
 
 /**
- * @brief Human-readable version string in "MAJOR.MINOR.PATCH" form (e.g. "0.13.3").
+ * @brief Human-readable version string in "MAJOR.MINOR.PATCH" form (e.g. "0.14.0").
  */
 #define ZXC_LIB_VERSION_STR    \
     ZXC_STR(ZXC_VERSION_MAJOR) \
@@ -99,7 +99,8 @@
  *
  * @{
  */
-/** @brief File header size: Magic(4) + Version(1) + Chunk(1) + Flags(1) + Reserved(7) + CRC(2). */
+/** @brief File header size: Magic(4) + Version(1) + Chunk(1) + Flags(1) + Reserved(7) +
+ * Checksum(2). */
 #define ZXC_FILE_HEADER_SIZE 16
 /** @brief File footer size: original_size(8) + global_checksum(4). */
 #define ZXC_FILE_FOOTER_SIZE 12

--- a/lz/zxc/include/zxc_dict.h
+++ b/lz/zxc/include/zxc_dict.h
@@ -156,6 +156,10 @@ ZXC_EXPORT int64_t zxc_train_dict(const void* const* samples, const size_t* samp
  * shared table drop their own 128-byte table header, which is decisive at
  * small block sizes.
  *
+ * Used at levels 6 and 7 only. Pass the same table to decompress: dict_id
+ * covers content and table, so the content alone is a
+ * @ref ZXC_ERROR_DICT_MISMATCH.
+ *
  * @param[in]  samples         Array of pointers to sample buffers (typically
  *                             the same corpus used for zxc_train_dict()).
  * @param[in]  sample_sizes    Array of sample sizes in bytes.

--- a/lz/zxc/include/zxc_error.h
+++ b/lz/zxc/include/zxc_error.h
@@ -25,7 +25,6 @@ extern "C" {
 
 /**
  * @defgroup error Error Handling
- * @brief Error codes returned by ZXC library functions.
  * @{
  */
 
@@ -48,7 +47,7 @@ typedef enum {
     /* Format/header errors */
     ZXC_ERROR_BAD_MAGIC = -4,    /**< Invalid magic word in file header. */
     ZXC_ERROR_BAD_VERSION = -5,  /**< Unsupported file format version. */
-    ZXC_ERROR_BAD_HEADER = -6,   /**< Corrupted or invalid header (CRC mismatch). */
+    ZXC_ERROR_BAD_HEADER = -6,   /**< Corrupted or invalid header (checksum mismatch). */
     ZXC_ERROR_BAD_CHECKSUM = -7, /**< Block or global checksum verification failed. */
 
     /* Data integrity errors */

--- a/lz/zxc/include/zxc_opts.h
+++ b/lz/zxc/include/zxc_opts.h
@@ -67,6 +67,7 @@ typedef struct {
     const void* dict_huf; /**< Optional shared literal Huffman table: the 128-byte packed
                                code-lengths header from zxc_train_dict_huf() /
                                zxc_dict_huf() (NULL = none, ignored without dict).
+                               Used at levels 6-7 only.
                                Becomes part of the archive's dict_id binding. */
     zxc_progress_callback_t progress_cb; /**< Optional progress callback (NULL to disable). */
     void* user_data;                     /**< User context pointer passed to progress_cb. */
@@ -87,9 +88,9 @@ typedef struct {
     int checksum_enabled; /**< 1 to verify per-block and global checksums, 0 to skip. */
     const void* dict;     /**< Pre-trained dictionary content (NULL = none). */
     size_t dict_size;     /**< Dictionary size in bytes (0 = none). */
-    const void* dict_huf; /**< Optional shared literal Huffman table: the 128-byte packed
-                               code-lengths header used at compression time
-                               (NULL = none, ignored without dict). */
+    const void* dict_huf; /**< Shared literal Huffman table: the same 128-byte header
+                               used at compression time. Required if the archive has
+                               one, else ZXC_ERROR_DICT_MISMATCH. Ignored without dict. */
     zxc_progress_callback_t progress_cb; /**< Optional progress callback (NULL to disable). */
     void* user_data;                     /**< User context pointer passed to progress_cb. */
 } zxc_decompress_opts_t;

--- a/lz/zxc/include/zxc_seekable.h
+++ b/lz/zxc/include/zxc_seekable.h
@@ -237,7 +237,8 @@ ZXC_EXPORT void zxc_seekable_free(zxc_seekable* s);
  * @param[in] dict_huf  Shared literal Huffman table (128 bytes, see
  *                      zxc_dict_huf()), or NULL if the archive was compressed
  *                      without one. Must be the compression-time table: the
- *                      archive's dict_id binds the (dict, table) pair.
+ *                      archive's dict_id binds the (dict, table) pair. Wrong or
+ *                      missing: @ref ZXC_ERROR_DICT_MISMATCH, on this call.
  * @return @ref ZXC_OK on success, or a negative @ref zxc_error_t code.
  */
 ZXC_EXPORT int zxc_seekable_set_dict(zxc_seekable* s, const void* dict, size_t dict_size,

--- a/lz/zxc/src/lib/zxc_common.c
+++ b/lz/zxc/src/lib/zxc_common.c
@@ -18,20 +18,14 @@
 #include "../../include/zxc_error.h"
 #include "zxc_internal.h"
 
-/*
- * ============================================================================
- * CONTEXT MANAGEMENT
- * ============================================================================
- */
+// ============================================================================
+// CONTEXT MANAGEMENT
+// ============================================================================
 
 /**
  * @brief Allocates memory aligned to the specified boundary.
  *
  * Uses `_aligned_malloc` on Windows and `posix_memalign` elsewhere.
- *
- * @param[in] size      Number of bytes to allocate.
- * @param[in] alignment Required alignment (must be a power of two).
- * @return Pointer to the allocated block, or @c NULL on failure.
  */
 void* zxc_aligned_malloc(const size_t size, const size_t alignment) {
 #if defined(_WIN32)
@@ -45,8 +39,6 @@ void* zxc_aligned_malloc(const size_t size, const size_t alignment) {
 
 /**
  * @brief Frees memory previously allocated by zxc_aligned_malloc().
- *
- * @param[in] ptr Pointer returned by zxc_aligned_malloc() (may be @c NULL).
  */
 void zxc_aligned_free(void* ptr) {
 #if defined(_WIN32)
@@ -76,39 +68,62 @@ size_t zxc_compress_opts_size(void) { return sizeof(zxc_compress_opts_t); }
  */
 size_t zxc_decompress_opts_size(void) { return sizeof(zxc_decompress_opts_t); }
 
-/* Offset table of the persistent buffer carved by every cctx/dctx init. Both
- * modes compute it identically, for the workspace sizer and the in-place init. */
+// Offset table of the persistent buffer carved by every cctx/dctx init. Both
+// modes compute it identically, for the workspace sizer and the in-place init.
 typedef struct {
     size_t total;
-    /* mode == 0 (decompress) */
+    // mode == 0 (decompress)
     size_t off_work;
     size_t off_lit_dctx;
-    /* mode == 0: scratch for a Huffman-coded GLO token section (enc_litlen == HUFFMAN). */
+    // mode == 0: scratch for a Huffman-coded GLO token section (enc_tok == HUFFMAN).
     size_t off_tok_dctx;
     size_t sz_tok_dctx;
-    /* mode == 0: PivCo decode level scratch (one chunk-sized ping-pong buffer). */
+    // mode == 0: PivCo decode level scratch (one chunk-sized ping-pong buffer).
     size_t off_pivco_dctx;
     size_t sz_pivco_dctx;
-    /* mode == 1 (compress) */
+    // mode == 1 (compress)
     size_t off_hash_pos;
     size_t off_hash_tags;
     size_t off_chain;
     size_t off_seq_union;
     size_t off_extras;
     size_t off_lit_cctx;
-    /* meaningful only when sz_opt > 0 (level >= ZXC_LEVEL_DENSITY). */
+    // meaningful only when sz_opt > 0 (level >= ZXC_LEVEL_DENSITY).
     size_t off_opt;
-    /* both modes: [dict | data] concat scratch, present only when dict_size > 0. */
+    // both modes: [dict | data] concat scratch, present only when dict_size > 0.
     size_t off_dict;
-    /* both modes: dict Huffman tree-at-attach state, present only when dict_size > 0. */
+    // both modes: dict Huffman tree-at-attach state, present only when dict_size > 0.
     size_t off_dict_huf;
-    /* Sub-buffer sizes (re-used by the partitioning step + zero-init). */
+    // Sub-buffer sizes (re-used by the partitioning step + zero-init).
     size_t sz_hash_pos;
     size_t sz_hash_tags;
     size_t sz_opt;
     size_t sz_dict; /* 0 = no dictionary buffer. */
     size_t max_seq;
 } zxc_cctx_layout_t;
+
+/**
+ * @brief Worst-case sequence count for one block. Shared by the compressor's
+ *        buffer sizing and the decoder's token scratch: the decode side must
+ *        accept exactly what the compress side can emit, so both derive from
+ *        this single expression.
+ */
+static ZXC_ALWAYS_INLINE size_t zxc_cctx_max_seq(const size_t chunk_size) {
+    return chunk_size / ZXC_LZ_MIN_MATCH_LEN + 16;
+}
+
+/**
+ * @brief Decode-side entropy scratch sizes for one block: token scratch
+ *        (worst-case sequence count + wild-read pad) and PivCo ping-pong
+ *        scratch. Single definition shared by the layout (full provisioning:
+ *        static workspaces) and the lazy heap allocator
+ *        (@ref zxc_cctx_alloc_entropy_scratch), so the two can never drift.
+ */
+static void zxc_dctx_entropy_sizes(const size_t chunk_size, size_t* RESTRICT sz_tok,
+                                   size_t* RESTRICT sz_pivco) {
+    *sz_tok = zxc_cctx_max_seq(chunk_size) + ZXC_PAD_SIZE;
+    *sz_pivco = chunk_size + ZXC_PIVCO_SCRATCH_PAD;
+}
 
 /**
  * @brief Computes the single-allocation memory layout for a compression /
@@ -133,31 +148,11 @@ typedef struct {
  * @param[in] level       Compression level (only consulted when @p mode == 1).
  * @param[in] dict_size   Dictionary prefill size; when > 0 the layout includes
  *                        the [dict | data] concat buffer.
+ * @param[in] defer_entropy_scratch  When non-zero, the decode-side token
+ *                        and PivCo scratch are left out of the layout and
+ *                        allocated lazily on the first entropy section.
  * @return Fully populated layout; @c .total is the required workspace size.
  */
-/**
- * @brief Worst-case sequence count for one block. Shared by the compressor's
- *        buffer sizing and the decoder's token scratch: the decode side must
- *        accept exactly what the compress side can emit, so both derive from
- *        this single expression.
- */
-static ZXC_ALWAYS_INLINE size_t zxc_cctx_max_seq(const size_t chunk_size) {
-    return chunk_size / ZXC_LZ_MIN_MATCH_LEN + 16;
-}
-
-/**
- * @brief Decode-side entropy scratch sizes for one block: token scratch
- *        (worst-case sequence count + wild-read pad) and PivCo ping-pong
- *        scratch. Single definition shared by the layout (full provisioning:
- *        static workspaces) and the lazy heap allocator
- *        (@ref zxc_cctx_alloc_entropy_scratch), so the two can never drift.
- */
-static void zxc_dctx_entropy_sizes(const size_t chunk_size, size_t* RESTRICT sz_tok,
-                                   size_t* RESTRICT sz_pivco) {
-    *sz_tok = zxc_cctx_max_seq(chunk_size) + ZXC_PAD_SIZE;
-    *sz_pivco = chunk_size + ZXC_PIVCO_SCRATCH_PAD;
-}
-
 static zxc_cctx_layout_t compute_cctx_layout(const size_t chunk_size, const int mode,
                                              const int level, const size_t dict_size,
                                              const int defer_entropy_scratch) {
@@ -166,9 +161,9 @@ static zxc_cctx_layout_t compute_cctx_layout(const size_t chunk_size, const int 
     const size_t max_seq = zxc_cctx_max_seq(chunk_size);
 
     if (mode == 0) {
-        /* Decompress: work_buf + lit_buffer, padded for wild-copy overshoot and
-         * sized worst-case. lit_buffer is provisioned at every level - the decoder
-         * cannot predict a block's literal encoding (RAW / RLE / HUFFMAN). */
+        // Decompress: work_buf + lit_buffer, padded for wild-copy overshoot and
+        // sized worst-case. lit_buffer is provisioned at every level - the decoder
+        // cannot predict a block's literal encoding (RAW / RLE / HUFFMAN).
         const size_t sz_work = chunk_size + ZXC_DECOMPRESS_TAIL_PAD;
         const size_t sz_lit = chunk_size + ZXC_PAD_SIZE;
 
@@ -176,11 +171,11 @@ static zxc_cctx_layout_t compute_cctx_layout(const size_t chunk_size, const int 
         layout.total += ZXC_ALIGN_CL(sz_work);
         layout.off_lit_dctx = layout.total;
         layout.total += ZXC_ALIGN_CL(sz_lit);
-        /* Token-section decode scratch (level-7 GLO Huffman-codes the tokens) +
-         * PivCo ping-pong scratch. enc_lit/enc_litlen are unpredictable, so static
-         * workspaces provision both up front (no-alloc contract); heap contexts
-         * defer them to the first entropy section, sparing L1-5 archives ~1.2x
-         * chunk_size. See zxc_cctx_alloc_entropy_scratch. */
+        // Token-section decode scratch (level-7 GLO Huffman-codes the tokens) +
+        // PivCo ping-pong scratch. enc_lit/enc_tok are unpredictable, so static
+        // workspaces provision both up front (no-alloc contract); heap contexts
+        // defer them to the first entropy section, sparing L1-5 archives ~1.2x
+        // chunk_size. See zxc_cctx_alloc_entropy_scratch.
         if (!defer_entropy_scratch) {
             size_t sz_tok = 0;
             size_t sz_pivco = 0;
@@ -193,29 +188,29 @@ static zxc_cctx_layout_t compute_cctx_layout(const size_t chunk_size, const int 
             layout.total += ZXC_ALIGN_CL(layout.sz_pivco_dctx);
         }
     } else {
-        /* Compress: 6 partitions + optional opt_scratch at level >= ZXC_LEVEL_DENSITY. */
+        // Compress: 6 partitions + optional opt_scratch at level >= ZXC_LEVEL_DENSITY.
         const uint32_t offset_bits = zxc_log2_u32((uint32_t)chunk_size);
         layout.max_seq = max_seq;
         layout.sz_hash_pos = ZXC_LZ_HASH_SIZE * sizeof(uint32_t);
         layout.sz_hash_tags = ZXC_LZ_HASH_SIZE * sizeof(uint8_t);
         const size_t sz_chain = ZXC_LZ_WINDOW_SIZE * sizeof(uint16_t);
-        /* buf_sequences (GHI, level <= ZXC_LEVEL_FAST) aliases buf_offsets + buf_tokens (GLO,
-         * level >= ZXC_LEVEL_DEFAULT). Mutually exclusive per block; sized for the larger. */
+        // buf_sequences (GHI, level <= ZXC_LEVEL_FAST) aliases buf_offsets + buf_tokens (GLO,
+        // level >= ZXC_LEVEL_DEFAULT). Mutually exclusive per block; sized for the larger.
         const size_t sz_seq_union = layout.max_seq * sizeof(uint32_t);
         const size_t vbyte_len = (offset_bits + 6) / 7;
         const size_t sz_extras = layout.max_seq * 2 * vbyte_len;
         const size_t sz_lit = chunk_size + ZXC_PAD_SIZE;
 
-        /* opt_scratch (level >= ZXC_LEVEL_DENSITY): the optimal parser's DP arrays,
-         * reused transiently as package-merge scratch by the code-length builder,
-         * so sized to the larger demand. Keep in sync with zxc_estimate_cctx_size()
-         * and its consumer in zxc_compress.c. */
+        // opt_scratch (level >= ZXC_LEVEL_DENSITY): the optimal parser's DP arrays,
+        // reused transiently as package-merge scratch by the code-length builder,
+        // so sized to the larger demand. Keep in sync with zxc_estimate_cctx_size()
+        // and its consumer in zxc_compress.c.
         if (level >= ZXC_LEVEL_DENSITY) {
-            const size_t sz_dp = ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint32_t));
-            const size_t sz_pl = ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint16_t));
-            const size_t sz_po = ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint16_t));
-            const size_t n_bm_words = ZXC_BITMAP_WORDS(chunk_size + 1);
-            const size_t sz_bm = ZXC_ALIGN_CL(n_bm_words * sizeof(uint64_t));
+            size_t sz_dp;
+            size_t sz_pl;
+            size_t sz_po;
+            size_t sz_bm;
+            zxc_opt_dp_sizes(chunk_size, &sz_dp, &sz_pl, &sz_po, &sz_bm);
             const size_t dp_needed = sz_dp + sz_pl + sz_po + sz_bm;
             layout.sz_opt =
                 (dp_needed > ZXC_HUF_BUILD_SCRATCH_SIZE) ? dp_needed : ZXC_HUF_BUILD_SCRATCH_SIZE;
@@ -233,16 +228,16 @@ static zxc_cctx_layout_t compute_cctx_layout(const size_t chunk_size, const int 
         layout.total += ZXC_ALIGN_CL(sz_extras);
         layout.off_lit_cctx = layout.total;
         layout.total += ZXC_ALIGN_CL(sz_lit);
-        /* opt_scratch is appended last so it is absent for levels 1..5 (zero
-         * waste on the common path) and only inflates the workspace at level 6. */
+        // opt_scratch is appended last so it is absent for levels 1..5 (zero
+        // waste on the common path) and only inflates the workspace at level 6.
         if (layout.sz_opt) {
             layout.off_opt = layout.total;
             layout.total += ZXC_ALIGN_CL(layout.sz_opt);
         }
     }
 
-    /* [dict | data] concat scratch (dict only). Compress chunk_size already
-     * spans [dict | block]; decompress prepends dict to a (chunk + PAD) region. */
+    // [dict | data] concat scratch (dict only). Compress chunk_size already
+    // spans [dict | block]; decompress prepends dict to a (chunk + PAD) region.
     if (dict_size > 0) {
         layout.sz_dict = (mode == 1) ? (chunk_size + ZXC_DECOMPRESS_TAIL_PAD)
                                      : (dict_size + chunk_size + ZXC_DECOMPRESS_TAIL_PAD);
@@ -260,12 +255,6 @@ static zxc_cctx_layout_t compute_cctx_layout(const size_t chunk_size, const int 
  * Public contract documented at the declaration in @c zxc_internal.h. Thin
  * wrapper that returns @c compute_cctx_layout(...).total, or 0 when
  * @p chunk_size is 0.
- *
- * @param[in] chunk_size  Block size in bytes.
- * @param[in] mode        1 = compression, 0 = decompression.
- * @param[in] level       Compression level (only consulted when @p mode == 1).
- * @param[in] dict_size   Dictionary prefill size; > 0 includes the concat buffer.
- * @return Workspace size in bytes, or 0 if @p chunk_size is 0.
  */
 size_t zxc_cctx_compute_workspace_size(const size_t chunk_size, const int mode, const int level,
                                        const size_t dict_size) {
@@ -281,16 +270,6 @@ size_t zxc_cctx_compute_workspace_size(const size_t chunk_size, const int mode, 
  * @ref compute_cctx_layout, rejects an undersized @p workspace, then carves the
  * sub-buffers out of it. @c ctx->memory_block stays NULL so @ref zxc_cctx_free
  * leaves the caller-owned workspace untouched.
- *
- * @param[out] ctx               Context to initialise.
- * @param[in]  workspace         Caller-allocated, cache-line-aligned buffer.
- * @param[in]  workspace_size    Capacity of @p workspace in bytes.
- * @param[in]  chunk_size        Block size in bytes.
- * @param[in]  mode              1 = compression, 0 = decompression.
- * @param[in]  level             Compression level (ignored when @p mode == 0).
- * @param[in]  checksum_enabled  Non-zero to enable checksum computation.
- * @param[in]  dict_size         Dictionary prefill size; > 0 carves the concat buffer.
- * @return @ref ZXC_OK, @ref ZXC_ERROR_NULL_INPUT, or @ref ZXC_ERROR_DST_TOO_SMALL.
  */
 int zxc_cctx_init_in_workspace(zxc_cctx_t* RESTRICT ctx, void* RESTRICT workspace,
                                const size_t workspace_size, const size_t chunk_size, const int mode,
@@ -310,13 +289,13 @@ int zxc_cctx_init_in_workspace(zxc_cctx_t* RESTRICT ctx, void* RESTRICT workspac
     ctx->offset_mask = (uint32_t)((1ULL << offset_bits) - 1);
     ctx->max_epoch = (uint32_t)(1ULL << (32 - offset_bits));
 
-    /* memory_block stays NULL on the static-init path so zxc_cctx_free does
-     * not try to free the caller's workspace.  Sub-buffer pointers carry the
-     * partition; ownership is implicit (the caller owns @p workspace). */
+    // memory_block stays NULL on the static-init path so zxc_cctx_free does
+    // not try to free the caller's workspace.  Sub-buffer pointers carry the
+    // partition; ownership is implicit (the caller owns @p workspace).
     uint8_t* const mem = (uint8_t*)workspace;
 
-    /* Dictionary concat scratch (both modes); init owns dict_size now so callers
-     * no longer assign ctx->dict_size after init. */
+    // Dictionary concat scratch (both modes); init owns dict_size now so callers
+    // no longer assign ctx->dict_size after init.
     ctx->dict_size = dict_size;
     if (dict_size > 0) {
         ctx->dict_buffer = mem + layout.off_dict;
@@ -363,25 +342,17 @@ int zxc_cctx_init_in_workspace(zxc_cctx_t* RESTRICT ctx, void* RESTRICT workspac
  * @brief Initialises a compression / decompression context, allocating the
  *        persistent buffer with @c ZXC_ALIGNED_MALLOC.
  *
- * Thin wrapper around @ref zxc_cctx_init_in_workspace: sizes the buffer via
+ * Thin wrapper around zxc_cctx_init_in_workspace(): sizes the buffer via
  * @ref zxc_cctx_compute_workspace_size, allocates it, then partitions it.
  * The pointer is stored in @c ctx->memory_block so @ref zxc_cctx_free can
  * release it.  The static-cctx public API (see @c zxc_buffer.h) bypasses
  * this wrapper and partitions a caller-supplied workspace directly.
- *
- * @param[out] ctx               Context to initialise.
- * @param[in]  chunk_size        Block size in bytes.
- * @param[in]  mode              1 = compression, 0 = decompression.
- * @param[in]  level             Compression level (ignored when @p mode == 0).
- * @param[in]  checksum_enabled  Non-zero to enable checksum computation.
- * @param[in]  dict_size         Dictionary prefill size.
- * @return @ref ZXC_OK on success, @ref ZXC_ERROR_MEMORY on allocation failure.
  */
 int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int mode,
                   const int level, const int checksum_enabled, const size_t dict_size) {
     if (UNLIKELY(chunk_size == 0)) return ZXC_ERROR_NULL_INPUT;
-    /* Heap contexts defer the decode-side entropy scratch to the first entropy
-     * section; static workspaces must have it already, they may never allocate. */
+    // Heap contexts defer the decode-side entropy scratch to the first entropy
+    // section; static workspaces must have it already, they may never allocate.
     const int defer_entropy = (mode == 0);
     const size_t total =
         compute_cctx_layout(chunk_size, mode, level, dict_size, defer_entropy).total;
@@ -398,7 +369,7 @@ int zxc_cctx_init(zxc_cctx_t* RESTRICT ctx, const size_t chunk_size, const int m
         return rc;
         // LCOV_EXCL_STOP
     }
-    /* Library-owned buffer: record the allocation so zxc_cctx_free frees it. */
+    // Library-owned buffer: record the allocation so zxc_cctx_free frees it.
     ctx->memory_block = mem;
     return ZXC_OK;
 }
@@ -435,8 +406,6 @@ int zxc_cctx_alloc_entropy_scratch(zxc_cctx_t* ctx) {
  *
  * After this call every pointer inside @p ctx is @c NULL and the context
  * may be safely re-initialised with zxc_cctx_init().
- *
- * @param[in,out] ctx Context to tear down.
  */
 void zxc_cctx_free(zxc_cctx_t* ctx) {
     if (ctx->memory_block) {
@@ -494,7 +463,7 @@ int zxc_cctx_attach_dict_huf(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT l
     ctx->dict_huf_tree_ok = 0;
     if (lengths == NULL) return ZXC_OK;
 
-    /* Empty (all-zero) table from a low-entropy corpus: treat it as "no shared table". */
+    // Empty (all-zero) table from a low-entropy corpus: treat it as "no shared table".
     int empty = 1;
     for (size_t i = 0; i < ZXC_HUF_TABLE_SIZE; i++) {
         if (lengths[i]) {
@@ -504,9 +473,9 @@ int zxc_cctx_attach_dict_huf(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT l
     }
     if (UNLIKELY(empty || ctx->dict_huf == NULL)) return ZXC_OK;
 
-    /* Tree-at-attach: unpack + build the PivCo tree, codes and decoder tables
-     * once here; the per-block encode/estimate/decode paths reuse them via
-     * the context. */
+    // Tree-at-attach: unpack + build the PivCo tree, codes and decoder tables
+    // once here; the per-block encode/estimate/decode paths reuse them via
+    // the context.
     const int rc = zxc_huf_dict_tree_build(lengths, &ctx->dict_huf->tree, ctx->dict_huf->codes,
                                            ctx->dict_huf->code_len, &ctx->dict_huf->dec);
     if (UNLIKELY(rc != ZXC_OK)) return rc;
@@ -514,26 +483,15 @@ int zxc_cctx_attach_dict_huf(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT l
     return ZXC_OK;
 }
 
-/*
- * ============================================================================
- * HEADER I/O
- * ============================================================================
- */
+// ============================================================================
+// HEADER I/O
+// ============================================================================
 
 /**
  * @brief Serialises a ZXC file header into @p dst.
  *
  * Layout (16 bytes): Magic (4) | Version (1) | Chunk (1) | Flags (1) |
- * Reserved (7) | CRC-16 (2).
- *
- * @param[out] dst          Destination buffer (>= @ref ZXC_FILE_HEADER_SIZE bytes).
- * @param[in]  dst_capacity Capacity of @p dst.
- * @param[in]  chunk_size   Block size (stored as its log2 exponent).
- * @param[in]  has_checksum Non-zero to set the checksum flag.
- * @param[in]  dict_id      Dictionary id; when non-zero, sets the dictionary flag
- *                          and is stored in the header.
- * @return Number of bytes written (@ref ZXC_FILE_HEADER_SIZE) on success,
- *         or a negative @ref zxc_error_t code.
+ * Reserved (7) | Checksum-16 (2).
  */
 int zxc_write_file_header(uint8_t* RESTRICT dst, const size_t dst_capacity, const size_t chunk_size,
                           const int has_checksum, const uint32_t dict_id) {
@@ -553,10 +511,10 @@ int zxc_write_file_header(uint8_t* RESTRICT dst, const size_t dst_capacity, cons
     ZXC_MEMSET(dst + 7, 0, 7);
     if (dict_id != 0) zxc_store_le32(dst + 7, dict_id);
 
-    // Bytes 14-15: CRC (16-bit)
+    // Bytes 14-15: checksum (16-bit)
     zxc_store_le16(dst + 14, 0);  // Zero out before hashing
-    const uint16_t crc = zxc_hash16(dst);
-    zxc_store_le16(dst + 14, crc);
+    const uint16_t sum = zxc_hash16(dst);
+    zxc_store_le16(dst + 14, sum);
 
     return ZXC_FILE_HEADER_SIZE;
 }
@@ -564,16 +522,7 @@ int zxc_write_file_header(uint8_t* RESTRICT dst, const size_t dst_capacity, cons
 /**
  * @brief Parses and validates a ZXC file header from @p src.
  *
- * Checks the magic word, format version, and CRC-16.
- *
- * @param[in]  src              Source buffer (>= @ref ZXC_FILE_HEADER_SIZE bytes).
- * @param[in]  src_size         Size of @p src.
- * @param[out] out_block_size   Receives the decoded block size (may be @c NULL).
- * @param[out] out_has_checksum Receives 1 if checksums are present, 0 otherwise
- *                              (may be @c NULL).
- * @param[out] out_dict_id      Receives the dictionary id, or 0 if none
- *                              (may be @c NULL).
- * @return @ref ZXC_OK on success, or a negative @ref zxc_error_t code.
+ * Checks the magic word, format version, and 16-bit checksum.
  */
 int zxc_read_file_header(const uint8_t* RESTRICT src, const size_t src_size,
                          size_t* RESTRICT out_block_size, int* RESTRICT out_has_checksum,
@@ -584,13 +533,13 @@ int zxc_read_file_header(const uint8_t* RESTRICT src, const size_t src_size,
 
     uint8_t temp[ZXC_FILE_HEADER_SIZE];
     ZXC_MEMCPY(temp, src, ZXC_FILE_HEADER_SIZE);
-    // Zero out CRC bytes (14-15) before hash check
+    // Zero out checksum bytes (14-15) before hash check
     temp[14] = 0;
     temp[15] = 0;
-    // Header CRC16 (integrity), then the checksum-algorithm id in flags bits 0-3
-    // (only 0 = RapidHash is defined). CRC is checked first via short-circuit.
+    // Header checksum (integrity), then the checksum-algorithm id in flags bits 0-3
+    // (only 0 = RapidHash is defined). It is checked first via short-circuit.
     if (UNLIKELY(zxc_le16(src + 14) != zxc_hash16(temp) ||
-                 (src[6] & 0x0FU) != ZXC_CHECKSUM_RAPIDHASH))
+                 (src[6] & ZXC_FILE_CHECKSUM_ALGO_MASK) != ZXC_CHECKSUM_RAPIDHASH))
         return ZXC_ERROR_BAD_HEADER;
 
     if (out_block_size) {
@@ -608,12 +557,6 @@ int zxc_read_file_header(const uint8_t* RESTRICT src, const size_t src_size,
 
 /**
  * @brief Serialises a block header (8 bytes) into @p dst.
- *
- * @param[out] dst          Destination buffer (>= @ref ZXC_BLOCK_HEADER_SIZE bytes).
- * @param[in]  dst_capacity Capacity of @p dst.
- * @param[in]  bh           Populated block header descriptor.
- * @return Number of bytes written (@ref ZXC_BLOCK_HEADER_SIZE) on success,
- *         or a negative @ref zxc_error_t code.
  */
 int zxc_write_block_header(uint8_t* RESTRICT dst, const size_t dst_capacity,
                            const zxc_block_header_t* RESTRICT bh) {
@@ -632,12 +575,7 @@ int zxc_write_block_header(uint8_t* RESTRICT dst, const size_t dst_capacity,
 /**
  * @brief Parses and validates a block header from @p src.
  *
- * Validates the 8-bit CRC embedded in the header.
- *
- * @param[in]  src      Source buffer (>= @ref ZXC_BLOCK_HEADER_SIZE bytes).
- * @param[in]  src_size Size of @p src.
- * @param[out] bh       Receives the decoded block header fields.
- * @return @ref ZXC_OK on success, or a negative @ref zxc_error_t code.
+ * Validates the 8-bit checksum embedded in the header.
  */
 int zxc_read_block_header(const uint8_t* RESTRICT src, const size_t src_size,
                           zxc_block_header_t* RESTRICT bh) {
@@ -652,21 +590,13 @@ int zxc_read_block_header(const uint8_t* RESTRICT src, const size_t src_size,
     bh->block_flags = 0;  // Flags not used currently
     bh->reserved = src[2];
     bh->comp_size = zxc_le32(src + 3);
-    bh->header_crc = src[7];
+    bh->header_checksum = src[7];
 
     return ZXC_OK;
 }
 
 /**
  * @brief Writes the 12-byte file footer (source size + global checksum).
- *
- * @param[out] dst              Destination buffer (>= @ref ZXC_FILE_FOOTER_SIZE bytes).
- * @param[in]  dst_capacity     Capacity of @p dst.
- * @param[in]  src_size         Original uncompressed size in bytes.
- * @param[in]  global_hash      Accumulated global checksum value.
- * @param[in]  checksum_enabled Non-zero to write the checksum; zero to zero-fill.
- * @return Number of bytes written (@ref ZXC_FILE_FOOTER_SIZE) on success,
- *         or a negative @ref zxc_error_t code.
  */
 int zxc_write_file_footer(uint8_t* RESTRICT dst, const size_t dst_capacity, const uint64_t src_size,
                           const uint32_t global_hash, const int checksum_enabled) {
@@ -684,36 +614,74 @@ int zxc_write_file_footer(uint8_t* RESTRICT dst, const size_t dst_capacity, cons
 }
 
 /**
- * @brief Serialises a GLO block header followed by its section descriptors.
+ * @brief Writes the 12-byte GLO/GHI sub-header shared by both block types.
  *
- * @param[out] dst  Destination buffer.
- * @param[in]  rem  Remaining capacity of @p dst.
- * @param[in]  gh   Populated GLO header descriptor.
- * @param[in]  desc Array of @ref ZXC_GLO_SECTIONS section descriptors.
- * @return Total bytes written on success, or a negative @ref zxc_error_t code.
+ * @param[out] dst Destination buffer, at least 12 bytes.
+ * @param[in]  gh  Populated header descriptor.
  */
-int zxc_write_glo_header_and_desc(uint8_t* RESTRICT dst, const size_t rem,
-                                  const zxc_gnr_header_t* RESTRICT gh,
-                                  const zxc_section_desc_t desc[ZXC_GLO_SECTIONS]) {
-    const size_t needed =
-        ZXC_GLO_HEADER_BINARY_SIZE + ZXC_GLO_SECTIONS * ZXC_SECTION_DESC_BINARY_SIZE;
-
-    if (UNLIKELY(rem < needed)) return ZXC_ERROR_DST_TOO_SMALL;
-
+static ZXC_ALWAYS_INLINE void zxc_write_gnr_header(uint8_t* RESTRICT dst,
+                                                   const zxc_gnr_header_t* RESTRICT gh) {
     zxc_store_le32(dst, gh->n_sequences);
     zxc_store_le32(dst + 4, gh->n_literals);
 
     dst[8] = gh->enc_lit;
-    dst[9] = gh->enc_litlen;
+    dst[9] = gh->enc_tok;
     dst[10] = gh->enc_mlen;
     dst[11] = gh->enc_off;
+}
 
-    zxc_store_le32(dst + 12, 0);
+/**
+ * @brief Reads the 12-byte GLO/GHI sub-header shared by both block types.
+ *
+ * @param[in]  src Source buffer, at least 12 bytes.
+ * @param[out] gh  Receives the decoded header.
+ */
+static ZXC_ALWAYS_INLINE void zxc_read_gnr_header(const uint8_t* RESTRICT src,
+                                                  zxc_gnr_header_t* RESTRICT gh) {
+    gh->n_sequences = zxc_le32(src);
+    gh->n_literals = zxc_le32(src + 4);
+    gh->enc_lit = src[8];
+    gh->enc_tok = src[9];
+    gh->enc_mlen = src[10];
+    gh->enc_off = src[11];
+}
+
+/**
+ * @brief Size of the GLO section descriptors, implied by the encoding fields.
+ *
+ * 0, 4 or 8 bytes - see @ref zxc_write_glo_header_and_desc for what they hold.
+ */
+static ZXC_ALWAYS_INLINE size_t zxc_glo_desc_size(const uint8_t enc_lit, const uint8_t enc_tok) {
+    return ((enc_lit != ZXC_SECTION_ENCODING_RAW) ? sizeof(uint32_t) : 0) +
+           ((enc_tok == ZXC_SECTION_ENCODING_HUFFMAN) ? sizeof(uint32_t) : 0);
+}
+
+/**
+ * @brief Serialises a GLO block header followed by its section descriptors.
+ *
+ * Only the two sizes the header cannot imply are stored: the literal section's
+ * compressed size when it is RLE- or entropy-coded, and the token section's
+ * when level 7 Huffman-codes it. The decoder derives the rest - literals raw
+ * size from @c n_literals, offsets from @c n_sequences and @c enc_off, extras
+ * from the payload residue - so those cannot be forged inconsistently.
+ */
+int zxc_write_glo_header_and_desc(uint8_t* RESTRICT dst, const size_t rem,
+                                  const zxc_gnr_header_t* RESTRICT gh, const uint32_t lit_comp,
+                                  const uint32_t tok_comp) {
+    const size_t desc_sz = zxc_glo_desc_size(gh->enc_lit, gh->enc_tok);
+    const size_t needed = ZXC_GLO_HEADER_BINARY_SIZE + desc_sz;
+
+    if (UNLIKELY(rem < needed)) return ZXC_ERROR_DST_TOO_SMALL;
+
+    zxc_write_gnr_header(dst, gh);
     uint8_t* p = dst + ZXC_GLO_HEADER_BINARY_SIZE;
 
-    for (int i = 0; i < ZXC_GLO_SECTIONS; i++) {
-        zxc_store_le64(p, desc[i].sizes);
-        p += ZXC_SECTION_DESC_BINARY_SIZE;
+    if (gh->enc_lit != ZXC_SECTION_ENCODING_RAW) {
+        zxc_store_le32(p, lit_comp);
+        p += sizeof(uint32_t);
+    }
+    if (gh->enc_tok == ZXC_SECTION_ENCODING_HUFFMAN) {
+        zxc_store_le32(p, tok_comp);
     }
 
     return (int)needed;
@@ -721,111 +689,61 @@ int zxc_write_glo_header_and_desc(uint8_t* RESTRICT dst, const size_t rem,
 
 /**
  * @brief Parses a GLO block header and its section descriptors from @p src.
- *
- * @param[in]  src  Source buffer.
- * @param[in]  len  Size of @p src.
- * @param[out] gh   Receives the decoded GLO header.
- * @param[out] desc Receives @ref ZXC_GLO_SECTIONS decoded section descriptors.
- * @return @ref ZXC_OK on success, or a negative @ref zxc_error_t code.
  */
 int zxc_read_glo_header_and_desc(const uint8_t* RESTRICT src, const size_t len,
-                                 zxc_gnr_header_t* RESTRICT gh,
-                                 zxc_section_desc_t desc[ZXC_GLO_SECTIONS]) {
-    const size_t needed =
-        ZXC_GLO_HEADER_BINARY_SIZE + ZXC_GLO_SECTIONS * ZXC_SECTION_DESC_BINARY_SIZE;
+                                 zxc_gnr_header_t* RESTRICT gh, uint32_t* RESTRICT lit_comp,
+                                 uint32_t* RESTRICT tok_comp) {
+    if (UNLIKELY(len < ZXC_GLO_HEADER_BINARY_SIZE)) return ZXC_ERROR_SRC_TOO_SMALL;
 
+    zxc_read_gnr_header(src, gh);
+
+    const size_t desc_sz = zxc_glo_desc_size(gh->enc_lit, gh->enc_tok);
+    const size_t needed = ZXC_GLO_HEADER_BINARY_SIZE + desc_sz;
     if (UNLIKELY(len < needed)) return ZXC_ERROR_SRC_TOO_SMALL;
-
-    gh->n_sequences = zxc_le32(src);
-    gh->n_literals = zxc_le32(src + 4);
-    gh->enc_lit = src[8];
-    gh->enc_litlen = src[9];
-    gh->enc_mlen = src[10];
-    gh->enc_off = src[11];
 
     const uint8_t* p = src + ZXC_GLO_HEADER_BINARY_SIZE;
 
-    for (int i = 0; i < ZXC_GLO_SECTIONS; i++) {
-        desc[i].sizes = zxc_le64(p);
-        p += ZXC_SECTION_DESC_BINARY_SIZE;
+    if (gh->enc_lit != ZXC_SECTION_ENCODING_RAW) {
+        *lit_comp = zxc_le32(p);
+        p += sizeof(uint32_t);
+    } else {
+        *lit_comp = gh->n_literals;
     }
-    return ZXC_OK;
-}
-
-/**
- * @brief Serialises a GHI block header followed by its section descriptors.
- *
- * @param[out] dst  Destination buffer.
- * @param[in]  rem  Remaining capacity of @p dst.
- * @param[in]  gh   Populated GHI header descriptor.
- * @param[in]  desc Array of @ref ZXC_GHI_SECTIONS section descriptors.
- * @return Total bytes written on success, or a negative @ref zxc_error_t code.
- */
-int zxc_write_ghi_header_and_desc(uint8_t* RESTRICT dst, const size_t rem,
-                                  const zxc_gnr_header_t* RESTRICT gh,
-                                  const zxc_section_desc_t desc[ZXC_GHI_SECTIONS]) {
-    const size_t needed =
-        ZXC_GHI_HEADER_BINARY_SIZE + ZXC_GHI_SECTIONS * ZXC_SECTION_DESC_BINARY_SIZE;
-
-    if (UNLIKELY(rem < needed)) return ZXC_ERROR_DST_TOO_SMALL;
-
-    zxc_store_le32(dst, gh->n_sequences);
-    zxc_store_le32(dst + 4, gh->n_literals);
-
-    dst[8] = gh->enc_lit;
-    dst[9] = gh->enc_litlen;
-    dst[10] = gh->enc_mlen;
-    dst[11] = gh->enc_off;
-
-    zxc_store_le32(dst + 12, 0);
-    uint8_t* p = dst + ZXC_GHI_HEADER_BINARY_SIZE;
-
-    for (int i = 0; i < ZXC_GHI_SECTIONS; i++) {
-        zxc_store_le64(p, desc[i].sizes);
-        p += ZXC_SECTION_DESC_BINARY_SIZE;
-    }
+    *tok_comp = (gh->enc_tok == ZXC_SECTION_ENCODING_HUFFMAN) ? zxc_le32(p) : gh->n_sequences;
 
     return (int)needed;
 }
 
 /**
- * @brief Parses a GHI block header and its section descriptors from @p src.
+ * @brief Serialises a GHI block header.
  *
- * @param[in]  src  Source buffer.
- * @param[in]  len  Size of @p src.
- * @param[out] gh   Receives the decoded GHI header.
- * @param[out] desc Receives @ref ZXC_GHI_SECTIONS decoded section descriptors.
- * @return @ref ZXC_OK on success, or a negative @ref zxc_error_t code.
+ * GHI carries no section descriptors at all: its literals are always RAW
+ * (`lit_comp == gh->n_literals`), its sequence stream is
+ * `gh->n_sequences * 4` bytes wide, and its extras run from there to the
+ * payload end.
  */
-int zxc_read_ghi_header_and_desc(const uint8_t* RESTRICT src, const size_t len,
-                                 zxc_gnr_header_t* RESTRICT gh,
-                                 zxc_section_desc_t desc[ZXC_GHI_SECTIONS]) {
-    const size_t needed =
-        ZXC_GHI_HEADER_BINARY_SIZE + ZXC_GHI_SECTIONS * ZXC_SECTION_DESC_BINARY_SIZE;
+int zxc_write_ghi_header(uint8_t* RESTRICT dst, const size_t rem,
+                         const zxc_gnr_header_t* RESTRICT gh) {
+    if (UNLIKELY(rem < ZXC_GHI_HEADER_BINARY_SIZE)) return ZXC_ERROR_DST_TOO_SMALL;
 
-    if (UNLIKELY(len < needed)) return ZXC_ERROR_SRC_TOO_SMALL;
+    zxc_write_gnr_header(dst, gh);
+    return ZXC_GHI_HEADER_BINARY_SIZE;
+}
 
-    gh->n_sequences = zxc_le32(src);
-    gh->n_literals = zxc_le32(src + 4);
-    gh->enc_lit = src[8];
-    gh->enc_litlen = src[9];
-    gh->enc_mlen = src[10];
-    gh->enc_off = src[11];
+/**
+ * @brief Parses a GHI block header from @p src.
+ */
+int zxc_read_ghi_header(const uint8_t* RESTRICT src, const size_t len,
+                        zxc_gnr_header_t* RESTRICT gh) {
+    if (UNLIKELY(len < ZXC_GHI_HEADER_BINARY_SIZE)) return ZXC_ERROR_SRC_TOO_SMALL;
 
-    const uint8_t* p = src + ZXC_GHI_HEADER_BINARY_SIZE;
-
-    for (int i = 0; i < ZXC_GHI_SECTIONS; i++) {
-        desc[i].sizes = zxc_le64(p);
-        p += ZXC_SECTION_DESC_BINARY_SIZE;
-    }
+    zxc_read_gnr_header(src, gh);
     return ZXC_OK;
 }
 
-/*
- * ============================================================================
- * COMPRESS BOUND CALCULATION
- * ============================================================================
- */
+// ============================================================================
+// COMPRESS BOUND CALCULATION
+// ============================================================================
 /**
  * @brief Returns the maximum compressed size for a given input size.
  *
@@ -835,9 +753,6 @@ int zxc_read_ghi_header_and_desc(const uint8_t* RESTRICT src, const size_t len,
  *
  * The block count is derived from @ref ZXC_BLOCK_SIZE_MIN (4 KB) to
  * guarantee the bound holds for all valid block sizes and seekable mode.
- *
- * @param[in] input_size Uncompressed input size in bytes.
- * @return Upper bound on compressed size, or 0 if @p input_size would overflow.
  */
 uint64_t zxc_compress_bound(const size_t input_size) {
     // Guard against uint64 overflow when summing per-block overhead
@@ -855,12 +770,6 @@ uint64_t zxc_compress_bound(const size_t input_size) {
 
 /**
  * @brief Returns the maximum compressed size for a single block (no file framing).
- *
- * @param[in] input_size Uncompressed block size in bytes
- *                       (must be <= @ref ZXC_BLOCK_SIZE_MAX).
- * @return Upper bound on compressed block size, or 0 if @p input_size is out
- *         of range for the Block API (i.e. exceeds ZXC_BLOCK_SIZE_MAX) or if
- *         the arithmetic would overflow.
  */
 uint64_t zxc_compress_block_bound(const size_t input_size) {
     // Mirrors the Block API contract: outside [1, ZXC_BLOCK_SIZE_MAX] the call
@@ -883,10 +792,6 @@ uint64_t zxc_compress_block_bound(const size_t input_size) {
  *
  * Returns 0 if @p uncompressed_size exceeds ZXC_BLOCK_SIZE_MAX (the Block API
  * limit), or if the arithmetic would overflow.
- *
- * @param[in] uncompressed_size  Exact decompressed size of the block.
- * @return Minimum @c dst_capacity in bytes, or 0 if @p uncompressed_size exceeds
- *         @c ZXC_BLOCK_SIZE_MAX.
  */
 uint64_t zxc_decompress_block_bound(const size_t uncompressed_size) {
     if (UNLIKELY(uncompressed_size > ZXC_BLOCK_SIZE_MAX)) return 0;
@@ -906,10 +811,6 @@ uint64_t zxc_decompress_block_bound(const size_t uncompressed_size) {
  * (@c opt_scratch, ~8.125 bytes per chunk_size byte) used by the optimal
  * parser and reused as transient package-merge scratch for the Huffman
  * code-length builder.
- *
- * @param[in] src_size  Input size; rounded up to a valid block size.
- * @param[in] level     Compression level (>= 6 includes the optimal-parser scratch).
- * @return Estimated context buffer size in bytes, or 0 if @p src_size is 0.
  */
 uint64_t zxc_estimate_cctx_size(const size_t src_size, const int level) {
     if (UNLIKELY(src_size == 0)) return 0;
@@ -917,18 +818,12 @@ uint64_t zxc_estimate_cctx_size(const size_t src_size, const int level) {
     return (uint64_t)zxc_cctx_compute_workspace_size(chunk_size, 1, level, 0);
 }
 
-/*
- * ============================================================================
- * ERROR CODE UTILITIES
- * ============================================================================
- */
+// ============================================================================
+// ERROR CODE UTILITIES
+// ============================================================================
 
 /**
  * @brief Returns a human-readable string for the given error code.
- *
- * @param[in] code An error code from @ref zxc_error_t (or @ref ZXC_OK).
- * @return A static string such as @c "ZXC_OK" or @c "ZXC_ERROR_MEMORY".
- *         Returns @c "ZXC_UNKNOWN_ERROR" for unrecognised codes.
  */
 const char* zxc_error_name(const int code) {
     switch ((zxc_error_t)code) {
@@ -975,11 +870,9 @@ const char* zxc_error_name(const int code) {
     }
 }
 
-/*
- * ============================================================================
- * LIBRARY INFORMATION
- * ============================================================================
- */
+// ============================================================================
+// LIBRARY INFORMATION
+// ============================================================================
 
 /**
  * @brief Returns the minimum supported compression level.

--- a/lz/zxc/src/lib/zxc_compress.c
+++ b/lz/zxc/src/lib/zxc_compress.c
@@ -15,12 +15,10 @@
  * by @ref zxc_dispatch.c.
  */
 
-/*
- * Function Multi-Versioning Support
- * With ZXC_FUNCTION_SUFFIX defined (e.g. _avx2), rename the entry point AND the
- * Huffman entry points this TU consumes. The defines precede zxc_internal.h so
- * the header's prototypes get the suffix too, keeping callers and callees matched.
- */
+// Function Multi-Versioning Support
+// With ZXC_FUNCTION_SUFFIX defined (e.g. _avx2), rename the entry point AND the
+// Huffman entry points this TU consumes. The defines precede zxc_internal.h so
+// the header's prototypes get the suffix too, keeping callers and callees matched.
 #ifdef ZXC_FUNCTION_SUFFIX
 #define ZXC_CAT_IMPL(x, y) x##y
 #define ZXC_CAT(x, y) ZXC_CAT_IMPL(x, y)
@@ -54,7 +52,89 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_hash_func(const uint64_t val, const int us
     }
 }
 
-/* SSE2 selected, not merely available: guards the two helpers below. */
+/**
+ * @brief 8-bit rejection tag: XOR fold of the first four bytes at a position.
+ *
+ * One tag per hash slot, so a mismatching head is rejected without touching the
+ * referenced data.
+ */
+static ZXC_ALWAYS_INLINE uint8_t zxc_hash_tag(const uint32_t val4) {
+    return (uint8_t)(val4 ^ (val4 >> 16));
+}
+
+/**
+ * @brief Decodes a hash-table slot into a block position, 0 if it is stale.
+ *
+ * Slots carry the epoch above @c offset_mask, so an entry left from an earlier
+ * block reads as "no match" and the table never needs clearing.
+ */
+static ZXC_ALWAYS_INLINE uint32_t zxc_epoch_pos(const uint32_t head, const uint32_t offset_mask,
+                                                const uint32_t epoch_mark) {
+    return ((head & ~offset_mask) == epoch_mark) ? (head & offset_mask) : 0;
+}
+
+/**
+ * @brief Chain link from a position back to the one the hash slot held.
+ *
+ * Branchless: a missing predecessor, or one beyond the window, gives 0, which
+ * the chain walk reads as end of chain.
+ */
+static ZXC_ALWAYS_INLINE uint16_t zxc_chain_delta(const uint32_t cur_pos, const uint32_t prev_idx) {
+    const uint32_t dist = cur_pos - prev_idx;
+    const uint32_t valid = -((int32_t)((prev_idx != 0) & (dist < ZXC_LZ_WINDOW_SIZE)));
+    return (uint16_t)(dist & valid);
+}
+
+/**
+ * @brief Pair-equality mask for the RLE lookahead: element i is set when
+ *        p[i] == p[i+1].
+ *
+ * The only thing that differs between vector widths; the scan that consumes it
+ * is written once. @c ZXC_RLE_WIN is the bytes examined per step and
+ * @c ZXC_RLE_BPB the mask bits each byte occupies (4 on NEON, which has no
+ * byte-movemask). 32-bit NEON has no cheap equivalent and keeps its own scan.
+ */
+#if defined(ZXC_USE_AVX512)
+#define ZXC_RLE_WIN 64
+#define ZXC_RLE_BPB 1
+#define ZXC_RLE_CTZ(x) zxc_ctz64(x)
+typedef uint64_t zxc_rle_mask_t;
+static ZXC_ALWAYS_INLINE zxc_rle_mask_t zxc_rle_pair_mask(const uint8_t* p) {
+    return (uint64_t)_mm512_cmpeq_epi8_mask(_mm512_loadu_si512((const void*)p),
+                                            _mm512_loadu_si512((const void*)(p + 1)));
+}
+#elif defined(ZXC_USE_AVX2)
+#define ZXC_RLE_WIN 32
+#define ZXC_RLE_BPB 1
+#define ZXC_RLE_CTZ(x) zxc_ctz32(x)
+typedef uint32_t zxc_rle_mask_t;
+static ZXC_ALWAYS_INLINE zxc_rle_mask_t zxc_rle_pair_mask(const uint8_t* p) {
+    const __m256i v0 = _mm256_loadu_si256((const __m256i*)p);
+    const __m256i v1 = _mm256_loadu_si256((const __m256i*)(p + 1));
+    return (uint32_t)_mm256_movemask_epi8(_mm256_cmpeq_epi8(v0, v1));
+}
+#elif defined(ZXC_USE_SSE2)
+#define ZXC_RLE_WIN 16
+#define ZXC_RLE_BPB 1
+#define ZXC_RLE_CTZ(x) zxc_ctz32(x)
+typedef uint32_t zxc_rle_mask_t;
+static ZXC_ALWAYS_INLINE zxc_rle_mask_t zxc_rle_pair_mask(const uint8_t* p) {
+    const __m128i v0 = _mm_loadu_si128((const __m128i*)p);
+    const __m128i v1 = _mm_loadu_si128((const __m128i*)(p + 1));
+    return (uint32_t)_mm_movemask_epi8(_mm_cmpeq_epi8(v0, v1));
+}
+#elif defined(ZXC_USE_NEON64)
+#define ZXC_RLE_WIN 16
+#define ZXC_RLE_BPB 4
+#define ZXC_RLE_CTZ(x) zxc_ctz64(x)
+typedef uint64_t zxc_rle_mask_t;
+static ZXC_ALWAYS_INLINE zxc_rle_mask_t zxc_rle_pair_mask(const uint8_t* p) {
+    const uint8x16_t eq = vceqq_u8(vld1q_u8(p), vld1q_u8(p + 1));
+    return vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(eq), 4)), 0);
+}
+#endif
+
+// SSE2 selected, not merely available: guards the two helpers below.
 #if defined(ZXC_USE_SSE2) && !(defined(ZXC_USE_AVX512) && defined(__AVX512VL__)) && \
     !defined(ZXC_USE_AVX2) && !defined(ZXC_USE_NEON64) && !defined(ZXC_USE_NEON32)
 #define ZXC_OPT_SSE2
@@ -99,12 +179,10 @@ static ZXC_ALWAYS_INLINE __m128i zxc_mm_packus_epi32_sse2(__m128i a, __m128i b) 
 #endif
 
 /**
- * @brief Writes a Prefix Varint encoded value to a buffer.
+ * @brief Writes a value in Prefix Varint form.
  *
- * This function encodes a 32-bit unsigned integer using Prefix Varint encoding
- * and writes it to the destination buffer. Unary prefix bits in the first
- * byte determine the total length (1-5 bytes), allowing for branchless or
- * predictable decoding.
+ * Unary prefix bits in the first byte give the total length (1 to 5 bytes), so
+ * the reader learns the size before it reads the payload:
  *
  * Format:
  * - 0xxxxxxx (1 byte)
@@ -143,6 +221,40 @@ static ZXC_ALWAYS_INLINE size_t zxc_write_varint(uint8_t* RESTRICT dst, const ui
     dst[1] = (uint8_t)(val >> 5);
     dst[2] = (uint8_t)(val >> 13);
     return 3;
+}
+
+/**
+ * @brief Appends a saturated token field's excess to the extras stream.
+ *
+ * A field holds values below its mask; a larger one stores the mask in the
+ * token and the excess here as a varint. Returns 0 if it does not fit one.
+ */
+static ZXC_ALWAYS_INLINE int zxc_emit_extra(uint8_t* RESTRICT extras, size_t* RESTRICT used,
+                                            const uint32_t val, const uint32_t mask) {
+    if (LIKELY(val < mask)) return 1;
+    const size_t n = zxc_write_varint(extras + *used, val - mask);
+    if (UNLIKELY(n == 0)) return 0;
+    *used += n;
+    return 1;
+}
+
+/**
+ * @brief Stages a run of literals into the literal stream.
+ *
+ * One 32-byte wild copy covers the common short run. Within 32 bytes of the
+ * block end that copy would read past it, so the tail takes an exact copy.
+ */
+static ZXC_ALWAYS_INLINE void zxc_flush_literals(uint8_t* literals, size_t* lit_c,
+                                                 const uint8_t* anchor, const uint32_t ll,
+                                                 const uint8_t* iend) {
+    if (LIKELY(anchor + ZXC_PAD_SIZE <= iend)) {
+        zxc_copy32(literals + *lit_c, anchor);
+        if (UNLIKELY(ll > ZXC_PAD_SIZE))
+            ZXC_MEMCPY(literals + *lit_c + ZXC_PAD_SIZE, anchor + ZXC_PAD_SIZE, ll - ZXC_PAD_SIZE);
+    } else {
+        ZXC_MEMCPY(literals + *lit_c, anchor, ll);
+    }
+    *lit_c += ll;
 }
 
 /**
@@ -200,7 +312,7 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
     uint32_t h = zxc_hash_func(cur_val8, use_hash5);
 
     // 8-bit tag: XOR fold of first 4 bytes for fast rejection
-    const uint8_t cur_tag = (uint8_t)(cur_val ^ (cur_val >> 16));
+    const uint8_t cur_tag = zxc_hash_tag(cur_val);
 
     const uint32_t cur_pos = (uint32_t)(ip - src);
 
@@ -210,8 +322,7 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
     if (level <= ZXC_LEVEL_FAST && stored_tag != cur_tag) {
         match_idx = 0;
     } else {
-        const uint32_t raw_head = hash_table[h];
-        match_idx = ((raw_head & ~offset_mask) == epoch_mark) ? (raw_head & offset_mask) : 0;
+        match_idx = zxc_epoch_pos(hash_table[h], offset_mask, epoch_mark);
     }
 
     // skip_head still drives the chain walk on level >= 3 (advances past the
@@ -223,18 +334,16 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
     hash_table[h] = epoch_mark | cur_pos;
     hash_tags[h] = cur_tag;
 
-    // Branchless chain table update
-    const uint32_t dist = cur_pos - match_idx;
-    const uint32_t valid_mask = -((int32_t)((match_idx != 0) & (dist < ZXC_LZ_WINDOW_SIZE)));
-    chain_table[cur_pos & ZXC_LZ_WINDOW_MASK] = (uint16_t)(dist & valid_mask);
+    chain_table[cur_pos & ZXC_LZ_WINDOW_MASK] = zxc_chain_delta(cur_pos, match_idx);
 
     int attempts = p.search_depth;
 
-    /* Repeat-offset seed (level-6 parser passes last_off; others pass 0).
-     * Probing the previous offset first often finds the longest match right
-     * away, speeding up the chain walk. It only raises best.len, never lowers
-     * it, so the result is unchanged - this is purely a speed optimization. */
-    if (last_off != 0U && last_off <= (uint32_t)ZXC_LZ_MAX_DIST && last_off <= cur_pos) {
+    // Repeat-offset seed (level-6 parser passes last_off; others pass 0).
+    // Probing the previous offset first often finds the longest match right
+    // away, speeding up the chain walk. It only raises best.len, never lowers
+    // it, so the result is unchanged - this is purely a speed optimization.
+    if (last_off != 0U && last_off >= p.min_offset && last_off <= (uint32_t)ZXC_LZ_MAX_DIST &&
+        last_off <= cur_pos) {
         const uint8_t* const rep_ref = src + (cur_pos - last_off);
         if (zxc_le32(rep_ref) == cur_val) {
             uint32_t mlen = sizeof(uint32_t);
@@ -282,7 +391,8 @@ static ZXC_ALWAYS_INLINE zxc_match_t zxc_lz77_find_best_match(
         const int tag_match = (ref_val == cur_val);
         // Cheap gate: 4-byte tag match, then check the byte past the current
         // best (the && skips that load unless the tag already matched).
-        const int should_compare = tag_match && (ref[best.len] == ip[best.len]);
+        const int should_compare =
+            (cur_pos - match_idx) >= p.min_offset && tag_match && (ref[best.len] == ip[best.len]);
 
         if (should_compare) {
             uint32_t mlen = sizeof(uint32_t);  // We already know the first 4 bytes match
@@ -462,9 +572,8 @@ _finalize_match:
         const uint32_t h2 = zxc_hash_func(next_val8, use_hash5);
         const uint8_t next_stored_tag = hash_tags[h2];
         const uint32_t next_head = hash_table[h2];
-        uint32_t next_idx =
-            (next_head & ~offset_mask) == epoch_mark ? (next_head & offset_mask) : 0;
-        const uint8_t next_tag = (uint8_t)(next_val ^ (next_val >> 16));
+        uint32_t next_idx = zxc_epoch_pos(next_head, offset_mask, epoch_mark);
+        const uint8_t next_tag = zxc_hash_tag(next_val);
         const int skip_lazy_head = (next_idx > 0 && next_stored_tag != next_tag);
         uint32_t max_lazy2 = 0;
         int lazy_att = p.lazy_attempts;
@@ -475,7 +584,10 @@ _finalize_match:
                 break;
             const uint8_t* ref2 = src + next_idx;
 
-            if ((!is_lazy_first || !skip_lazy_head) && zxc_le32(ref2) == next_val) {
+            // Filtered here too: a lazy hit only cancels best.ref, so a match
+            // we could never emit would drop a legal one for nothing.
+            if (((uint32_t)(ip + 1 - src) - next_idx) >= p.min_offset &&
+                (!is_lazy_first || !skip_lazy_head) && zxc_le32(ref2) == next_val) {
                 uint32_t l2 = sizeof(uint32_t);
                 const uint8_t* limit = iend - sizeof(uint64_t);
 
@@ -507,8 +619,8 @@ _finalize_match:
             const uint32_t h3 = zxc_hash_func(val3_8, use_hash5);
             const uint8_t tag3 = hash_tags[h3];
             const uint32_t head3 = hash_table[h3];
-            uint32_t idx3 = (head3 & ~offset_mask) == epoch_mark ? (head3 & offset_mask) : 0;
-            const uint8_t cur_tag3 = (uint8_t)(val3 ^ (val3 >> 16));
+            uint32_t idx3 = zxc_epoch_pos(head3, offset_mask, epoch_mark);
+            const uint8_t cur_tag3 = zxc_hash_tag(val3);
             const int skip_head3 = (idx3 > 0 && tag3 != cur_tag3);
 
             int is_first3 = 1;
@@ -518,7 +630,8 @@ _finalize_match:
                     break;
 
                 const uint8_t* ref3 = src + idx3;
-                if ((!is_first3 || !skip_head3) && zxc_le32(ref3) == val3) {
+                if (((uint32_t)(ip + 2 - src) - idx3) >= p.min_offset &&
+                    (!is_first3 || !skip_head3) && zxc_le32(ref3) == val3) {
                     uint32_t l3 = sizeof(uint32_t);
                     const uint8_t* limit = iend - sizeof(uint64_t);
 
@@ -619,16 +732,16 @@ static ZXC_ALWAYS_INLINE size_t zxc_opt_dp_update_const_cost(
         for (; L + 8 <= L_end; L += 8) {
             const __m256i v_L_lanes = _mm256_add_epi32(v_inc, _mm256_set1_epi32((int)L));
             const __m256i v_dp = _mm256_loadu_si256((const __m256i*)&dp[p + L]);
-            /* Unsigned-compare-via-bias trick:
-             *   (dp ^ 0x80000000) > (nxt ^ 0x80000000)  iff  dp > nxt
-             * because XOR with the sign bit maps unsigned ordering to
-             * signed ordering. AVX2 only has signed cmpgt for 32-bit. */
+            // Unsigned-compare-via-bias trick:
+            //   (dp ^ 0x80000000) > (nxt ^ 0x80000000)  iff  dp > nxt
+            // because XOR with the sign bit maps unsigned ordering to
+            // signed ordering. AVX2 only has signed cmpgt for 32-bit.
             const __m256i v_dp_b = _mm256_xor_si256(v_dp, v_bias);
             const __m256i v_mask = _mm256_cmpgt_epi32(v_dp_b, v_nxt_b);
             const __m256i v_dp_new = _mm256_blendv_epi8(v_dp, v_nxt, v_mask);
             _mm256_storeu_si256((__m256i*)&dp[p + L], v_dp_new);
-            /* Pack 8x int32 mask -> 8x int16 mask with signed saturation:
-             * 0xFFFFFFFF -> 0xFFFF, 0x00000000 -> 0x0000. */
+            // Pack 8x int32 mask -> 8x int16 mask with signed saturation:
+            // 0xFFFFFFFF -> 0xFFFF, 0x00000000 -> 0x0000.
             const __m128i v_mask16 = _mm_packs_epi32(_mm256_castsi256_si128(v_mask),
                                                      _mm256_extracti128_si256(v_mask, 1));
             const __m128i v_L_u16 = _mm_packus_epi32(_mm256_castsi256_si128(v_L_lanes),
@@ -670,14 +783,14 @@ static ZXC_ALWAYS_INLINE size_t zxc_opt_dp_update_const_cost(
         for (; L + 4 <= L_end; L += 4) {
             const __m128i v_L_lanes = _mm_add_epi32(v_inc, _mm_set1_epi32((int)L));
             const __m128i v_dp = _mm_loadu_si128((const __m128i*)&dp[p + L]);
-            /* Unsigned compare via sign-bit bias (SSE2 cmpgt is signed only):
-             *   (dp ^ 0x80000000) > (nxt ^ 0x80000000)  iff  dp > nxt. */
+            // Unsigned compare via sign-bit bias (SSE2 cmpgt is signed only):
+            //   (dp ^ 0x80000000) > (nxt ^ 0x80000000)  iff  dp > nxt.
             const __m128i v_dp_b = _mm_xor_si128(v_dp, v_bias);
             const __m128i v_mask = _mm_cmpgt_epi32(v_dp_b, v_nxt_b);
             const __m128i v_dp_new = zxc_mm_blendv_epi8_sse2(v_dp, v_nxt, v_mask);
             _mm_storeu_si128((__m128i*)&dp[p + L], v_dp_new);
-            /* Narrow the 4x int32 mask / length lanes to 4x int16 (low 64 bits).
-             * packs: 0xFFFFFFFF -> 0xFFFF, 0 -> 0; packus (SSE2-emulated): u32->u16. */
+            // Narrow the 4x int32 mask / length lanes to 4x int16 (low 64 bits).
+            // packs: 0xFFFFFFFF -> 0xFFFF, 0 -> 0; packus (SSE2-emulated): u32->u16.
             const __m128i v_mask16 = _mm_packs_epi32(v_mask, v_mask);
             const __m128i v_L_u16 = zxc_mm_packus_epi32_sse2(v_L_lanes, v_L_lanes);
             __m128i v_pl = _mm_loadl_epi64((const __m128i*)&parent_len[p + L]);
@@ -689,8 +802,8 @@ static ZXC_ALWAYS_INLINE size_t zxc_opt_dp_update_const_cost(
         }
     }
 #endif
-    /* Scalar tail (and full path on archs without SIMD).
-     * L < L_end <= UINT16_MAX (caller precondition), so the cast is lossless. */
+    // Scalar tail (and full path on archs without SIMD).
+    // L < L_end <= UINT16_MAX (caller precondition), so the cast is lossless.
     for (; L < L_end; L++) {
         if (nxt < dp[p + L]) {
             dp[p + L] = nxt;
@@ -738,17 +851,17 @@ static uint32_t zxc_opt_estimate_lit_bits(const uint8_t* RESTRICT src, const siz
                                             ZXC_HUF_MAX_CODE_LEN_DENSITY) != ZXC_OK))
         return CHAR_BIT;
 
-    /* Sample-weighted sum of code lengths = predicted Huffman bits; divide by
-     * the sample count for bits/byte, rounded up. The DP is integer, and
-     * rounding up favours matches over fractional-cost literals. */
+    // Sample-weighted sum of code lengths = predicted Huffman bits; divide by
+    // the sample count for bits/byte, rounded up. The DP is integer, and
+    // rounding up favours matches over fractional-cost literals.
     uint64_t total_bits = 0;
     for (int k = 0; k < ZXC_HUF_NUM_SYMBOLS; k++) {
         total_bits += (uint64_t)hist[k] * (uint64_t)code_len[k];
     }
     const uint32_t avg = (uint32_t)((total_bits + sampled - 1) / sampled);
 
-    /* Cap at RAW cost: if Huffman can't beat 8 bits/byte on the sample,
-     * the encoder will pick RAW anyway and 8 is the actual literal cost. */
+    // Cap at RAW cost: if Huffman can't beat 8 bits/byte on the sample,
+    // the encoder will pick RAW anyway and 8 is the actual literal cost.
     return (avg < CHAR_BIT) ? avg : CHAR_BIT;
 }
 
@@ -808,15 +921,15 @@ static int zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
     zxc_lz77_params_t lzp_opt = zxc_get_lz77_params(level);
     lzp_opt.use_lazy = 0;  // guard
 
-    /* With a dictionary, src = [dict | block]. The DP arrays index from the block
-     * start, so src_base points at the first block byte for literal copies while
-     * src stays the match finder's base. */
+    // With a dictionary, src = [dict | block]. The DP arrays index from the block
+    // start, so src_base points at the first block byte for literal copies while
+    // src stays the match finder's base.
     const size_t dict_sz = ctx->dict_size;
     const size_t block_sz = src_sz - dict_sz;
     const uint8_t* const src_base = src + dict_sz;
     const uint8_t* const iend = src + src_sz;
 
-    /* Block too small for any match: emit all as literals. */
+    // Block too small for any match: emit all as literals.
     if (UNLIKELY(block_sz < ZXC_LZ_SEARCH_MARGIN + 1)) {
         if (block_sz > 0) ZXC_MEMCPY(literals, src_base, block_sz);
         *lit_c_out = block_sz;
@@ -829,36 +942,27 @@ static int zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
     const size_t search_limit_pos = block_sz - ZXC_LZ_SEARCH_MARGIN;
     const uint8_t* const search_limit = src + search_limit_pos;
 
-    /* DP arrays carved from ctx->opt_scratch, one allocation reused across
-     * blocks, each sub-buffer cache-line padded. Keep `needed` in sync with
-     * zxc_estimate_cctx_size().
-     *
-     *   dp             : (chunk+1) x u32: min cost to reach position p.
-     *   parent_len     : (chunk+1) x u16: 0 = literal, >= MIN_MATCH = match.
-     *   parent_off     : (chunk+1) x u16: biased match offset (distance-1).
-     *   match_end_bits : one bit per position, set when a match on the chosen
-     *                    path ends there - a forward actions[] stack at 1/64
-     *                    the cost.
-     *
-     * The same buffer doubles as package-merge scratch for the code-length
-     * builder: that scratch is live before the DP and after the parse is read
-     * out, never during, so capacity is just the larger of the two. */
-    const size_t chunk = ctx->chunk_size;
-    const size_t sz_dp = ZXC_ALIGN_CL((chunk + 1) * sizeof(uint32_t));
-    const size_t sz_pl = ZXC_ALIGN_CL((chunk + 1) * sizeof(uint16_t));
-    const size_t sz_po = ZXC_ALIGN_CL((chunk + 1) * sizeof(uint16_t));
-    const size_t n_bm_words = ZXC_BITMAP_WORDS(chunk + 1);
-    const size_t sz_bm = ZXC_ALIGN_CL(n_bm_words * sizeof(uint64_t));
-    const size_t dp_needed = sz_dp + sz_pl + sz_po + sz_bm;
-    const size_t needed =
-        (dp_needed > ZXC_HUF_BUILD_SCRATCH_SIZE) ? dp_needed : ZXC_HUF_BUILD_SCRATCH_SIZE;
+    // DP arrays carved from ctx->opt_scratch, one allocation reused across
+    // blocks, each sub-buffer cache-line padded.
+    //
+    //   dp             : (chunk+1) x u32: min cost to reach position p.
+    //   parent_len     : (chunk+1) x u16: 0 = literal, >= MIN_MATCH = match.
+    //   parent_off     : (chunk+1) x u16: biased match offset (distance-1).
+    //   match_end_bits : one bit per position, set when a match on the chosen
+    //                    path ends there - a forward actions[] stack at 1/64
+    //                    the cost.
+    //
+    // The same buffer doubles as package-merge scratch for the code-length
+    // builder: that scratch is live before the DP and after the parse is read
+    // out, never during, so capacity is just the larger of the two.
+    size_t sz_dp;
+    size_t sz_pl;
+    size_t sz_po;
+    size_t sz_bm;
+    zxc_opt_dp_sizes(ctx->chunk_size, &sz_dp, &sz_pl, &sz_po, &sz_bm);
+    const size_t n_bm_words = ZXC_BITMAP_WORDS(ctx->chunk_size + 1);
 
-    /* zxc_cctx_init pre-allocates opt_scratch inside ctx->memory_block at
-     * level >= ZXC_LEVEL_DENSITY. The formula above must stay byte-for-byte in
-     * sync with it and with zxc_estimate_cctx_size(). */
-    (void)needed;
-
-    /* Per-block literal cost (sample only block data, not dict prefix): */
+    // Per-block literal cost (sample only block data, not dict prefix):
     const uint32_t lit_cost = zxc_opt_estimate_lit_bits(src_base, block_sz, ctx->opt_scratch);
 
     uint32_t* const dp = (uint32_t*)ctx->opt_scratch;
@@ -870,17 +974,17 @@ static int zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
     ZXC_MEMSET(dp + 1, 0xFF, block_sz * sizeof(uint32_t));
     ZXC_MEMSET(match_end_bits, 0, sz_bm);
 
-    /* Forward DP: visit every position, update reachable successors.
-     * `skip_until` suppresses find_best_match strictly inside the last long
-     * match - the transition from its start already covers dp[p+1..p+L], and
-     * re-searching there is what makes the parser quadratic on repetitive data. */
+    // Forward DP: visit every position, update reachable successors.
+    // `skip_until` suppresses find_best_match strictly inside the last long
+    // match - the transition from its start already covers dp[p+1..p+L], and
+    // re-searching there is what makes the parser quadratic on repetitive data.
     size_t skip_until = 0;
-    /* Rolling repeat-offset seed for find_best_match */
+    // Rolling repeat-offset seed for find_best_match
     uint32_t last_off = 0;
     for (size_t p = 0; p < search_limit_pos; p++) {
         if (UNLIKELY(dp[p] == UINT32_MAX)) continue;
 
-        /* Literal transition. */
+        // Literal transition.
         const uint32_t lit_next = dp[p] + lit_cost;
         if (lit_next < dp[p + 1]) {
             dp[p + 1] = lit_next;
@@ -889,10 +993,10 @@ static int zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
 
         if (p < skip_until) continue;
 
-        /* Match transition: no lazy, no backtrack (anchor=ip). Sub-lengths are
-         * iterated because any L <= max_L matches at the same offset and may end
-         * at a more useful DP position. ip is absolute so dict references
-         * resolve against src. */
+        // Match transition: no lazy, no backtrack (anchor=ip). Sub-lengths are
+        // iterated because any L <= max_L matches at the same offset and may end
+        // at a more useful DP position. ip is absolute so dict references
+        // resolve against src.
         const uint8_t* ip = src_base + p;
         const zxc_match_t m = zxc_lz77_find_best_match(
             src, ip, iend, search_limit, /*anchor=*/ip, hash_table, hash_tags, chain_table,
@@ -905,18 +1009,18 @@ static int zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
                 const size_t L_max_raw = (m.len > block_sz - p) ? (block_sz - p) : (size_t)m.len;
                 const size_t L_max = (L_max_raw > UINT16_MAX) ? UINT16_MAX : L_max_raw;
 
-                /* Cost is piecewise constant in varint segments, so split
-                 * [MIN_MATCH, L_max] into:
-                 *   1. cheap   : v < ML_MASK                   -> base
-                 *   2. varint1 : v in [ML_MASK, ML_MASK + 128) -> base + 8
-                 *   3. varint2+: v >= ML_MASK + 128            -> base + 16, ...
-                 * The first two have a constant nxt and vectorize; the third is
-                 * rare enough to stay scalar. */
+                // Cost is piecewise constant in varint segments, so split
+                // [MIN_MATCH, L_max] into:
+                //   1. cheap   : v < ML_MASK                   -> base
+                //   2. varint1 : v in [ML_MASK, ML_MASK + 128) -> base + 8
+                //   3. varint2+: v >= ML_MASK + 128            -> base + 16, ...
+                // The first two have a constant nxt and vectorize; the third is
+                // rare enough to stay scalar.
                 const uint16_t off_biased = (uint16_t)(off - ZXC_LZ_OFFSET_BIAS);
                 const size_t L_max_plus = L_max + 1;
                 size_t L = ZXC_LZ_MIN_MATCH_LEN;
 
-                /* 1. Cheap range. */
+                // 1. Cheap range.
                 {
                     const size_t L_cheap_end = ZXC_LZ_MIN_MATCH_LEN + ZXC_TOKEN_ML_MASK;
                     const size_t L_end = (L_max_plus < L_cheap_end) ? L_max_plus : L_cheap_end;
@@ -925,7 +1029,7 @@ static int zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
                                                      off_biased);
                 }
 
-                /* 2. First varint level (1-byte extension). */
+                // 2. First varint level (1-byte extension).
                 if (L < L_max_plus) {
                     const size_t L_v1_end = ZXC_LZ_MIN_MATCH_LEN + ZXC_TOKEN_ML_MASK + 128;
                     const size_t L_end = (L_max_plus < L_v1_end) ? L_max_plus : L_v1_end;
@@ -934,9 +1038,9 @@ static int zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
                                                      off_biased);
                 }
 
-                /* 3. Higher varint levels: variable cost, kept scalar.
-                 * Reached only by L >= ML_MASK + 128 + MIN_MATCH, so the
-                 * v >= ML_MASK guard from the original loop is implied. */
+                // 3. Higher varint levels: variable cost, kept scalar.
+                // Reached only by L >= ML_MASK + 128 + MIN_MATCH, so the
+                // v >= ML_MASK guard from the original loop is implied.
                 for (; L < L_max_plus; L++) {
                     uint32_t cost = ZXC_OPT_MATCH_COST_BASE;
                     uint32_t v = (uint32_t)(L - ZXC_LZ_MIN_MATCH_LEN) - ZXC_TOKEN_ML_MASK;
@@ -957,8 +1061,8 @@ static int zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
         }
     }
 
-    /* Tail (last ZXC_LZ_SEARCH_MARGIN bytes) can only be literals: the match finder
-     * stops at search_limit so its 8-byte probe reads stay in bounds. */
+    // Tail (last ZXC_LZ_SEARCH_MARGIN bytes) can only be literals: the match finder
+    // stops at search_limit so its 8-byte probe reads stay in bounds.
     for (size_t p = search_limit_pos; p < block_sz; p++) {
         if (UNLIKELY(dp[p] == UINT32_MAX)) continue;
         const uint32_t lit_next = dp[p] + lit_cost;
@@ -968,9 +1072,9 @@ static int zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
         }
     }
 
-    /* Backtrack from src_sz to 0. Only match endpoints are recorded; literals
-     * are the unmarked runs between them, rebuilt at emission from lit_start,
-     * so they need no backtrack storage. */
+    // Backtrack from src_sz to 0. Only match endpoints are recorded; literals
+    // are the unmarked runs between them, rebuilt at emission from lit_start,
+    // so they need no backtrack storage.
     {
         size_t pos = block_sz;
         while (pos > 0) {
@@ -984,9 +1088,9 @@ static int zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
         }
     }
 
-    /* Forward emission: walk match_end_bits word-by-word, peeling set bits
-     * with ctzll. Each set bit gives a match endpoint; parent_len/parent_off
-     * at that position recover (length, offset). */
+    // Forward emission: walk match_end_bits word-by-word, peeling set bits
+    // with ctzll. Each set bit gives a match endpoint; parent_len/parent_off
+    // at that position recover (length, offset).
     uint32_t seq_c = 0;
     size_t lit_c = 0;
     size_t extras_sz = 0;
@@ -1015,23 +1119,16 @@ static int zxc_lz77_optimal_parse_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
             buf_offsets[seq_c] = off_biased;
             if (off_biased > max_offset) max_offset = off_biased;
 
-            if (UNLIKELY(ll >= ZXC_TOKEN_LL_MASK)) {
-                const size_t n = zxc_write_varint(buf_extras + extras_sz, ll - ZXC_TOKEN_LL_MASK);
-                if (UNLIKELY(n == 0)) return ZXC_ERROR_OVERFLOW;
-                extras_sz += n;
-            }
-            if (UNLIKELY(ml >= ZXC_TOKEN_ML_MASK)) {
-                const size_t n = zxc_write_varint(buf_extras + extras_sz, ml - ZXC_TOKEN_ML_MASK);
-                if (UNLIKELY(n == 0)) return ZXC_ERROR_OVERFLOW;
-                extras_sz += n;
-            }
+            if (UNLIKELY(!zxc_emit_extra(buf_extras, &extras_sz, ll, ZXC_TOKEN_LL_MASK) ||
+                         !zxc_emit_extra(buf_extras, &extras_sz, ml, ZXC_TOKEN_ML_MASK)))
+                return ZXC_ERROR_OVERFLOW;
 
             seq_c++;
             lit_start = pos;
         }
     }
 
-    /* Tail literals after the last match (or all literals if no match). */
+    // Tail literals after the last match (or all literals if no match).
     if (lit_start < block_sz) {
         const size_t tail = block_sz - lit_start;
         ZXC_MEMCPY(literals + lit_c, src_base + lit_start, tail);
@@ -1070,93 +1167,65 @@ static void zxc_lz_seed_dict(const uint8_t* RESTRICT src, const size_t dict_size
     const int use_hash5 = (level >= 3);
     const size_t limit = dict_size - (ZXC_LZ_MIN_MATCH_LEN - 1);
 
-    /* Sparse seeding for the first half, dense for the second half.
-     * Positions near the end of the dict produce shorter offsets and are
-     * more likely to yield matches, so they deserve full coverage. */
+    // Sparse seeding for the first half, dense for the second half.
+    // Positions near the end of the dict produce shorter offsets and are
+    // more likely to yield matches, so they deserve full coverage.
     const size_t half = limit / 2;
     for (size_t i = 0; i < half; i += 4) {
         const uint64_t val8 = zxc_le64(src + i);
         const uint32_t h = zxc_hash_func(val8, use_hash5);
         const uint32_t cur_pos = (uint32_t)i;
-        const uint8_t tag = (uint8_t)((uint32_t)val8 ^ ((uint32_t)val8 >> 16));
 
         hash_table[h] = epoch_mark | cur_pos;
-        hash_tags[h] = tag;
+        hash_tags[h] = zxc_hash_tag((uint32_t)val8);
         chain_table[cur_pos & ZXC_LZ_WINDOW_MASK] = 0;
     }
     for (size_t i = half; i < limit; i++) {
         const uint64_t val8 = zxc_le64(src + i);
         const uint32_t h = zxc_hash_func(val8, use_hash5);
         const uint32_t cur_pos = (uint32_t)i;
-        const uint8_t tag = (uint8_t)((uint32_t)val8 ^ ((uint32_t)val8 >> 16));
-
-        const uint32_t raw_head = hash_table[h];
-        const uint32_t prev_idx =
-            ((raw_head & ~offset_mask) == epoch_mark) ? (raw_head & offset_mask) : 0;
+        const uint32_t prev_idx = zxc_epoch_pos(hash_table[h], offset_mask, epoch_mark);
 
         hash_table[h] = epoch_mark | cur_pos;
-        hash_tags[h] = tag;
-
-        const uint32_t dist = cur_pos - prev_idx;
-        const uint32_t valid = -((int32_t)((prev_idx != 0) & (dist < ZXC_LZ_WINDOW_SIZE)));
-        chain_table[cur_pos & ZXC_LZ_WINDOW_MASK] = (uint16_t)(dist & valid);
+        hash_tags[h] = zxc_hash_tag((uint32_t)val8);
+        chain_table[cur_pos & ZXC_LZ_WINDOW_MASK] = zxc_chain_delta(cur_pos, prev_idx);
     }
 }
 
 /**
- * @brief Encodes a data block using the General (GLO) compression format.
+ * @brief Encodes one block in the GLO format (levels 3 and up).
  *
- * This function implements the core LZ77 compression logic. It dynamically
- * adjusts compression parameters (search depth, lazy matching strategy, and
- * step skipping) based on the compression level configured in the context.
+ * Two parsers feed the same serialiser. Levels 6 and 7 hand the whole parse to
+ * zxc_lz77_optimal_parse_glo() and rejoin at @c parse_done; levels 3 to 5 run
+ * the lazy loop here, with the search depth, lazy attempts and hash step taken
+ * from zxc_get_lz77_params(). Either way the parse yields a literal run plus
+ * token, offset and extras streams.
  *
- * **LZ77 Implementation Details:**
- * 1. **Hash Chain:** Uses a hash table (`ctx->hash_table`) to find potential
- * match positions. Collisions are handled via a `chain_table`, allowing us to
- * search deeper into the history for a better match.
- * 2. **Lazy Matching:** If a match is found, we check the *next* byte to see if
- *    it produces a longer match. If so, we output a literal and take the better
- * match. This is enabled for levels >= 3.
- * 3. **Step Skipping:** For lower levels (1-3), we skip bytes when updating the
- *    hash table to increase speed (`step > 1`). For levels 4+, we process every
- * byte to maximize compression ratio.
- * 4. **SIMD Match Finding:** Uses AVX2/AVX512/NEON to compare 32/64 bytes at a
- * time during match length calculation, significantly speeding up long match
- * verification.
- * 5. **RLE Detection:** Analyzes literals to see if Run-Length Encoding would
- * be beneficial (saving > 10% space).
+ * The tail then picks an encoding per section - RAW against RLE for the
+ * literals, plus a Huffman candidate from level 6 - sizes the sequence streams,
+ * and writes the header, its descriptors and the payload.
  *
- * The encoding process consists of:
- * 1. **LZ77 Parsing**: The function iterates through the source data,
- * maintaining a hash chain to find repeated patterns (matches). It supports
- * "Lazy Matching" for higher compression levels to optimize match selection.
- * 2. **Sequence Storage**: Matches are converted into sequences consisting of
- *    literal lengths, match lengths, and offsets.
- * 3. **Bitpacking & Serialization**: The sequences are analyzed to determine
- * optimal bit-widths. The function then writes the block header, encodes
- * literals (using Raw or RLE encoding), and bit-packs the sequence streams into
- * the destination buffer.
- *
- * @param[in,out] ctx       Pointer to the compression context containing hash tables
- * and configuration.
- * @param[in] src       Pointer to the input source data.
- * @param[in] src_sz  Size of the input data in bytes.
- * @param[out] dst       Pointer to the destination buffer where compressed data will
- * be written.
- * @param[in] dst_cap   Maximum capacity of the destination buffer.
- * @param[out] out_sz    [Out] Pointer to a variable that will receive the total size
- * of the compressed output.
- *
- * @return ZXC_OK on success, or a negative zxc_error_t code (e.g., ZXC_ERROR_DST_TOO_SMALL) if an
- * error occurs (e.g., buffer overflow).
+ * @param[in,out] ctx     Compression context: hash and chain tables, buffers, level.
+ * @param[in]     src     Input, prefixed by the dictionary content when one is active.
+ * @param[in]     src_sz  Size of @p src, that prefix included.
+ * @param[out]    dst     Destination buffer.
+ * @param[in]     dst_cap Capacity of @p dst.
+ * @param[out]    out_sz  Receives the number of bytes written.
+ * @return ZXC_OK, or a negative @ref zxc_error_t, typically
+ *         @ref ZXC_ERROR_DST_TOO_SMALL.
  */
 static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                 const size_t src_sz, uint8_t* RESTRICT dst, size_t dst_cap,
                                 size_t* RESTRICT out_sz) {
+    if (UNLIKELY(dst_cap < ZXC_BLOCK_HEADER_SIZE)) return ZXC_ERROR_DST_TOO_SMALL;
+
     const int level = ctx->compression_level;
     const size_t dict_sz = ctx->dict_size;
 
-    const zxc_lz77_params_t lzp = zxc_get_lz77_params(level);
+    zxc_lz77_params_t lzp = zxc_get_lz77_params(level);
+    // The floor is a candidate until the block itself clears it.
+    if (lzp.min_offset > 1 && zxc_block_is_short_dist_bound(src + dict_sz, src_sz - dict_sz))
+        lzp.min_offset = 1;
 
     ctx->epoch++;
     if (UNLIKELY(ctx->epoch >= ctx->max_epoch)) {
@@ -1190,8 +1259,8 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
     size_t extras_sz = 0;
     uint16_t max_offset = 0;  // Track max offset for 1-byte/2-byte mode decision
 
-    /* Level 6+: price-based optimal parser (fills outputs and skips the
-     * lazy loop + last_lits handling below via `goto parse_done`). */
+    // Level 6+: price-based optimal parser (fills outputs and skips the
+    // lazy loop + last_lits handling below via `goto parse_done`).
     if (level >= ZXC_LEVEL_DENSITY) {
         const int rc = zxc_lz77_optimal_parse_glo(
             ctx, src, src_sz, hash_table, hash_tags, chain_table, epoch_mark, offset_mask, level,
@@ -1224,18 +1293,7 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
             const uint32_t ml = m.len - ZXC_LZ_MIN_MATCH_LEN;
             const uint32_t off = (uint32_t)(ip - m.ref);
 
-            if (ll > 0) {
-                if (LIKELY(anchor + ZXC_PAD_SIZE <= iend)) {
-                    zxc_copy32(literals + lit_c, anchor);
-                    if (UNLIKELY(ll > ZXC_PAD_SIZE)) {
-                        ZXC_MEMCPY(literals + lit_c + ZXC_PAD_SIZE, anchor + ZXC_PAD_SIZE,
-                                   ll - ZXC_PAD_SIZE);
-                    }
-                } else {
-                    ZXC_MEMCPY(literals + lit_c, anchor, ll);
-                }
-                lit_c += ll;
-            }
+            if (ll > 0) zxc_flush_literals(literals, &lit_c, anchor, ll, iend);
 
             const uint8_t ll_code = (ll >= ZXC_TOKEN_LL_MASK) ? ZXC_TOKEN_LL_MASK : (uint8_t)ll;
             const uint8_t ml_code = (ml >= ZXC_TOKEN_ML_MASK) ? ZXC_TOKEN_ML_MASK : (uint8_t)ml;
@@ -1244,16 +1302,9 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
             if ((off - ZXC_LZ_OFFSET_BIAS) > max_offset)
                 max_offset = (uint16_t)(off - ZXC_LZ_OFFSET_BIAS);
 
-            if (ll >= ZXC_TOKEN_LL_MASK) {
-                const size_t n = zxc_write_varint(buf_extras + extras_sz, ll - ZXC_TOKEN_LL_MASK);
-                if (UNLIKELY(n == 0)) return ZXC_ERROR_OVERFLOW;
-                extras_sz += n;
-            }
-            if (ml >= ZXC_TOKEN_ML_MASK) {
-                const size_t n = zxc_write_varint(buf_extras + extras_sz, ml - ZXC_TOKEN_ML_MASK);
-                if (UNLIKELY(n == 0)) return ZXC_ERROR_OVERFLOW;
-                extras_sz += n;
-            }
+            if (UNLIKELY(!zxc_emit_extra(buf_extras, &extras_sz, ll, ZXC_TOKEN_LL_MASK) ||
+                         !zxc_emit_extra(buf_extras, &extras_sz, ml, ZXC_TOKEN_ML_MASK)))
+                return ZXC_ERROR_OVERFLOW;
 
             seq_c++;
 
@@ -1264,15 +1315,11 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
                     const uint64_t val_u8 = zxc_le64(match_end - 2);
                     const uint32_t val_u = (uint32_t)val_u8;
                     const uint32_t h_u = zxc_hash_func(val_u8, 1);
-                    const uint32_t prev_head = hash_table[h_u];
                     const uint32_t prev_idx =
-                        (prev_head & ~offset_mask) == epoch_mark ? (prev_head & offset_mask) : 0;
+                        zxc_epoch_pos(hash_table[h_u], offset_mask, epoch_mark);
                     hash_table[h_u] = epoch_mark | pos_u;
-                    hash_tags[h_u] = (uint8_t)(val_u ^ (val_u >> 16));
-                    chain_table[pos_u & ZXC_LZ_WINDOW_MASK] =
-                        (prev_idx > 0 && (pos_u - prev_idx) < ZXC_LZ_WINDOW_SIZE)
-                            ? (uint16_t)(pos_u - prev_idx)
-                            : 0;
+                    hash_tags[h_u] = zxc_hash_tag(val_u);
+                    chain_table[pos_u & ZXC_LZ_WINDOW_MASK] = zxc_chain_delta(pos_u, prev_idx);
                 }
             }
 
@@ -1290,8 +1337,8 @@ static int zxc_encode_block_glo(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
     }
 
 parse_done:;
-    /* Dictionary-table trainer hook: accumulate the REAL post-LZ literal
-     * frequencies (see zxc_train_dict_huf). Cold path, NULL outside training. */
+    // Dictionary-table trainer hook: accumulate the REAL post-LZ literal
+    // frequencies (see zxc_train_dict_huf). Cold path, NULL outside training.
     if (UNLIKELY(ctx->lit_freq_acc != NULL)) {
         for (size_t i = 0; i < lit_c; i++) ctx->lit_freq_acc[literals[i]]++;
     }
@@ -1349,7 +1396,7 @@ parse_done:;
             while (p <= p_end - 16) {
                 const uint8x16_t v = vld1q_u8(p);
                 const uint8x16_t eq = vceqq_u8(v, vb);
-                /* SHRN nibble-mask: see find_best_match above for rationale. */
+                // SHRN nibble-mask: see find_best_match above for rationale.
                 const uint64_t mask =
                     vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(eq), 4)), 0);
                 if (LIKELY(mask == ~(uint64_t)0)) {
@@ -1412,93 +1459,24 @@ parse_done:;
                 // Literal run: scan ahead with fast SIMD lookahead
                 const uint8_t* lit_start = run_start;
 
-#if defined(ZXC_USE_AVX512)
-                while (p <= p_end_4 - 64) {
-                    const __m512i v0 = _mm512_loadu_si512((const void*)p);
-                    const __m512i v1 = _mm512_loadu_si512((const void*)(p + 1));
-                    const uint64_t m = (uint64_t)_mm512_cmpeq_epi8_mask(v0, v1);
-                    const uint64_t mask = m & (m >> 1) & (m >> 2);
+#if defined(ZXC_RLE_WIN)
+                while (p <= p_end_4 - ZXC_RLE_WIN) {
+                    const zxc_rle_mask_t m = zxc_rle_pair_mask(p);
+                    const zxc_rle_mask_t mask = m & (m >> ZXC_RLE_BPB) & (m >> (2 * ZXC_RLE_BPB));
                     if (LIKELY(mask == 0)) {
-                        p += 62;
+                        p += ZXC_RLE_WIN - 2;
                         continue;
                     }
-                    const unsigned rpos = (unsigned)zxc_ctz64(mask);
-                    const unsigned rpairs = (unsigned)zxc_ctz64(~(m >> rpos));
-                    if (UNLIKELY(rpos + rpairs >= 64)) {
+                    const unsigned rpos = (unsigned)(ZXC_RLE_CTZ(mask) / ZXC_RLE_BPB);
+                    const unsigned rpairs =
+                        (unsigned)(ZXC_RLE_CTZ(~(m >> (rpos * ZXC_RLE_BPB))) / ZXC_RLE_BPB);
+                    if (UNLIKELY(rpos + rpairs >= ZXC_RLE_WIN)) {
                         p += rpos;
                         goto _lit_done; /* run may extend past the window */
                     }
                     const size_t seg = (size_t)(p + rpos - lit_start);
                     rle_size += seg + ((seg + 127) >> 7);
-                    rle_size += 2; /* run in [4,63]: full_chunks=0, rem>=4 */
-                    p += rpos + rpairs + 1;
-                    lit_start = p;
-                }
-#elif defined(ZXC_USE_AVX2)
-                while (p <= p_end_4 - 32) {
-                    __m256i v0 = _mm256_loadu_si256((const __m256i*)p);
-                    __m256i v1 = _mm256_loadu_si256((const __m256i*)(p + 1));
-                    const uint32_t m = (uint32_t)_mm256_movemask_epi8(_mm256_cmpeq_epi8(v0, v1));
-                    const uint32_t mask = m & (m >> 1) & (m >> 2);
-                    if (LIKELY(mask == 0)) {
-                        p += 30;
-                        continue;
-                    }
-                    const unsigned rpos = zxc_ctz32(mask);
-                    const unsigned rpairs = zxc_ctz32(~(m >> rpos));
-                    if (UNLIKELY(rpos + rpairs >= 32)) {
-                        p += rpos;
-                        goto _lit_done; /* run may extend past the window */
-                    }
-                    const size_t seg = (size_t)(p + rpos - lit_start);
-                    rle_size += seg + ((seg + 127) >> 7);
-                    rle_size += 2; /* run in [4,31]: full_chunks=0, rem>=4 */
-                    p += rpos + rpairs + 1;
-                    lit_start = p;
-                }
-#elif defined(ZXC_USE_SSE2)
-                while (p <= p_end_4 - 16) {
-                    __m128i v0 = _mm_loadu_si128((const __m128i*)p);
-                    __m128i v1 = _mm_loadu_si128((const __m128i*)(p + 1));
-                    const uint32_t m = (uint32_t)_mm_movemask_epi8(_mm_cmpeq_epi8(v0, v1));
-                    const uint32_t mask = m & (m >> 1) & (m >> 2);
-                    if (LIKELY(mask == 0)) {
-                        p += 14;
-                        continue;
-                    }
-                    const unsigned rpos = zxc_ctz32(mask);
-                    const unsigned rpairs = zxc_ctz32(~(m >> rpos));
-                    if (UNLIKELY(rpos + rpairs >= 16)) {
-                        p += rpos;
-                        goto _lit_done; /* run may extend past the window */
-                    }
-                    const size_t seg = (size_t)(p + rpos - lit_start);
-                    rle_size += seg + ((seg + 127) >> 7);
-                    rle_size += 2; /* run in [4,16]: full_chunks=0, rem>=4 */
-                    p += rpos + rpairs + 1;
-                    lit_start = p;
-                }
-#elif defined(ZXC_USE_NEON64)
-                while (p <= p_end_4 - 16) {
-                    uint8x16_t v0 = vld1q_u8(p);
-                    uint8x16_t v1 = vld1q_u8(p + 1);
-                    const uint8x16_t eq = vceqq_u8(v0, v1);
-                    const uint64_t m = vget_lane_u64(
-                        vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(eq), 4)), 0);
-                    const uint64_t mask = m & (m >> 4) & (m >> 8);
-                    if (LIKELY(mask == 0)) {
-                        p += 14;
-                        continue;
-                    }
-                    const unsigned rpos = (unsigned)(zxc_ctz64(mask) >> 2);
-                    const unsigned rpairs = (unsigned)(zxc_ctz64(~(m >> (rpos * 4))) >> 2);
-                    if (UNLIKELY(rpos + rpairs >= 16)) {
-                        p += rpos;
-                        goto _lit_done; /* run may extend past the window */
-                    }
-                    const size_t seg = (size_t)(p + rpos - lit_start);
-                    rle_size += seg + ((seg + 127) >> 7);
-                    rle_size += 2; /* run in [4,16]: full_chunks=0, rem>=4 */
+                    rle_size += 2; /* run fits one chunk: full_chunks=0, rem>=4 */
                     p += rpos + rpairs + 1;
                     lit_start = p;
                 }
@@ -1536,11 +1514,7 @@ parse_done:;
                     if (UNLIKELY(p[0] == p[1] && p[1] == p[2] && p[2] == p[3])) break;
                     p++;
                 }
-                while (p < p_end) {
-                    if (UNLIKELY(p + 3 < p_end && p[0] == p[1] && p[1] == p[2] && p[2] == p[3]))
-                        break;
-                    p++;
-                }
+                if (p >= p_end_4) p = p_end;
 
 #if defined(ZXC_USE_AVX512) || defined(ZXC_USE_AVX2) || defined(ZXC_USE_NEON64) || \
     defined(ZXC_USE_NEON32) || defined(ZXC_USE_SSE2)
@@ -1553,8 +1527,8 @@ parse_done:;
             }
         }
 
-        /* RLE over RAW: space-speed J comparison. The per-level premium
-         * reproduces the historical margin exactly below ULTRA. */
+        // RLE over RAW: space-speed J comparison. The per-level premium
+        // reproduces the historical margin exactly below ULTRA.
         const size_t rle_j = rle_size + ZXC_SS_TAX(lit_c, zxc_ss_prem_rle_q8(level));
         if (rle_j < best_j) {
             enc_lit = ZXC_SECTION_ENCODING_RLE;
@@ -1562,9 +1536,9 @@ parse_done:;
         }
     }
 
-    /* Level >= 6: Huffman as a third literal-encoding candidate. Histogram,
-     * length-limited code lengths, exact PivCo section size, and switch if its
-     * J (size + decode tax) beats the current winner's. */
+    // Level >= 6: Huffman as a third literal-encoding candidate. Histogram,
+    // length-limited code lengths, exact PivCo section size, and switch if its
+    // J (size + decode tax) beats the current winner's.
     uint8_t huf_code_len[ZXC_HUF_NUM_SYMBOLS];
     size_t huf_total_size = SIZE_MAX;
     uint32_t lit_freq[ZXC_HUF_NUM_SYMBOLS]; /* valid iff huf_total_size != SIZE_MAX */
@@ -1593,8 +1567,8 @@ parse_done:;
             (void)zxc_huf_nudge_code_lengths(freq, huf_code_len, ctx->opt_scratch,
                                              zxc_huf_enc_max_code_len(level));
             huf_total_size = zxc_huf_calc_size(freq, huf_code_len, 1);
-            /* Space-speed: the entropy candidate must beat the current winner's
-             * J, paying its own decode tax over the copy path. */
+            // Space-speed: the entropy candidate must beat the current winner's
+            // J, paying its own decode tax over the copy path.
             if (huf_total_size != SIZE_MAX) {
                 const size_t huf_j = huf_total_size + ZXC_SS_TAX(lit_c, zxc_ss_prem_huf_q8(level));
                 if (huf_j < best_j) {
@@ -1605,35 +1579,35 @@ parse_done:;
         }
     }
 
-    /* Shared dictionary table (level >= 6, dict with a table): the HUFFMAN
-     * bitstream minus the 128-byte header, so it stays viable far below
-     * ZXC_HUF_MIN_LITERALS. A literal without a code drops the candidate. */
+    // Shared dictionary table (level >= 6, dict with a table): the HUFFMAN
+    // bitstream minus the 128-byte header, so it stays viable far below
+    // ZXC_HUF_MIN_LITERALS. A literal without a code drops the candidate.
     size_t huf_dict_total_size = SIZE_MAX;
     if (level >= ZXC_LEVEL_DENSITY && ctx->dict_huf_tree_ok && lit_c > 0) {
-        /* The dict candidate runs on sections too small for the per-block
-         * table, so the histogram may not have been built above. */
+        // The dict candidate runs on sections too small for the per-block
+        // table, so the histogram may not have been built above.
         if (huf_total_size == SIZE_MAX) {
             ZXC_MEMSET(lit_freq, 0, sizeof(uint32_t) * ZXC_HUF_NUM_SYMBOLS);
             for (size_t i = 0; i < lit_c; i++) lit_freq[literals[i]]++;
         }
-        /* zxc_huf_calc_size returns SIZE_MAX for unencodable candidates
-         * (a literal byte without a code in the shared table). */
+        // zxc_huf_calc_size returns SIZE_MAX for unencodable candidates
+        // (a literal byte without a code in the shared table).
         huf_dict_total_size =
             zxc_huf_calc_size_dict(lit_freq, ctx->dict_huf->code_len, &ctx->dict_huf->tree);
         if (huf_dict_total_size != SIZE_MAX) {
-            /* Same J rule against the running winner: vs the per-block Huffman
-             * candidate the equal entropy taxes cancel (pure size comparison),
-             * while RAW/RLE baselines keep their decode-tax edge. */
+            // Same J rule against the running winner: vs the per-block Huffman
+            // candidate the equal entropy taxes cancel (pure size comparison),
+            // while RAW/RLE baselines keep their decode-tax edge.
             const size_t huf_dict_j =
                 huf_dict_total_size + ZXC_SS_TAX(lit_c, zxc_ss_prem_huf_q8(level));
-            /* Last candidate: no need to keep best_j updated past this point. */
+            // Last candidate: no need to keep best_j updated past this point.
             if (huf_dict_j < best_j) enc_lit = ZXC_SECTION_ENCODING_HUFFMAN_DICT;
         }
     }
 
-    /* Level-7 (ULTRA): Huffman-code the token stream with the literal codec -
-     * tokens are a <= 256-symbol alphabet. Same J rule; the decoder picks the
-     * path from gh.enc_litlen. opt_scratch is free by now. */
+    // Level-7 (ULTRA): Huffman-code the token stream with the literal codec -
+    // tokens are a <= 256-symbol alphabet. Same J rule; the decoder picks the
+    // path from gh.enc_tok. opt_scratch is free by now.
     uint8_t tok_code_len[ZXC_HUF_NUM_SYMBOLS];
     uint8_t enc_tok = ZXC_SECTION_ENCODING_RAW;
     size_t tok_huf_size = 0;
@@ -1646,8 +1620,8 @@ parse_done:;
             (void)zxc_huf_nudge_code_lengths(tfreq, tok_code_len, ctx->opt_scratch,
                                              zxc_huf_enc_max_code_len(level));
             tok_huf_size = zxc_huf_calc_size(tfreq, tok_code_len, 1);
-            /* Space-speed J comparison (this path is ULTRA-only): the PivCo
-             * token section pays the same decode tax as PivCo literals. */
+            // Space-speed J comparison (this path is ULTRA-only): the PivCo
+            // token section pays the same decode tax as PivCo literals.
             if (tok_huf_size != SIZE_MAX &&
                 tok_huf_size + ZXC_SS_TAX((size_t)seq_c, zxc_ss_prem_huf_q8(level)) < (size_t)seq_c)
                 enc_tok = ZXC_SECTION_ENCODING_HUFFMAN;
@@ -1664,33 +1638,23 @@ parse_done:;
     const zxc_gnr_header_t gh = {.n_sequences = seq_c,
                                  .n_literals = (uint32_t)lit_c,
                                  .enc_lit = enc_lit,
-                                 .enc_litlen = enc_tok,
+                                 .enc_tok = enc_tok,
                                  .enc_mlen = 0,
                                  .enc_off = (uint8_t)use_8bit_off};
 
-    zxc_section_desc_t desc[ZXC_GLO_SECTIONS] = {0};
-    const size_t lit_section_size = (enc_lit == ZXC_SECTION_ENCODING_RLE)       ? rle_size
-                                    : (enc_lit == ZXC_SECTION_ENCODING_HUFFMAN) ? huf_total_size
-                                    : (enc_lit == ZXC_SECTION_ENCODING_HUFFMAN_DICT)
-                                        ? huf_dict_total_size
-                                        : lit_c;
-    desc[0].sizes = (uint64_t)lit_section_size | ((uint64_t)lit_c << 32);
-    const size_t tok_section_size =
-        (enc_tok == ZXC_SECTION_ENCODING_HUFFMAN) ? tok_huf_size : seq_c;
-    desc[1].sizes = (uint64_t)tok_section_size | ((uint64_t)seq_c << 32);
-    desc[2].sizes = (uint64_t)off_stream_size | ((uint64_t)off_stream_size << 32);
-    desc[3].sizes = (uint64_t)extras_sz | ((uint64_t)extras_sz << 32);
+    const size_t sz_lit = (enc_lit == ZXC_SECTION_ENCODING_RLE)            ? rle_size
+                          : (enc_lit == ZXC_SECTION_ENCODING_HUFFMAN)      ? huf_total_size
+                          : (enc_lit == ZXC_SECTION_ENCODING_HUFFMAN_DICT) ? huf_dict_total_size
+                                                                           : lit_c;
+    const size_t sz_tok = (enc_tok == ZXC_SECTION_ENCODING_HUFFMAN) ? tok_huf_size : seq_c;
+    const size_t sz_off = off_stream_size;
+    const size_t sz_ext = extras_sz;
 
-    const int ghs = zxc_write_glo_header_and_desc(p, rem, &gh, desc);
+    const int ghs = zxc_write_glo_header_and_desc(p, rem, &gh, (uint32_t)sz_lit, (uint32_t)sz_tok);
     if (UNLIKELY(ghs < 0)) return ghs;
 
     uint8_t* p_curr = p + ghs;
     rem -= ghs;
-
-    const size_t sz_lit = (size_t)(desc[0].sizes & ZXC_SECTION_SIZE_MASK);
-    const size_t sz_tok = (size_t)(desc[1].sizes & ZXC_SECTION_SIZE_MASK);
-    const size_t sz_off = (size_t)(desc[2].sizes & ZXC_SECTION_SIZE_MASK);
-    const size_t sz_ext = (size_t)(desc[3].sizes & ZXC_SECTION_SIZE_MASK);
 
     if (UNLIKELY(rem < sz_lit)) return ZXC_ERROR_DST_TOO_SMALL;
 
@@ -1812,10 +1776,21 @@ parse_done:;
     }
     rem -= sz_off;
 
-    if (UNLIKELY(rem < sz_ext)) return ZXC_ERROR_DST_TOO_SMALL;
+    // The sections behind the literals must total ZXC_BLOCK_LIT_SLACK bytes so
+    // the decoder's literal wild-copy can overshoot. Tokens and offsets alone
+    // clear it from 16 sequences on, so pad is 0 on any real block. It rides
+    // inside the extras section, which the decoder sizes from the payload
+    // residue - hence no wire field.
+    const size_t behind_lit = sz_tok + sz_off + sz_ext;
+    const size_t pad = (behind_lit < ZXC_BLOCK_LIT_SLACK) ? ZXC_BLOCK_LIT_SLACK - behind_lit : 0;
+
+    if (UNLIKELY(rem < sz_ext + pad)) return ZXC_ERROR_DST_TOO_SMALL;
 
     ZXC_MEMCPY(p_curr, buf_extras, extras_sz);
     p_curr += extras_sz;
+
+    ZXC_MEMSET(p_curr, 0, pad);
+    p_curr += pad;
 
     bh.comp_size = (uint32_t)(p_curr - (dst + ZXC_BLOCK_HEADER_SIZE));
     const int hw = zxc_write_block_header(dst, dst_cap, &bh);
@@ -1827,41 +1802,36 @@ parse_done:;
 }
 
 /**
- * @brief Encodes a data block using the General High Velocity (GHI) compression format.
+ * @brief Encodes one block in the GHI format (levels 1 and 2, the speed path).
  *
- * 1. Compression Strategy
- * It uses an LZ77-based algorithm with a sliding window (64KB) and a hash table/chain table
- * mechanism.
+ * What sets GHI apart is the sequence record. GLO packs a 1-byte token (4-bit
+ * literal length, 4-bit match length) and escapes anything longer through a
+ * varint; GHI spends a fixed 4 bytes instead - 8-bit LL, 8-bit ML (both
+ * escaping at 255) and a 16-bit offset covering the whole 64 KB window. Lengths
+ * between 16 and 255 are common, and this keeps them out of the varint reader,
+ * which is what the decoder actually pays for.
  *
- * 2. Token Format (Fixed-Width)
- * Unlike the standard GLO block which uses 1-byte tokens (4-bit literal length / 4-bit match
- * length), GHI uses 4-byte (32-bit) sequence records for better performance on long runs:
- * Literal Length (LL): 8 bits (stores 0-254; 255 indicates overflow).
- * Match Length (ML): 8 bits (stores 0-254; 255 indicates overflow).
- * Offset: 16 bits (supports the full 64KB window).
- * This format minimizes the number of expensive VByte reads during decompression for common
- * sequences where lengths are between 16 and 255.
- *
- * @param[in,out] ctx   Pointer to the compression context containing hash tables
- * and configuration.
- * @param[in] src       Pointer to the input source data.
- * @param[in] src_sz    Size of the input data in bytes.
- * @param[out] dst      Pointer to the destination buffer where compressed data will
- * be written.
- * @param[in] dst_cap   Maximum capacity of the destination buffer.
- * @param[out] out_sz   Pointer to a variable that will receive the total size
- * of the compressed output.
- *
- * @return ZXC_OK on success, or a negative zxc_error_t code (e.g., ZXC_ERROR_DST_TOO_SMALL) if an
- * error occurs (e.g., buffer overflow).
+ * @param[in,out] ctx     Compression context: hash and chain tables, buffers, level.
+ * @param[in]     src     Input, prefixed by the dictionary content when one is active.
+ * @param[in]     src_sz  Size of @p src, that prefix included.
+ * @param[out]    dst     Destination buffer.
+ * @param[in]     dst_cap Capacity of @p dst.
+ * @param[out]    out_sz  Receives the number of bytes written.
+ * @return ZXC_OK, or a negative @ref zxc_error_t, typically
+ *         @ref ZXC_ERROR_DST_TOO_SMALL.
  */
 static int zxc_encode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                 const size_t src_sz, uint8_t* RESTRICT dst, const size_t dst_cap,
                                 size_t* RESTRICT const out_sz) {
+    if (UNLIKELY(dst_cap < ZXC_BLOCK_HEADER_SIZE)) return ZXC_ERROR_DST_TOO_SMALL;
+
     const int level = ctx->compression_level;
     const size_t dict_sz = ctx->dict_size;
 
-    const zxc_lz77_params_t lzp = zxc_get_lz77_params(level);
+    zxc_lz77_params_t lzp = zxc_get_lz77_params(level);
+    // The floor is a candidate until the block itself clears it.
+    if (lzp.min_offset > 1 && zxc_block_is_short_dist_bound(src + dict_sz, src_sz - dict_sz))
+        lzp.min_offset = 1;
 
     ctx->epoch++;
     if (UNLIKELY(ctx->epoch >= ctx->max_epoch)) {
@@ -1919,18 +1889,7 @@ static int zxc_encode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
             const uint32_t ml = m.len - ZXC_LZ_MIN_MATCH_LEN;
             const uint32_t off = (uint32_t)(ip - m.ref);
 
-            if (ll > 0) {
-                if (LIKELY(anchor + ZXC_PAD_SIZE <= iend)) {
-                    zxc_copy32(literals + lit_c, anchor);
-                    if (UNLIKELY(ll > ZXC_PAD_SIZE)) {
-                        ZXC_MEMCPY(literals + lit_c + ZXC_PAD_SIZE, anchor + ZXC_PAD_SIZE,
-                                   ll - ZXC_PAD_SIZE);
-                    }
-                } else {
-                    ZXC_MEMCPY(literals + lit_c, anchor, ll);
-                }
-                lit_c += ll;
-            }
+            if (ll > 0) zxc_flush_literals(literals, &lit_c, anchor, ll, iend);
 
             const uint32_t ll_write = (ll >= ZXC_SEQ_LL_MASK) ? 255U : ll;
             const uint32_t ml_write = (ml >= ZXC_SEQ_ML_MASK) ? 255U : ml;
@@ -1940,16 +1899,9 @@ static int zxc_encode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
             buf_sequences[seq_c] = seq_val;
             seq_c++;
 
-            if (ll >= ZXC_SEQ_LL_MASK) {
-                const size_t n = zxc_write_varint(buf_extras + extras_c, ll - ZXC_SEQ_LL_MASK);
-                if (UNLIKELY(n == 0)) return ZXC_ERROR_OVERFLOW;
-                extras_c += n;
-            }
-            if (ml >= ZXC_SEQ_ML_MASK) {
-                const size_t n = zxc_write_varint(buf_extras + extras_c, ml - ZXC_SEQ_ML_MASK);
-                if (UNLIKELY(n == 0)) return ZXC_ERROR_OVERFLOW;
-                extras_c += n;
-            }
+            if (UNLIKELY(!zxc_emit_extra(buf_extras, &extras_c, ll, ZXC_SEQ_LL_MASK) ||
+                         !zxc_emit_extra(buf_extras, &extras_c, ml, ZXC_SEQ_ML_MASK)))
+                return ZXC_ERROR_OVERFLOW;
 
             ip += m.len;
             anchor = ip;
@@ -1971,33 +1923,30 @@ static int zxc_encode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
     const zxc_gnr_header_t gh = {.n_sequences = seq_c,
                                  .n_literals = (uint32_t)lit_c,
                                  .enc_lit = ZXC_SECTION_ENCODING_RAW,
-                                 .enc_litlen = 0,
+                                 .enc_tok = 0,
                                  .enc_mlen = 0,
                                  .enc_off = 0};
 
-    zxc_section_desc_t desc[ZXC_GHI_SECTIONS] = {0};
-    desc[0].sizes = (uint64_t)lit_c | ((uint64_t)lit_c << 32);
-    size_t sz_seqs = seq_c * sizeof(uint32_t);
-    desc[1].sizes = (uint64_t)sz_seqs | ((uint64_t)sz_seqs << 32);
-    desc[2].sizes = (uint64_t)extras_c | ((uint64_t)extras_c << 32);
-
-    const int ghs = zxc_write_ghi_header_and_desc(p, rem, &gh, desc);
+    const int ghs = zxc_write_ghi_header(p, rem, &gh);
     if (UNLIKELY(ghs < 0)) return ghs;
 
     uint8_t* p_curr = p + ghs;
     rem -= ghs;
 
-    const size_t sz_lit = (size_t)(desc[0].sizes & ZXC_SECTION_SIZE_MASK);
-    const size_t sz_seq = (size_t)(desc[1].sizes & ZXC_SECTION_SIZE_MASK);
-    const size_t sz_ext = (size_t)(desc[2].sizes & ZXC_SECTION_SIZE_MASK);
+    const size_t sz_lit = lit_c;
+    const size_t sz_seq = seq_c * sizeof(uint32_t);
+    const size_t sz_ext = extras_c;
 
-    if (UNLIKELY(rem < sz_lit + sz_seq + sz_ext)) return ZXC_ERROR_DST_TOO_SMALL;
+    // See the GLO twin. GHI literals are always RAW, so the slack always
+    // matters here.
+    const size_t behind_lit = sz_seq + sz_ext;
+    const size_t pad = (behind_lit < ZXC_BLOCK_LIT_SLACK) ? ZXC_BLOCK_LIT_SLACK - behind_lit : 0;
+
+    if (UNLIKELY(rem < sz_lit + sz_seq + sz_ext + pad)) return ZXC_ERROR_DST_TOO_SMALL;
 
     ZXC_MEMCPY(p_curr, literals, lit_c);
     p_curr += lit_c;
-    rem -= sz_lit;
 
-    if (UNLIKELY(rem < sz_seq)) return ZXC_ERROR_DST_TOO_SMALL;
     // Write sequences in little-endian order
 #ifdef ZXC_BIG_ENDIAN
     for (uint32_t i = 0; i < seq_c; i++) {
@@ -2013,6 +1962,9 @@ static int zxc_encode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
     ZXC_MEMCPY(p_curr, buf_extras, sz_ext);
     p_curr += sz_ext;
 
+    ZXC_MEMSET(p_curr, 0, pad);
+    p_curr += pad;
+
     bh.comp_size = (uint32_t)(p_curr - (dst + ZXC_BLOCK_HEADER_SIZE));
     const int hw = zxc_write_block_header(dst, dst_cap, &bh);
     if (UNLIKELY(hw < 0)) return hw;
@@ -2023,11 +1975,9 @@ static int zxc_encode_block_ghi(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRIC
 }
 
 /**
- * @brief Encodes a raw data block (uncompressed).
+ * @brief Encodes a RAW (stored) block: header plus a verbatim copy.
  *
- * This function prepares and writes a "RAW" type block into the destination
- * buffer. It handles the block header and copying of source data; any checksum
- * is appended separately by the wrapper.
+ * Any block checksum is appended by the caller, not here.
  *
  * @param[in] src Pointer to the source data to encode.
  * @param[in] src_sz Size of the source data in bytes.
@@ -2067,17 +2017,12 @@ static int zxc_encode_block_raw(const uint8_t* RESTRICT src, const size_t src_sz
  * block when the coded form would not shrink the data. When @c ctx->dict_size
  * is > 0, @p chunk is the [dict | block] concat and only the block tail counts
  * toward the expansion check. Appends the per-block checksum when enabled.
- *
- * @param[in,out] ctx     Compression context (level, dict_size, checksum, buffers).
- * @param[in]     chunk   Source bytes ([dict | block] when a dictionary is active).
- * @param[in]     src_sz  Length of @p chunk in bytes (includes any dict prefix).
- * @param[out]    dst     Destination block buffer.
- * @param[in]     dst_cap Capacity of @p dst in bytes.
- * @return Compressed block size in bytes on success, or a negative @ref zxc_error_t.
  */
 // cppcheck-suppress unusedFunction
 int zxc_compress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT chunk,
                                const size_t src_sz, uint8_t* RESTRICT dst, const size_t dst_cap) {
+    if (UNLIKELY(dst_cap < ZXC_BLOCK_HEADER_SIZE)) return ZXC_ERROR_DST_TOO_SMALL;
+
     const size_t dict_sz = ctx->dict_size;
     const size_t block_sz = src_sz - dict_sz;
     const uint8_t* block_data = chunk + dict_sz;
@@ -2102,9 +2047,9 @@ int zxc_compress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT
             return ZXC_ERROR_OVERFLOW;
 
         uint32_t payload_sz = (uint32_t)(w - ZXC_BLOCK_HEADER_SIZE);
-        uint32_t crc =
+        uint32_t sum =
             zxc_checksum(dst + ZXC_BLOCK_HEADER_SIZE, payload_sz, ZXC_CHECKSUM_RAPIDHASH);
-        zxc_store_le32(dst + w, crc);
+        zxc_store_le32(dst + w, sum);
         w += ZXC_BLOCK_CHECKSUM_SIZE;
     }
 

--- a/lz/zxc/src/lib/zxc_decompress.c
+++ b/lz/zxc/src/lib/zxc_decompress.c
@@ -14,12 +14,10 @@
  * @c ZXC_FUNCTION_SUFFIX to produce per-ISA variants.
  */
 
-/*
- * Function Multi-Versioning Support
- * With ZXC_FUNCTION_SUFFIX defined (e.g. _avx2), rename the entry point AND the
- * Huffman decoder this TU consumes. The defines precede zxc_internal.h so the
- * header's prototypes get the suffix too, keeping callers and callees matched.
- */
+// Function Multi-Versioning Support
+// With ZXC_FUNCTION_SUFFIX defined (e.g. _avx2), rename the entry point AND the
+// Huffman decoder this TU consumes. The defines precede zxc_internal.h so the
+// header's prototypes get the suffix too, keeping callers and callees matched.
 #ifdef ZXC_FUNCTION_SUFFIX
 #define ZXC_CAT_IMPL(x, y) x##y
 #define ZXC_CAT(x, y) ZXC_CAT_IMPL(x, y)
@@ -36,11 +34,10 @@
 #include "zxc_internal.h"
 
 /**
- * @brief Reads a Prefix Varint encoded integer from a stream.
+ * @brief Reads a Prefix Varint encoded integer.
  *
- * This function decodes a 32-bit unsigned integer encoded in Prefix Varint format
- * from the provided byte stream. Unary prefix bits in the first byte determine
- * the total length (1-3 bytes).
+ * Unary prefix bits in the first byte give the total length, at most 3 bytes
+ * here since that covers every length this decoder can meet:
  *
  * Format:
  * - 1 byte  (0xxxxxxx):  7-bit payload (val < 2^7  = 128)
@@ -90,146 +87,291 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_read_varint(const uint8_t** ptr, const uin
     return 0;
 }
 
-/**
- * @brief Shuffle masks for overlapping copies with small offsets (0-15).
- *
- * Shared between ARM NEON and x86 SSSE3. Each row defines how to replicate
- * source bytes to fill 16 bytes when offset < 16.
- */
 #if defined(ZXC_USE_NEON64) || defined(ZXC_USE_NEON32) || defined(ZXC_USE_AVX2) || \
     defined(ZXC_USE_AVX512)
 /**
- * @brief Precomputed masks for handling overlapping data during decompression.
+ * @brief Periodic pattern masks, `mask[off][i] = i % off`, for off in [2, 31].
  *
- * This 16x16 lookup table contains 128-bit aligned masks used to efficiently
- * mask off or combine bytes when processing overlapping copy operations or
- * boundary conditions in the ZXC decompression algorithm.
- *
- * The alignment to 16 bytes ensures compatibility with SIMD instructions
- * (like SSE/AVX) for optimized memory operations.
+ * Rows 0 and 1 stay zero and unused: offset 1 is a byte splat, not a pattern.
  */
-static const ZXC_ALIGN(16) uint8_t zxc_overlap_masks[16][16] = {
-    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},      // off=0 (unused)
-    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},      // off=1 (RLE handled separately)
-    {0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1},      // off=2
-    {0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0},      // off=3
-    {0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3},      // off=4
-    {0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0},      // off=5
-    {0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3},      // off=6
-    {0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 0, 1},      // off=7
-    {0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7},      // off=8
-    {0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6},      // off=9
-    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5},      // off=10
-    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 1, 2, 3, 4},     // off=11
-    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0, 1, 2, 3},    // off=12
-    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2},   // off=13
-    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 0, 1},  // off=14
-    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 0}  // off=15
+static const ZXC_ALIGN(32) uint8_t zxc_overlap_masks32[32][32] = {
+    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},  // off=0 (unused)
+    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},  // off=1 (RLE handled separately)
+    {0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1,
+     0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1},  // off=2
+    {0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0,
+     1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1},  // off=3
+    {0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3,
+     0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3},  // off=4
+    {0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0,
+     1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1},  // off=5
+    {0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3,
+     4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1},  // off=6
+    {0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 0, 1,
+     2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3},  // off=7
+    {0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7,
+     0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7},  // off=8
+    {0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6,
+     7, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4},  // off=9
+    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5,
+     6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1},  // off=10
+    {0, 1, 2, 3, 4, 5,  6, 7, 8, 9, 10, 0, 1, 2, 3, 4,
+     5, 6, 7, 8, 9, 10, 0, 1, 2, 3, 4,  5, 6, 7, 8, 9},  // off=11
+    {0, 1, 2, 3, 4, 5, 6,  7,  8, 9, 10, 11, 0, 1, 2, 3,
+     4, 5, 6, 7, 8, 9, 10, 11, 0, 1, 2,  3,  4, 5, 6, 7},  // off=12
+    {0, 1, 2, 3, 4, 5, 6, 7,  8,  9,  10, 11, 12, 0, 1, 2,
+     3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0,  1,  2,  3, 4, 5},  // off=13
+    {0, 1, 2, 3, 4, 5, 6, 7, 8,  9,  10, 11, 12, 13, 0, 1,
+     2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 0,  1,  2, 3},  // off=14
+    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9,  10, 11, 12, 13, 14, 0,
+     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 0,  1},  // off=15
+    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},  // off=16
+    {0,  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+     16, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,  10, 11, 12, 13, 14},  // off=17
+    {0,  1,  2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+     16, 17, 0, 1, 2, 3, 4, 5, 6, 7, 8,  9,  10, 11, 12, 13},  // off=18
+    {0,  1,  2,  3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+     16, 17, 18, 0, 1, 2, 3, 4, 5, 6, 7,  8,  9,  10, 11, 12},  // off=19
+    {0,  1,  2,  3,  4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+     16, 17, 18, 19, 0, 1, 2, 3, 4, 5, 6,  7,  8,  9,  10, 11},  // off=20
+    {0,  1,  2,  3,  4,  5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+     16, 17, 18, 19, 20, 0, 1, 2, 3, 4, 5,  6,  7,  8,  9,  10},  // off=21
+    {0,  1,  2,  3,  4,  5,  6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+     16, 17, 18, 19, 20, 21, 0, 1, 2, 3, 4,  5,  6,  7,  8,  9},  // off=22
+    {0,  1,  2,  3,  4,  5,  6,  7, 8, 9, 10, 11, 12, 13, 14, 15,
+     16, 17, 18, 19, 20, 21, 22, 0, 1, 2, 3,  4,  5,  6,  7,  8},  // off=23
+    {0,  1,  2,  3,  4,  5,  6,  7,  8, 9, 10, 11, 12, 13, 14, 15,
+     16, 17, 18, 19, 20, 21, 22, 23, 0, 1, 2,  3,  4,  5,  6,  7},  // off=24
+    {0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
+     16, 17, 18, 19, 20, 21, 22, 23, 24, 0, 1,  2,  3,  4,  5,  6},  // off=25
+    {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
+     16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 0,  1,  2,  3,  4,  5},  // off=26
+    {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
+     16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 0,  1,  2,  3,  4},  // off=27
+    {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
+     16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 0,  1,  2,  3},  // off=28
+    {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
+     16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 0,  1,  2},  // off=29
+    {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
+     16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 0,  1},  // off=30
+    {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
+     16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 0}  // off=31
 };
 #endif
 
 /**
- * @brief Per-offset store stride for periodic overlap runs: the largest
- *        multiple of @c off that fits in 16 bytes, i.e. `16 - (16 % off)`.
+ * @brief Store stride for the 32-byte pattern: `(32 / off) * off`.
  *
- * Advancing the output cursor by a multiple of @c off keeps the 16-byte
- * pattern vector phase-aligned, so the run is emitted with pure stores of a
- * single register. Entries 0 and 1 are unused (RLE handled separately).
+ * Past 16 no second period fits, so the stride is the offset itself and each
+ * store's tail gets rewritten by the next one.
  */
-static const uint8_t zxc_overlap_strides[16] = {16, 16, 16, 15, 16, 15, 12, 14,
-                                                16, 9,  10, 11, 12, 13, 14, 15};
+static const uint8_t zxc_overlap_strides32[32] = {32, 32, 32, 30, 32, 30, 30, 28, 32, 27, 30,
+                                                  22, 24, 26, 28, 30, 32, 17, 18, 19, 20, 21,
+                                                  22, 23, 24, 25, 26, 27, 28, 29, 30, 31};
 
 /**
- * @brief Copies an @p ml-byte LZ run whose pattern repeats with period @p off (2..15).
+ * @brief Copies an @p ml-byte run of period @p off (2..31) with 32-byte stores.
  *
- * Builds the 16-byte periodic pattern `out[i] = dst[-off + (i % off)]` once
- * (one shuffle on NEON/SSSE3, a wrap-counter byte loop on the SSE2/scalar
- * tier), then emits 16-byte stores advancing by @ref zxc_overlap_strides so
- * the pattern never needs re-shuffling. May overshoot up to 15 bytes past
- * @p ml; the caller must guarantee @ref ZXC_PAD_SIZE bytes of headroom.
+ * Builds the run's first 32 bytes in a register pair, then stores them
+ * repeatedly. Nothing is re-shuffled: advancing by a multiple of @p off keeps
+ * the pattern in phase.
+ *
+ * Replaced a 16-byte form that reloaded the source every iteration, which for
+ * offsets of 17 and up straddled two of its own recent stores and stalled on
+ * store forwarding - worth up to 7x on periodic data.
+ *
+ * Reading 32 source bytes touches destination bytes not written yet on the
+ * smallest offsets. They are never selected (every mask index is `< off`) and
+ * sit inside the @ref ZXC_PAD_SIZE headroom the caller owes.
+ *
+ * May overshoot up to 31 bytes past @p ml, like the 32-byte copy ladder.
  *
  * @param[out] dst Output cursor; the run source is `dst - off`.
- * @param[in]  off Back-reference distance, in [2, 15].
+ * @param[in]  off Back-reference distance, in [2, 31].
  * @param[in]  ml  Run length in bytes (>= 1).
  */
 // codeql[cpp/unused-static-function] : False positive
-static ZXC_ALWAYS_INLINE void zxc_decode_copy_overlap_run(uint8_t* dst, const uint32_t off,
-                                                          const uint64_t ml) {
-    const size_t stride = zxc_overlap_strides[off];
+static ZXC_ALWAYS_INLINE void zxc_decode_copy_overlap_run32(uint8_t* dst, const uint32_t off,
+                                                            const uint64_t ml) {
+    const size_t stride = zxc_overlap_strides32[off];
     size_t copied = 0;
 #if defined(ZXC_USE_NEON64)
-    const uint8x16_t mask = vld1q_u8(zxc_overlap_masks[off]);
-    const uint8x16_t pat = vqtbl1q_u8(vld1q_u8(dst - off), mask);
+    uint8x16x2_t tbl;
+    tbl.val[0] = vld1q_u8(dst - off);
+    tbl.val[1] = vld1q_u8(dst - off + 16);
+    const uint8x16_t pat_lo = vqtbl2q_u8(tbl, vld1q_u8(zxc_overlap_masks32[off]));
+    const uint8x16_t pat_hi = vqtbl2q_u8(tbl, vld1q_u8(zxc_overlap_masks32[off] + 16));
     do {
-        vst1q_u8(dst + copied, pat);
+        vst1q_u8(dst + copied, pat_lo);
+        vst1q_u8(dst + copied + 16, pat_hi);
         copied += stride;
     } while (copied < ml);
 
 #elif defined(ZXC_USE_NEON32)
-    uint8x8x2_t src_tbl;
-    src_tbl.val[0] = vld1_u8(dst - off);
-    src_tbl.val[1] = vld1_u8(dst - off + 8);
-    const uint8x8_t pat_lo = vtbl2_u8(src_tbl, vld1_u8(zxc_overlap_masks[off]));
-    const uint8x8_t pat_hi = vtbl2_u8(src_tbl, vld1_u8(zxc_overlap_masks[off] + 8));
+    // VTBL reaches 8 bytes per lookup from a 4-register (32-byte) table, so the
+    // pattern takes four lookups instead of NEON64's two.
+    uint8x8x4_t tbl;
+    tbl.val[0] = vld1_u8(dst - off);
+    tbl.val[1] = vld1_u8(dst - off + 8);
+    tbl.val[2] = vld1_u8(dst - off + 16);
+    tbl.val[3] = vld1_u8(dst - off + 24);
+    const uint8_t* const m = zxc_overlap_masks32[off];
+    const uint8x8_t p0 = vtbl4_u8(tbl, vld1_u8(m));
+    const uint8x8_t p1 = vtbl4_u8(tbl, vld1_u8(m + 8));
+    const uint8x8_t p2 = vtbl4_u8(tbl, vld1_u8(m + 16));
+    const uint8x8_t p3 = vtbl4_u8(tbl, vld1_u8(m + 24));
     do {
-        vst1_u8(dst + copied, pat_lo);
-        vst1_u8(dst + copied + 8, pat_hi);
+        vst1_u8(dst + copied, p0);
+        vst1_u8(dst + copied + 8, p1);
+        vst1_u8(dst + copied + 16, p2);
+        vst1_u8(dst + copied + 24, p3);
         copied += stride;
     } while (copied < ml);
 
 #elif defined(ZXC_USE_AVX2) || defined(ZXC_USE_AVX512)
-    const __m128i mask = _mm_load_si128((const __m128i*)zxc_overlap_masks[off]);
-    const __m128i src_data = _mm_loadu_si128((const __m128i*)(dst - off));
-    const __m128i pat = _mm_shuffle_epi8(src_data, mask);
+    // pshufb only reaches 16 bytes per lane, so the 32-byte table is emulated:
+    // shuffle both halves, then pick per byte on bit 4 of the index.
+    const __m128i t0 = _mm_loadu_si128((const __m128i*)(dst - off));
+    const __m128i t1 = _mm_loadu_si128((const __m128i*)(dst - off + 16));
+    const __m128i sixteen = _mm_set1_epi8(16);
+    const __m128i m_lo = _mm_load_si128((const __m128i*)zxc_overlap_masks32[off]);
+    const __m128i m_hi = _mm_load_si128((const __m128i*)(zxc_overlap_masks32[off] + 16));
+    const __m128i pat_lo =
+        _mm_blendv_epi8(_mm_shuffle_epi8(t0, m_lo),
+                        _mm_shuffle_epi8(t1, _mm_sub_epi8(m_lo, sixteen)), _mm_slli_epi16(m_lo, 3));
+    const __m128i pat_hi =
+        _mm_blendv_epi8(_mm_shuffle_epi8(t0, m_hi),
+                        _mm_shuffle_epi8(t1, _mm_sub_epi8(m_hi, sixteen)), _mm_slli_epi16(m_hi, 3));
     do {
-        _mm_storeu_si128((__m128i*)(dst + copied), pat);
+        _mm_storeu_si128((__m128i*)(dst + copied), pat_lo);
+        _mm_storeu_si128((__m128i*)(dst + copied + 16), pat_hi);
         copied += stride;
     } while (copied < ml);
 
 #else
-    // SSE2-only tier and non-SIMD builds: no PSHUFB, build the pattern with a
-    // wrap counter (no per-byte modulo), then store it via zxc_copy16.
+    // SSE2 (no PSHUFB) and non-SIMD tiers: build the 32-byte pattern with a
+    // wrap counter (no per-byte modulo), then store it as two 16-byte halves.
     const uint8_t* src = dst - off;
-    uint8_t pat[16];
+    uint8_t pat[32];
     uint32_t k = 0;
-    for (size_t i = 0; i < 16; i++) {
+    for (size_t i = 0; i < 32; i++) {
         pat[i] = src[k];
         if (++k == off) k = 0;
     }
     do {
         zxc_copy16(dst + copied, pat);
+        zxc_copy16(dst + copied + 16, pat + 16);
         copied += stride;
     } while (copied < ml);
 #endif
 }
 
 /**
+ * @brief Overlap copy for a run of period @p off (2..31) bounded by @c ml <= 32.
+ *
+ * Bounded length buys two things over zxc_decode_copy_overlap_run32(): the
+ * loop disappears, and the upper 16 bytes are skipped whenever @p ml allows -
+ * which is most of the time, GLO matches averaging 7 to 11 bytes here.
+ *
+ * The lower half never needs the second source register: its mask indices are
+ * `i % off` for `i < 16`, hence always below 16. Only the upper half can reach
+ * past 15, and only when `off > 16`.
+ *
+ * Overshoots to 16 or 32 bytes, so the caller owes @ref ZXC_PAD_SIZE of
+ * headroom. Reading 32 source bytes is safe because no mask index reaches
+ * `dst` (all are `< off`).
+ *
+ * @param[out] dst Output cursor; the run source is `dst - off`.
+ * @param[in]  off Back-reference distance, in [2, 31].
+ * @param[in]  ml  Match length, `<= 32`.
+ */
+// codeql[cpp/unused-static-function] : False positive
+static ZXC_ALWAYS_INLINE void zxc_decode_copy_overlap_short(uint8_t* dst, const uint32_t off,
+                                                            const uint64_t ml) {
+#if defined(ZXC_USE_NEON64)
+    const uint8x16_t s0 = vld1q_u8(dst - off);
+    vst1q_u8(dst, vqtbl1q_u8(s0, vld1q_u8(zxc_overlap_masks32[off])));
+    if (UNLIKELY(ml > 16)) {
+        uint8x16x2_t tbl;
+        tbl.val[0] = s0;
+        tbl.val[1] = vld1q_u8(dst - off + 16);
+        vst1q_u8(dst + 16, vqtbl2q_u8(tbl, vld1q_u8(zxc_overlap_masks32[off] + 16)));
+    }
+
+#elif defined(ZXC_USE_NEON32)
+    uint8x8x2_t lo_tbl;
+    lo_tbl.val[0] = vld1_u8(dst - off);
+    lo_tbl.val[1] = vld1_u8(dst - off + 8);
+    const uint8_t* const m = zxc_overlap_masks32[off];
+    vst1_u8(dst, vtbl2_u8(lo_tbl, vld1_u8(m)));
+    vst1_u8(dst + 8, vtbl2_u8(lo_tbl, vld1_u8(m + 8)));
+    if (UNLIKELY(ml > 16)) {
+        uint8x8x4_t tbl;
+        tbl.val[0] = lo_tbl.val[0];
+        tbl.val[1] = lo_tbl.val[1];
+        tbl.val[2] = vld1_u8(dst - off + 16);
+        tbl.val[3] = vld1_u8(dst - off + 24);
+        vst1_u8(dst + 16, vtbl4_u8(tbl, vld1_u8(m + 16)));
+        vst1_u8(dst + 24, vtbl4_u8(tbl, vld1_u8(m + 24)));
+    }
+
+#elif defined(ZXC_USE_AVX2) || defined(ZXC_USE_AVX512)
+    // pshufb reaches 16 bytes, so only the upper half needs two tables: shuffle
+    // both and pick per byte on bit 4 of the index.
+    const __m128i t0 = _mm_loadu_si128((const __m128i*)(dst - off));
+    _mm_storeu_si128(
+        (__m128i*)dst,
+        _mm_shuffle_epi8(t0, _mm_load_si128((const __m128i*)zxc_overlap_masks32[off])));
+    if (UNLIKELY(ml > 16)) {
+        const __m128i t1 = _mm_loadu_si128((const __m128i*)(dst - off + 16));
+        const __m128i m_hi = _mm_load_si128((const __m128i*)(zxc_overlap_masks32[off] + 16));
+        _mm_storeu_si128(
+            (__m128i*)(dst + 16),
+            _mm_blendv_epi8(_mm_shuffle_epi8(t0, m_hi),
+                            _mm_shuffle_epi8(t1, _mm_sub_epi8(m_hi, _mm_set1_epi8(16))),
+                            _mm_slli_epi16(m_hi, 3)));
+    }
+
+#else
+    const uint8_t* src = dst - off;
+    const size_t n = (ml > 16) ? 32 : 16;
+    uint32_t k = 0;
+    for (size_t i = 0; i < n; i++) {
+        dst[i] = src[k];
+        if (++k == off) k = 0;
+    }
+#endif
+}
+
+/**
  * @brief Fills an @p ml-byte single-byte run (LZ offset == 1) with wild stores.
  *
- * Splats @p byte into a vector register and emits @ref ZXC_PAD_SIZE-byte
- * chunks, avoiding a libc memset call on the typically short runs of the hot
- * path. Like the other run copiers it may **overshoot** up to
- * @ref ZXC_PAD_SIZE - 1 bytes past @p ml; the caller must guarantee
- * @ref ZXC_PAD_SIZE bytes of headroom. Falls back to @ref ZXC_MEMSET on
- * non-SIMD builds.
+ * Splats @p byte into a vector register and emits 32-byte chunks, avoiding a
+ * libc memset call on the typically short runs of the hot path. Like the other
+ * run copiers it may **overshoot** up to 31 bytes past @p ml; the caller must
+ * guarantee @ref ZXC_PAD_SIZE bytes of headroom. Falls back to
+ * `ZXC_MEMSET` on non-SIMD builds.
  *
  * @param[out] dst  Output cursor.
  * @param[in]  byte Byte value to replicate.
  * @param[in]  ml   Run length in bytes (>= 1).
  */
-// codeql[cpp/unused-static-function] : False positive, used in DECODE_SEQ_SAFE/FAST macros
+// codeql[cpp/unused-static-function] : False positive, used in DECODE_MATCH_SAFE/FAST macros
 static ZXC_ALWAYS_INLINE void zxc_decode_fill_run(uint8_t* dst, const uint8_t byte,
                                                   const uint64_t ml) {
 #if defined(ZXC_USE_AVX2) || defined(ZXC_USE_AVX512)
     const __m256i v = _mm256_set1_epi8((char)byte);
     _mm256_storeu_si256((__m256i*)dst, v);
-    if (UNLIKELY(ml > ZXC_PAD_SIZE)) {
-        uint8_t* out = dst + ZXC_PAD_SIZE;
-        size_t rem = ml - ZXC_PAD_SIZE;
-        while (rem > ZXC_PAD_SIZE) {
+    if (UNLIKELY(ml > 32)) {
+        uint8_t* out = dst + 32;
+        size_t rem = ml - 32;
+        while (rem > 32) {
             _mm256_storeu_si256((__m256i*)out, v);
-            out += ZXC_PAD_SIZE;
-            rem -= ZXC_PAD_SIZE;
+            out += 32;
+            rem -= 32;
         }
         _mm256_storeu_si256((__m256i*)out, v);
     }
@@ -237,14 +379,14 @@ static ZXC_ALWAYS_INLINE void zxc_decode_fill_run(uint8_t* dst, const uint8_t by
     const __m128i v = _mm_set1_epi8((char)byte);
     _mm_storeu_si128((__m128i*)dst, v);
     _mm_storeu_si128((__m128i*)(dst + 16), v);
-    if (UNLIKELY(ml > ZXC_PAD_SIZE)) {
-        uint8_t* out = dst + ZXC_PAD_SIZE;
-        size_t rem = ml - ZXC_PAD_SIZE;
-        while (rem > ZXC_PAD_SIZE) {
+    if (UNLIKELY(ml > 32)) {
+        uint8_t* out = dst + 32;
+        size_t rem = ml - 32;
+        while (rem > 32) {
             _mm_storeu_si128((__m128i*)out, v);
             _mm_storeu_si128((__m128i*)(out + 16), v);
-            out += ZXC_PAD_SIZE;
-            rem -= ZXC_PAD_SIZE;
+            out += 32;
+            rem -= 32;
         }
         _mm_storeu_si128((__m128i*)out, v);
         _mm_storeu_si128((__m128i*)(out + 16), v);
@@ -253,14 +395,14 @@ static ZXC_ALWAYS_INLINE void zxc_decode_fill_run(uint8_t* dst, const uint8_t by
     const uint8x16_t v = vdupq_n_u8(byte);
     vst1q_u8(dst, v);
     vst1q_u8(dst + 16, v);
-    if (UNLIKELY(ml > ZXC_PAD_SIZE)) {
-        uint8_t* out = dst + ZXC_PAD_SIZE;
-        size_t rem = ml - ZXC_PAD_SIZE;
-        while (rem > ZXC_PAD_SIZE) {
+    if (UNLIKELY(ml > 32)) {
+        uint8_t* out = dst + 32;
+        size_t rem = ml - 32;
+        while (rem > 32) {
             vst1q_u8(out, v);
             vst1q_u8(out + 16, v);
-            out += ZXC_PAD_SIZE;
-            rem -= ZXC_PAD_SIZE;
+            out += 32;
+            rem -= 32;
         }
         vst1q_u8(out, v);
         vst1q_u8(out + 16, v);
@@ -270,22 +412,22 @@ static ZXC_ALWAYS_INLINE void zxc_decode_fill_run(uint8_t* dst, const uint8_t by
 #endif
 }
 
-/* ==========================================================================
- * Shared decode macros for the GLO and GHI decoders (fast + safe variants).
- * Defined at file scope to avoid four identical copies inside each function.
- * They reference the local names l_ptr, d_ptr, d_floor that every call site
- * has in scope. #undef-ed at the end of the last consumer.
- * ========================================================================== */
+// ==========================================================================
+// Shared decode macros for the GLO and GHI decoders (fast + safe variants).
+// Defined at file scope to avoid four identical copies inside each function.
+// They reference the local names l_ptr, d_ptr, d_floor that every call site
+// has in scope. #undef-ed at the end of the last consumer.
+// ==========================================================================
 
 /**
  * @brief Copies @p ll literal bytes from @p src to @p dst using 32-byte wild copies.
  *
- * Writes in @ref ZXC_PAD_SIZE-byte chunks and may **overshoot** by up to
- * @ref ZXC_PAD_SIZE - 1 bytes past @p ll; the caller must guarantee @p dst has at
- * least @ref ZXC_PAD_SIZE bytes of writable headroom (the unrolled loops and the
- * trailing-literal margins ensure this). Pointers are taken by value and the
- * caller advances its own cursors by @p ll, keeping them in registers on the hot
- * path.
+ * Writes in 32-byte chunks -- the width of @ref zxc_copy32 -- and may
+ * **overshoot** by up to 31 bytes past @p ll; the caller must guarantee @p dst
+ * has at least @ref ZXC_PAD_SIZE bytes of writable headroom (the unrolled loops
+ * and the trailing-literal margins ensure this). Pointers are taken by value and
+ * the caller advances its own cursors by @p ll, keeping them in registers on the
+ * hot path.
  *
  * @param[out] dst Output cursor. Must not overlap @p src and must have
  *                 @ref ZXC_PAD_SIZE bytes of overshoot headroom.
@@ -296,15 +438,15 @@ static ZXC_ALWAYS_INLINE void zxc_decode_copy_literals(uint8_t* RESTRICT dst,
                                                        const uint8_t* RESTRICT src,
                                                        const uint64_t ll) {
     zxc_copy32(dst, src);
-    if (UNLIKELY(ll > ZXC_PAD_SIZE)) {
-        dst += ZXC_PAD_SIZE;
-        src += ZXC_PAD_SIZE;
-        size_t rem = ll - ZXC_PAD_SIZE;
-        while (rem > ZXC_PAD_SIZE) {
+    if (UNLIKELY(ll > 32)) {
+        dst += 32;
+        src += 32;
+        size_t rem = ll - 32;
+        while (rem > 32) {
             zxc_copy32(dst, src);
-            dst += ZXC_PAD_SIZE;
-            src += ZXC_PAD_SIZE;
-            rem -= ZXC_PAD_SIZE;
+            dst += 32;
+            src += 32;
+            rem -= 32;
         }
         zxc_copy32(dst, src);
     }
@@ -315,13 +457,17 @@ static ZXC_ALWAYS_INLINE void zxc_decode_copy_literals(uint8_t* RESTRICT dst,
  *
  * The source @c d_ptr-off may overlap the destination (the LZ repeat case), so the
  * copy strategy is chosen by back-reference distance:
- *  - @p off >= @ref ZXC_PAD_SIZE      : 32-byte wild copies (no overlap within a chunk);
- *  - @p off >= @ref ZXC_PAD_SIZE / 2  : 16-byte wild copies;
- *  - @p off == 1                      : single-byte run via @ref zxc_decode_fill_run;
- *  - otherwise (2..15)                : pattern-replicating overlap copy.
+ *  - @p off >= 32   : 32-byte wild copies (no overlap within a chunk);
+ *  - @p off == 1    : single-byte run via @ref zxc_decode_fill_run;
+ *  - otherwise 2-31 : pattern-replicating overlap copy.
  *
- * Like @ref zxc_decode_copy_literals it may **overshoot** up to @ref ZXC_PAD_SIZE - 1
- * bytes past @p ml, so @p d_ptr must have @ref ZXC_PAD_SIZE bytes of headroom. @p d_ptr
+ * The 32 and 16 below are the widths of @ref zxc_copy32 and @ref zxc_copy16 --
+ * a copy may never be wider than the distance it reads back, or it would read
+ * bytes it is still writing. They are not @ref ZXC_PAD_SIZE, which measures the
+ * overshoot the caller leaves writable and merely happens to equal 32.
+ *
+ * Like @ref zxc_decode_copy_literals it may **overshoot** up to 31 bytes past
+ * @p ml, so @p d_ptr must have @ref ZXC_PAD_SIZE bytes of headroom. @p d_ptr
  * is taken by value; the caller advances its cursor by @p ml.
  *
  * @param[in,out] d_ptr Output cursor; the match source is @c d_ptr-off. Must have
@@ -332,38 +478,67 @@ static ZXC_ALWAYS_INLINE void zxc_decode_copy_literals(uint8_t* RESTRICT dst,
 static ZXC_ALWAYS_INLINE void zxc_decode_copy_match(uint8_t* RESTRICT d_ptr, const uint32_t off,
                                                     const uint64_t ml) {
     const uint8_t* match_src = d_ptr - off;
-    if (LIKELY(off >= ZXC_PAD_SIZE)) {
+    if (LIKELY(off >= 32)) {
         zxc_copy32(d_ptr, match_src);
-        if (UNLIKELY(ml > ZXC_PAD_SIZE)) {
-            uint8_t* out = d_ptr + ZXC_PAD_SIZE;
-            const uint8_t* ref = match_src + ZXC_PAD_SIZE;
-            size_t rem = ml - ZXC_PAD_SIZE;
-            while (rem > ZXC_PAD_SIZE) {
+        if (UNLIKELY(ml > 32)) {
+            uint8_t* out = d_ptr + 32;
+            const uint8_t* ref = match_src + 32;
+            size_t rem = ml - 32;
+            while (rem > 32) {
                 zxc_copy32(out, ref);
-                out += ZXC_PAD_SIZE;
-                ref += ZXC_PAD_SIZE;
-                rem -= ZXC_PAD_SIZE;
+                out += 32;
+                ref += 32;
+                rem -= 32;
             }
             zxc_copy32(out, ref);
-        }
-    } else if (off >= (ZXC_PAD_SIZE / 2)) {
-        zxc_copy16(d_ptr, match_src);
-        if (UNLIKELY(ml > (ZXC_PAD_SIZE / 2))) {
-            uint8_t* out = d_ptr + (ZXC_PAD_SIZE / 2);
-            const uint8_t* ref = match_src + (ZXC_PAD_SIZE / 2);
-            size_t rem = ml - (ZXC_PAD_SIZE / 2);
-            while (rem > (ZXC_PAD_SIZE / 2)) {
-                zxc_copy16(out, ref);
-                out += (ZXC_PAD_SIZE / 2);
-                ref += (ZXC_PAD_SIZE / 2);
-                rem -= (ZXC_PAD_SIZE / 2);
-            }
-            zxc_copy16(out, ref);
         }
     } else if (off == 1) {
         zxc_decode_fill_run(d_ptr, match_src[0], ml);
     } else {
-        zxc_decode_copy_overlap_run(d_ptr, off, ml);
+        zxc_decode_copy_overlap_run32(d_ptr, off, ml);
+    }
+}
+
+/**
+ * @brief Match copy for a length that cannot exceed 32 bytes.
+ *
+ * @ref zxc_decode_copy_match without its length ladder, which a bounded @p ml
+ * makes unreachable. Below 32 a full-width copy would read destination bytes
+ * not written yet, hence the overlap form.
+ *
+ * The 32 is the width of @ref zxc_copy32, not @ref ZXC_PAD_SIZE - they only
+ * happen to share a value.
+ *
+ * @param[in,out] d_ptr Output cursor; match source is @c d_ptr-off. Needs
+ *                      @ref ZXC_PAD_SIZE bytes of overshoot headroom.
+ * @param[in]     off   Resolved back-reference distance, @c >= 1.
+ * @param[in]     ml    Match length, @c <= 32 (caller's obligation).
+ */
+static ZXC_ALWAYS_INLINE void zxc_decode_copy_match_short(uint8_t* RESTRICT d_ptr,
+                                                          const uint32_t off, const uint64_t ml) {
+    const uint8_t* match_src = d_ptr - off;
+    if (LIKELY(off >= 32)) {
+        zxc_copy32(d_ptr, match_src);
+    } else if (off == 1) {
+        zxc_decode_fill_run(d_ptr, match_src[0], ml);
+    } else {
+        zxc_decode_copy_overlap_short(d_ptr, off, ml);
+    }
+}
+
+/**
+ * @brief GLO match copy: bounded form when the ml nibble did not saturate.
+ *
+ * The test is exact (the escape always yields more) and statically decidable
+ * from either predecessor, so jump threading folds it away. GHI uses
+ * @ref zxc_decode_copy_match directly - its inline ml reaches 259.
+ */
+static ZXC_ALWAYS_INLINE void zxc_decode_copy_match_glo(uint8_t* RESTRICT d_ptr, const uint32_t off,
+                                                        const uint64_t ml) {
+    if (LIKELY(ml <= ZXC_GLO_MAX_INLINE_ML)) {
+        zxc_decode_copy_match_short(d_ptr, off, ml);
+    } else {
+        zxc_decode_copy_match(d_ptr, off, ml);
     }
 }
 
@@ -400,26 +575,26 @@ static ZXC_NOINLINE void zxc_decode_copy_match_exact(uint8_t* d_ptr, const uint8
     }
 }
 
-// SAFE version: rejects a match reaching below d_floor.
-#define DECODE_SEQ_SAFE(ll, ml, off)                                                  \
+// Match emission only. The literal copy lives in the per-format sequence macros
+// because the two formats want different strategies: GLO's inline ll is at most
+// 14, so one zxc_copy16 covers it, while GHI's reaches 254 and needs the
+// 32-byte ladder.
+
+// SAFE version: rejects a match reaching below d_floor. COPY is the format's
+// match-copy helper, so GLO can pass the length-bounded one.
+#define DECODE_MATCH_SAFE(ml, off, COPY)                                              \
     do {                                                                              \
-        zxc_decode_copy_literals(d_ptr, l_ptr, ll);                                   \
-        l_ptr += ll;                                                                  \
-        d_ptr += ll;                                                                  \
         if (UNLIKELY((size_t)(d_ptr - d_floor) < (off))) return ZXC_ERROR_BAD_OFFSET; \
-        zxc_decode_copy_match(d_ptr, off, ml);                                        \
+        COPY(d_ptr, off, ml);                                                         \
         d_ptr += ml;                                                                  \
     } while (0)
 
 // FAST version: no offset check. Only reached past d_bounds, where no encodable
 // offset can reach below d_floor, so the check above would always pass.
-#define DECODE_SEQ_FAST(ll, ml, off)                \
-    do {                                            \
-        zxc_decode_copy_literals(d_ptr, l_ptr, ll); \
-        l_ptr += ll;                                \
-        d_ptr += ll;                                \
-        zxc_decode_copy_match(d_ptr, off, ml);      \
-        d_ptr += ml;                                \
+#define DECODE_MATCH_FAST(ml, off, COPY) \
+    do {                                 \
+        COPY(d_ptr, off, ml);            \
+        d_ptr += ml;                     \
     } while (0)
 
 /**
@@ -439,7 +614,7 @@ static ZXC_NOINLINE void zxc_decode_copy_match_exact(uint8_t* d_ptr, const uint8
  * @brief Decodes one GLO sequence of a 4x batch: extracts ll/ml, applies the
  *        varint extensions with their bounds checks, then emits via @p DECODE.
  *
- * Like @ref DECODE_SEQ_SAFE, references the call site's local names (e_ptr,
+ * Like `DECODE_MATCH_SAFE`, references the call site's local names (e_ptr,
  * e_end, l_ptr, l_end, d_ptr, d_end). @p RESERVE is the sum of the inline
  * (pre-varint) literal lengths of the batch's remaining sequences, so one
  * l_ptr bound covers the whole batch; @p N_REM counts the remaining
@@ -447,30 +622,39 @@ static ZXC_NOINLINE void zxc_decode_copy_match_exact(uint8_t* d_ptr, const uint8
  * (0 for the last sequence - the compiler folds the dead terms). @p ON_FAIL
  * is `goto rollback_*` in the state-saving safe variants and
  * `return ZXC_ERROR_OVERFLOW` otherwise.
- *
  */
-#define DECODE_GLO_SEQ(LL, ML, OFF, RESERVE, N_REM, DECODE, ON_FAIL)                       \
-    do {                                                                                   \
-        uint64_t ll = (LL);                                                                \
-        uint64_t ml = (ML);                                                                \
-        if (UNLIKELY(ll == ZXC_TOKEN_LL_MASK)) {                                           \
-            ll += zxc_read_varint(&e_ptr, e_end);                                          \
-            const uint64_t reserve = (RESERVE);                                            \
-            if (UNLIKELY(ll + reserve > (size_t)(l_end - l_ptr) ||                         \
-                         ll + ml + ZXC_LZ_MIN_MATCH_LEN +                                  \
-                                 (N_REM) * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE > \
-                             (size_t)(d_end - d_ptr)))                                     \
-                ON_FAIL;                                                                   \
-        }                                                                                  \
-        if (UNLIKELY(ml == ZXC_TOKEN_ML_MASK)) {                                           \
-            ml += zxc_read_varint(&e_ptr, e_end);                                          \
-            if (UNLIKELY(ll + ml + ZXC_LZ_MIN_MATCH_LEN +                                  \
-                             (N_REM) * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >     \
-                         (size_t)(d_end - d_ptr)))                                         \
-                ON_FAIL;                                                                   \
-        }                                                                                  \
-        ml += ZXC_LZ_MIN_MATCH_LEN;                                                        \
-        DECODE(ll, ml, OFF);                                                               \
+#define DECODE_GLO_SEQ(LL, ML, OFF, RESERVE, N_REM, DECODE, ON_FAIL)                            \
+    do {                                                                                        \
+        uint64_t ll = (LL);                                                                     \
+        uint64_t ml = (ML);                                                                     \
+        if (UNLIKELY(ll == ZXC_TOKEN_LL_MASK)) {                                                \
+            ll += zxc_read_varint(&e_ptr, e_end);                                               \
+            const uint64_t reserve = (RESERVE);                                                 \
+            /* An extended ll eats the batch's destination budget, so reserve                   \
+             * this sequence's match and the remaining ones too. ml is still                    \
+             * the raw nibble here; an escaped one re-checks itself below. */                   \
+            if (UNLIKELY(ll + reserve > (size_t)(l_end - l_ptr) ||                              \
+                         ll + ml + ZXC_LZ_MIN_MATCH_LEN +                                       \
+                                 (N_REM) * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE >      \
+                             (size_t)(d_end - d_ptr)))                                          \
+                ON_FAIL;                                                                        \
+            zxc_decode_copy_literals(d_ptr, l_ptr, ll);                                         \
+        } else {                                                                                \
+            /* ll <= 14 here, so one 16-byte store covers it. */                                \
+            zxc_copy16(d_ptr, l_ptr);                                                           \
+        }                                                                                       \
+        l_ptr += ll;                                                                            \
+        d_ptr += ll;                                                                            \
+        if (UNLIKELY(ml == ZXC_TOKEN_ML_MASK)) {                                                \
+            ml += zxc_read_varint(&e_ptr, e_end);                                               \
+            /* d_ptr already carries the literals, hence no `ll +` term here. */                \
+            if (UNLIKELY(ml + ZXC_LZ_MIN_MATCH_LEN + (N_REM) * ZXC_GLO_MAX_INLINE_OUT_PER_SEQ + \
+                             ZXC_PAD_SIZE >                                                     \
+                         (size_t)(d_end - d_ptr)))                                              \
+                ON_FAIL;                                                                        \
+        }                                                                                       \
+        ml += ZXC_LZ_MIN_MATCH_LEN;                                                             \
+        DECODE(ml, OFF, zxc_decode_copy_match_glo);                                             \
     } while (0)
 
 /**
@@ -522,6 +706,7 @@ static ZXC_NOINLINE void zxc_decode_copy_match_exact(uint8_t* d_ptr, const uint8
         if (UNLIKELY(ll == ZXC_SEQ_LL_MASK)) {                                               \
             ll += zxc_read_varint(&extras_ptr, extras_end);                                  \
             const uint64_t reserve = (RESERVE);                                              \
+            /* Same reservation as the GLO twin; GHI's inline ml reaches 259. */             \
             if (UNLIKELY(ll + reserve > (size_t)(l_end - l_ptr) ||                           \
                          ll + ml + (N_REM) * ZXC_GHI_MAX_INLINE_OUT_PER_SEQ + ZXC_PAD_SIZE > \
                              (size_t)(d_end - d_ptr)))                                       \
@@ -534,7 +719,11 @@ static ZXC_NOINLINE void zxc_decode_copy_match_exact(uint8_t* d_ptr, const uint8
                 ON_FAIL;                                                                     \
         }                                                                                    \
         const uint32_t off = ((S) & 0xFFFF) + ZXC_LZ_OFFSET_BIAS;                            \
-        DECODE(ll, ml, off);                                                                 \
+        /* GHI keeps the ladder: its inline ll reaches 254. */                               \
+        zxc_decode_copy_literals(d_ptr, l_ptr, ll);                                          \
+        l_ptr += ll;                                                                         \
+        d_ptr += ll;                                                                         \
+        DECODE(ml, off, zxc_decode_copy_match);                                              \
     } while (0)
 
 /**
@@ -574,36 +763,6 @@ static ZXC_NOINLINE void zxc_decode_copy_match_exact(uint8_t* d_ptr, const uint8
 static ZXC_NOINLINE ZXC_COLD int zxc_ensure_entropy_scratch(const zxc_cctx_t* RESTRICT ctx) {
     if (LIKELY(ctx->pivco_scratch != NULL)) return ZXC_OK;
     return zxc_cctx_alloc_entropy_scratch((zxc_cctx_t*)(uintptr_t)ctx);
-}
-
-/**
- * @brief Stages a RAW literal stream into the padded @c lit_buffer.
- *
- * @ref zxc_decode_copy_literals wild-copies in @ref ZXC_PAD_SIZE chunks and
- * reads that far past the literals it consumes. Decoded streams land in
- * @c lit_buffer, which is allocated with the padding; a RAW stream instead
- * points into the caller's buffer, where the overshoot is only covered by the
- * block's remaining sections. Callers stage the stream here when those are
- * shorter than @ref ZXC_PAD_SIZE.
- *
- * @param[in]     ctx   Decompression context (owns @c lit_buffer).
- * @param[in,out] l_ptr Literal cursor; re-pointed at the staged copy.
- * @param[in,out] l_end Literal end; re-pointed at the staged copy.
- * @return @ref ZXC_OK, or @ref ZXC_ERROR_CORRUPT_DATA if the stream cannot fit
- *         (a valid block's literals never exceed the chunk size).
- */
-static ZXC_NOINLINE ZXC_COLD int zxc_stage_raw_literals(const zxc_cctx_t* RESTRICT ctx,
-                                                        const uint8_t** RESTRICT l_ptr,
-                                                        const uint8_t** RESTRICT l_end) {
-    const size_t lit_size = (size_t)(*l_end - *l_ptr);
-    uint8_t* const stage = ctx->lit_buffer;
-    if (UNLIKELY(!stage || ctx->lit_buffer_cap < lit_size + ZXC_PAD_SIZE))
-        return ZXC_ERROR_CORRUPT_DATA;
-
-    ZXC_MEMCPY(stage, *l_ptr, lit_size);
-    *l_ptr = stage;
-    *l_end = stage + lit_size;
-    return ZXC_OK;
 }
 
 static ZXC_NOINLINE ZXC_COLD int zxc_decode_lit_pivco(const zxc_cctx_t* RESTRICT ctx,
@@ -661,8 +820,8 @@ static ZXC_NOINLINE int zxc_decode_block_glo_entropy_safe(const zxc_cctx_t* REST
  * @brief Unified GLO (General Low) block decoder body, shared by the fast,
  *        safe, dictionary and entropy-token variants.
  *
- * Decodes a block in the internal GLO format; the decompressed size is derived
- * from the Section Descriptors in the payload. @p safe, @p has_dict and
+ * Decodes a block in the internal GLO format. The decompressed size is not on
+ * the wire: it falls out of walking the sequences. @p safe, @p has_dict and
  * @p tok_entropy must be compile-time constants (0 or 1): the 4x-unrolled
  * loops are duplicated inside @c if(safe)/else branches so each variant keeps
  * single-assignment @c const save pointers, and after constant propagation
@@ -672,7 +831,7 @@ static ZXC_NOINLINE int zxc_decode_block_glo_entropy_safe(const zxc_cctx_t* REST
  * The @p tok_entropy dimension keeps the token pointer on a SINGLE provenance
  * per instantiation (in-place @c src tokens vs @c ctx->tok_buffer): the
  * tok_entropy=0 instantiations tail-call their entropy twin right after the
- * header parse when they meet enc_litlen == 2.
+ * header parse when they meet enc_tok == 2.
  *
  * @param[in,out] ctx          Decompression context (dict buffer, scratch).
  * @param[in]     src          Compressed block payload.
@@ -692,26 +851,29 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
                                                        const int has_dict, const int tok_entropy) {
     zxc_gnr_header_t gh;
 
-    /* Constant 0 when !has_dict, so `d_floor` folds to `dst`. */
+    // Constant 0 when !has_dict, so `d_floor` folds to `dst`.
     const size_t dict_size = has_dict ? ctx->dict_size : 0;
-    zxc_section_desc_t desc[ZXC_GLO_SECTIONS];
+    uint32_t lit_comp;
+    uint32_t tok_comp;
 
-    if (UNLIKELY(zxc_read_glo_header_and_desc(src, src_size, &gh, desc) != ZXC_OK))
-        return ZXC_ERROR_BAD_HEADER;
+    const int hdr_sz = zxc_read_glo_header_and_desc(src, src_size, &gh, &lit_comp, &tok_comp);
+    if (UNLIKELY(hdr_sz < 0)) return ZXC_ERROR_BAD_HEADER;
 
-    /* Entropy-coded tokens (level 7): tail-call the dedicated instantiation
-     * before any section work - it restarts from the header, so only the parse
-     * above is duplicated. Flags are constant per instantiation, so exactly one
-     * call survives and t_ptr keeps a single provenance below. */
-    if (!tok_entropy && UNLIKELY(gh.enc_litlen == ZXC_SECTION_ENCODING_HUFFMAN)) {
+    // Only 0 and 1 are defined widths.
+    if (UNLIKELY(gh.enc_off > 1)) return ZXC_ERROR_CORRUPT_DATA;
+
+    // Entropy-coded tokens (level 7): tail-call the dedicated instantiation
+    // before any section work - it restarts from the header, so only the parse
+    // above is duplicated. Flags are constant per instantiation, so exactly one
+    // call survives and t_ptr keeps a single provenance below.
+    if (!tok_entropy && UNLIKELY(gh.enc_tok == ZXC_SECTION_ENCODING_HUFFMAN)) {
         if (safe) return zxc_decode_block_glo_entropy_safe(ctx, src, src_size, dst, dst_capacity);
         if (has_dict)
             return zxc_decode_block_glo_entropy_dict(ctx, src, src_size, dst, dst_capacity);
         return zxc_decode_block_glo_entropy(ctx, src, src_size, dst, dst_capacity);
     }
 
-    const uint8_t* p_data =
-        src + ZXC_GLO_HEADER_BINARY_SIZE + ZXC_GLO_SECTIONS * ZXC_SECTION_DESC_BINARY_SIZE;
+    const uint8_t* p_data = src + (size_t)hdr_sz;
     const uint8_t* p_curr = p_data;
 
     // --- Literal Stream Setup ---
@@ -719,9 +881,9 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
     const uint8_t* l_end;
     uint8_t* rle_buf = NULL;
 
-    size_t lit_stream_size = (size_t)(desc[0].sizes & ZXC_SECTION_SIZE_MASK);
-    /* Decoded size of an encoded literal section (RAW ignores it). */
-    const size_t required_size = (size_t)(desc[0].sizes >> 32);
+    size_t lit_stream_size = lit_comp;
+    // Decoded size of an encoded literal section (RAW ignores it).
+    const size_t required_size = gh.n_literals;
 
     if (gh.enc_lit == ZXC_SECTION_ENCODING_HUFFMAN ||
         gh.enc_lit == ZXC_SECTION_ENCODING_HUFFMAN_DICT) {
@@ -747,8 +909,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
                 return ZXC_ERROR_DST_TOO_SMALL;
             const size_t alloc_size = required_size + ZXC_PAD_SIZE;
 
-            /* lit_buffer is pre-allocated to chunk_size + ZXC_PAD_SIZE by
-             * zxc_cctx_init (mode == 0).*/
+            // lit_buffer is pre-allocated to chunk_size + ZXC_PAD_SIZE by
+            // zxc_cctx_init (mode == 0).
             if (UNLIKELY(ctx->lit_buffer_cap < alloc_size)) return ZXC_ERROR_CORRUPT_DATA;
 
             rle_buf = ctx->lit_buffer;
@@ -763,7 +925,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
             while (r_ptr < r_end && w_ptr < w_end) {
                 uint8_t token = *r_ptr++;
                 if (LIKELY(!(token & ZXC_LIT_RLE_FLAG))) {
-                    // Raw copy (most common path): use ZXC_PAD_SIZE-byte wild copies
+                    // Raw copy (most common path): 32-byte wild copies (zxc_copy32 width)
                     // token is 7-bit (0-127), so len is 1-128 bytes
                     const uint32_t len = (uint32_t)token + 1;
                     if (UNLIKELY(w_ptr + len > w_end || r_ptr + len > r_end))
@@ -771,23 +933,24 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
 
                     // Destination has ZXC_PAD_SIZE bytes of safe overrun space.
                     // Source may not - check before wild copy.
-                    // Fast path: source has ZXC_PAD_SIZE-byte read headroom (most common)
-                    if (LIKELY(r_ptr + ZXC_PAD_SIZE <= r_end)) {
-                        // Single 32-byte copy covers len <= ZXC_PAD_SIZE (most tokens)
+                    // Fast path: source holds a full zxc_copy32 read (most common)
+                    if (LIKELY(r_ptr + 32 <= r_end)) {
+                        // Single copy covers len <= 32 (most tokens)
                         zxc_copy32(w_ptr, r_ptr);
 
-                        if (UNLIKELY(len > ZXC_PAD_SIZE)) {
-                            // Unroll: max len=128, so max 4 copies total
-                            // Use unconditional stores with overlap - faster than branches
-                            if (len <= 2 * ZXC_PAD_SIZE) {
-                                zxc_copy32(w_ptr + len - ZXC_PAD_SIZE, r_ptr + len - ZXC_PAD_SIZE);
-                            } else if (len <= 3 * ZXC_PAD_SIZE) {
-                                zxc_copy32(w_ptr + ZXC_PAD_SIZE, r_ptr + ZXC_PAD_SIZE);
-                                zxc_copy32(w_ptr + len - ZXC_PAD_SIZE, r_ptr + len - ZXC_PAD_SIZE);
+                        if (UNLIKELY(len > 32)) {
+                            // Unroll: max len=128, so max 4 copies total. The last
+                            // copy is placed to end exactly on len, overlapping the
+                            // previous one - unconditional stores beat branches here.
+                            if (len <= 64) {
+                                zxc_copy32(w_ptr + len - 32, r_ptr + len - 32);
+                            } else if (len <= 96) {
+                                zxc_copy32(w_ptr + 32, r_ptr + 32);
+                                zxc_copy32(w_ptr + len - 32, r_ptr + len - 32);
                             } else {
-                                zxc_copy32(w_ptr + ZXC_PAD_SIZE, r_ptr + ZXC_PAD_SIZE);
-                                zxc_copy32(w_ptr + 2 * ZXC_PAD_SIZE, r_ptr + 2 * ZXC_PAD_SIZE);
-                                zxc_copy32(w_ptr + len - ZXC_PAD_SIZE, r_ptr + len - ZXC_PAD_SIZE);
+                                zxc_copy32(w_ptr + 32, r_ptr + 32);
+                                zxc_copy32(w_ptr + 64, r_ptr + 64);
+                                zxc_copy32(w_ptr + len - 32, r_ptr + len - 32);
                             }
                         }
                     } else {
@@ -823,37 +986,37 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
     p_curr += lit_stream_size;
 
     // --- Stream Pointers & Validation ---
-    const size_t sz_tokens = (size_t)(desc[1].sizes & ZXC_SECTION_SIZE_MASK);
-    const size_t sz_offsets = (size_t)(desc[2].sizes & ZXC_SECTION_SIZE_MASK);
-    const size_t sz_extras = (size_t)(desc[3].sizes & ZXC_SECTION_SIZE_MASK);
+    // Only the literal and token sizes are on the wire; offsets follow from the
+    // sequence count and width, and extras take the payload residue.
+    const size_t sz_tokens = tok_comp;
+    const uint64_t sz_offsets = GLO_OFF8 ? (uint64_t)gh.n_sequences : (uint64_t)gh.n_sequences * 2;
 
-    // Validate stream sizes match sequence count (early rejection of malformed data)
-    const uint64_t expected_off_size =
-        GLO_OFF8 ? (uint64_t)gh.n_sequences : (uint64_t)gh.n_sequences * 2;
+    const size_t payload_avail = (size_t)(src + src_size - p_data);
+    const uint64_t consumed = (uint64_t)lit_stream_size + (uint64_t)sz_tokens + sz_offsets;
+    if (UNLIKELY(consumed > (uint64_t)payload_avail)) return ZXC_ERROR_CORRUPT_DATA;
+    const size_t sz_extras = payload_avail - (size_t)consumed; /* slack padding included */
 
-    /* Offsets/extras follow the on-disk token SECTION; sz_tokens is its size
-     * (== n_sequences when RAW, the Huffman payload size when enc_litlen set). */
-    const uint8_t* o_ptr = p_curr + sz_tokens;
-    const uint8_t* e_ptr = o_ptr + sz_offsets;
-    const uint8_t* const e_end = e_ptr + sz_extras;  // For vbyte overflow detection
-
-    // Validate streams don't overflow source buffer + match sequence count.
-    if (UNLIKELY((e_end != src + src_size) || (uint64_t)sz_offsets < expected_off_size))
+    // RAW literals point into the caller's buffer and the wild copy overshoots,
+    // so it needs ZXC_BLOCK_LIT_SLACK readable bytes behind it. v7 staged short
+    // streams into a padded scratch here; v8 rejects instead. No underflow:
+    // lit_stream_size <= consumed <= payload_avail.
+    if (UNLIKELY(payload_avail - lit_stream_size < ZXC_BLOCK_LIT_SLACK))
         return ZXC_ERROR_CORRUPT_DATA;
 
-    if (UNLIKELY(gh.enc_lit == ZXC_SECTION_ENCODING_RAW &&
-                 (size_t)(src + src_size - l_end) < ZXC_PAD_SIZE)) {
-        const int rc = zxc_stage_raw_literals(ctx, &l_ptr, &l_end);
-        if (UNLIKELY(rc != ZXC_OK)) return rc;
-    }
+    // Offsets/extras follow the on-disk token SECTION; sz_tokens is its size
+    // (== n_sequences when RAW, the Huffman payload size when enc_tok set).
+    const uint8_t* o_ptr = p_curr + sz_tokens;
+    const uint8_t* e_ptr = o_ptr + (size_t)sz_offsets;
+    const uint8_t* const e_end = e_ptr + sz_extras;
 
     const uint8_t* RESTRICT t_ptr;
     if (!tok_entropy) {
-        /* enc_litlen == 2 was re-routed right after the header parse. */
-        if (UNLIKELY(sz_tokens < gh.n_sequences)) return ZXC_ERROR_CORRUPT_DATA;
+        // enc_tok == 2 was re-routed right after the header parse; any other
+        // value would have mis-sized the section descriptors above.
+        if (UNLIKELY(gh.enc_tok != 0)) return ZXC_ERROR_CORRUPT_DATA;
         t_ptr = p_curr;
     } else {
-        if (UNLIKELY(gh.enc_litlen != ZXC_SECTION_ENCODING_HUFFMAN)) return ZXC_ERROR_CORRUPT_DATA;
+        if (UNLIKELY(gh.enc_tok != ZXC_SECTION_ENCODING_HUFFMAN)) return ZXC_ERROR_CORRUPT_DATA;
         const int rc = zxc_decode_tok_pivco(ctx, p_curr, sz_tokens, gh.n_sequences);
         if (UNLIKELY(rc != ZXC_OK)) return rc;
         t_ptr = ctx->tok_buffer;
@@ -865,7 +1028,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
     const uint8_t* const d_floor = dst - dict_size;
     // Destination safe margin for 4x loop: max output without varint extension.
     // ll_max = 14, ml_max = 14 + 5 = 19, per-seq = 33, 4x = 132.
-    // Add ZXC_PAD_SIZE (32) for the wild zxc_copy32 overshoot + 4 safety = 168.
+    // Plus the overshoot the wild copies are allowed (ZXC_PAD_SIZE) + 4 safety = 168.
     const uint8_t* const d_end_safe = d_end - (132 + ZXC_PAD_SIZE + 4);
 
     // Literal margin for the 4x loops: without a varint, ll <= 14 per sequence,
@@ -890,14 +1053,14 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
 
     // --- SAFE Loop: offset validation until d_bounds (4x unroll) ---
     if (safe) {
-        /* SAFE variant: save per-batch state so overflow can rollback. */
+        // SAFE variant: save per-batch state so overflow can rollback.
         while (n_seq >= 4 && d_ptr < d_end_safe && l_ptr < l_end_safe_4x && d_ptr < d_bounds) {
             const uint8_t* const t_save = t_ptr;
             const uint8_t* const o_save = o_ptr;
             const uint8_t* const e_save = e_ptr;
             uint8_t* const d_save = d_ptr;
             const uint8_t* const l_save = l_ptr;
-            DECODE_GLO_BATCH_4X(DECODE_SEQ_SAFE, goto rollback_safe_4x);
+            DECODE_GLO_BATCH_4X(DECODE_MATCH_SAFE, goto rollback_safe_4x);
             continue;
 
         rollback_safe_4x:
@@ -910,7 +1073,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
         }
     } else {
         while (n_seq >= 4 && d_ptr < d_end_safe && l_ptr < l_end_safe_4x && d_ptr < d_bounds) {
-            DECODE_GLO_BATCH_4X(DECODE_SEQ_SAFE, return ZXC_ERROR_OVERFLOW);
+            DECODE_GLO_BATCH_4X(DECODE_MATCH_SAFE, return ZXC_ERROR_OVERFLOW);
         }
     }
 
@@ -922,7 +1085,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
             const uint8_t* const e_save = e_ptr;
             uint8_t* const d_save = d_ptr;
             const uint8_t* const l_save = l_ptr;
-            DECODE_GLO_BATCH_4X(DECODE_SEQ_FAST, goto rollback_fast_4x);
+            DECODE_GLO_BATCH_4X(DECODE_MATCH_FAST, goto rollback_fast_4x);
             continue;
 
         rollback_fast_4x:
@@ -935,7 +1098,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
         }
     } else {
         while (n_seq >= 4 && d_ptr < d_end_safe && l_ptr < l_end_safe_4x) {
-            DECODE_GLO_BATCH_4X(DECODE_SEQ_FAST, return ZXC_ERROR_OVERFLOW);
+            DECODE_GLO_BATCH_4X(DECODE_MATCH_FAST, return ZXC_ERROR_OVERFLOW);
         }
     }
 
@@ -980,16 +1143,23 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
             break;
         }
 
-        zxc_decode_copy_literals(d_ptr, l_ptr, ll);
+        // Unlike the 4x batch the copy cannot sit in the varint branch's else -
+        // the rollback above must run first - so re-test ll instead. Exact:
+        // the escape leaves ll >= ZXC_TOKEN_LL_MASK.
+        if (LIKELY(ll < ZXC_TOKEN_LL_MASK)) {
+            zxc_copy16(d_ptr, l_ptr);
+        } else {
+            zxc_decode_copy_literals(d_ptr, l_ptr, ll);
+        }
         l_ptr += ll;
         d_ptr += ll;
 
         if (UNLIKELY(d_ptr < d_bounds && (size_t)(d_ptr - d_floor) < offset))
             return ZXC_ERROR_BAD_OFFSET;
 
-        /* The loop entry check guarantees ll + ml + ZXC_PAD_SIZE bytes of
-         * headroom, so the wild-copy ladder (incl. overlap/fill runs) is safe. */
-        zxc_decode_copy_match(d_ptr, offset, ml);
+        // The loop entry check guarantees ll + ml + ZXC_PAD_SIZE bytes of
+        // headroom, so the wild-copy ladder (incl. overlap/fill runs) is safe.
+        zxc_decode_copy_match_glo(d_ptr, offset, ml);
         d_ptr += ml;
         n_seq--;
     }
@@ -1042,8 +1212,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_glo_impl(const zxc_cctx_t* RESTRIC
  * @brief Unified GHI (General High) block decoder body, shared by the fast, safe
  *        and dictionary variants.
  *
- * Decodes a block in the internal GHI format; the decompressed size is derived
- * from the Section Descriptors in the payload. @p safe and @p has_dict must be
+ * Decodes a block in the internal GHI format. The decompressed size is not on
+ * the wire: it falls out of walking the sequences. @p safe and @p has_dict must be
  * compile-time constants (0 or 1): the 4x-unrolled loops are duplicated inside
  * @c if(safe)/else branches so each variant keeps single-assignment @c const
  * save pointers, and after constant propagation only one branch survives per
@@ -1065,38 +1235,38 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
                                                        const int has_dict) {
     zxc_gnr_header_t gh;
 
-    /* 0 when !has_dict (safe path) -> folds `d_floor` to `dst`. */
+    // 0 when !has_dict (safe path) -> folds `d_floor` to `dst`.
     const size_t dict_size = has_dict ? ctx->dict_size : 0;
-    zxc_section_desc_t desc[ZXC_GHI_SECTIONS];
 
-    if (UNLIKELY(zxc_read_ghi_header_and_desc(src, src_size, &gh, desc) != ZXC_OK))
-        return ZXC_ERROR_BAD_HEADER;
+    if (UNLIKELY(zxc_read_ghi_header(src, src_size, &gh) != ZXC_OK)) return ZXC_ERROR_BAD_HEADER;
+    if (UNLIKELY(gh.enc_lit != ZXC_SECTION_ENCODING_RAW || gh.enc_tok != 0))
+        return ZXC_ERROR_CORRUPT_DATA;
 
-    const uint8_t* p_curr =
-        src + ZXC_GHI_HEADER_BINARY_SIZE + ZXC_GHI_SECTIONS * ZXC_SECTION_DESC_BINARY_SIZE;
+    const uint8_t* const p_data = src + ZXC_GHI_HEADER_BINARY_SIZE;
+    const uint8_t* p_curr = p_data;
 
     // --- Stream Pointers & Validation ---
-    const size_t sz_lit = (uint32_t)desc[0].sizes;
-    const size_t sz_seqs = (uint32_t)desc[1].sizes;
-    const size_t sz_exts = (uint32_t)desc[2].sizes;
+    // GHI carries no section descriptors: literals are always RAW, the sequence
+    // stream is four bytes per sequence, and extras run to the payload end.
+    const size_t sz_lit = gh.n_literals;
+    const uint64_t sz_seqs = (uint64_t)gh.n_sequences * sizeof(uint32_t);
+
+    const size_t payload_avail = (size_t)(src + src_size - p_data);
+    const uint64_t consumed = (uint64_t)sz_lit + sz_seqs;
+    if (UNLIKELY(consumed > (uint64_t)payload_avail)) return ZXC_ERROR_CORRUPT_DATA;
+    const size_t sz_exts = payload_avail - (size_t)consumed; /* slack padding included */
+
+    // GHI literals are always RAW, so the slack is always load-bearing here.
+    // No underflow: sz_lit <= consumed <= payload_avail.
+    if (UNLIKELY(payload_avail - sz_lit < ZXC_BLOCK_LIT_SLACK)) return ZXC_ERROR_CORRUPT_DATA;
+
     const uint8_t* l_ptr = p_curr;
     const uint8_t* l_end = l_ptr + sz_lit;
     p_curr += sz_lit;
 
     const uint8_t* seq_ptr = p_curr;
-    const uint8_t* extras_ptr = p_curr + sz_seqs;
+    const uint8_t* extras_ptr = p_curr + (size_t)sz_seqs;
     const uint8_t* const extras_end = extras_ptr + sz_exts;
-
-    // Validate streams don't overflow source buffer +
-    // Validate sequence stream size matches sequence count
-    if (UNLIKELY((extras_end != src + src_size) ||
-                 ((uint64_t)sz_seqs < (uint64_t)gh.n_sequences * 4)))
-        return ZXC_ERROR_CORRUPT_DATA;
-
-    if (UNLIKELY((size_t)(src + src_size - l_end) < ZXC_PAD_SIZE)) {
-        const int rc = zxc_stage_raw_literals(ctx, &l_ptr, &l_end);
-        if (UNLIKELY(rc != ZXC_OK)) return rc;
-    }
 
     uint8_t* d_ptr = dst;
     const uint8_t* const d_end = dst + dst_capacity;
@@ -1124,15 +1294,15 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
 
     // --- SAFE loop: validate offsets until d_bounds (4x unroll) ---
     if (safe) {
-        /* SAFE variant: save per-batch state so an OVERFLOW can rollback and
-         * hand over to the 1x loop / Safe Path. Wild writes already committed
-         * are deterministically overwritten when the 1x loop replays. */
+        // SAFE variant: save per-batch state so an OVERFLOW can rollback and
+        // hand over to the 1x loop / Safe Path. Wild writes already committed
+        // are deterministically overwritten when the 1x loop replays.
         while (n_seq >= 4 && d_ptr < d_end_fast && l_ptr < l_end_safe_4x && d_ptr < d_bounds) {
             const uint8_t* const t_save = seq_ptr;
             const uint8_t* const e_save = extras_ptr;
             uint8_t* const d_save = d_ptr;
             const uint8_t* const l_save = l_ptr;
-            DECODE_GHI_BATCH_4X(DECODE_SEQ_SAFE, goto rollback_safe_4x, (void)0);
+            DECODE_GHI_BATCH_4X(DECODE_MATCH_SAFE, goto rollback_safe_4x, (void)0);
             continue;
 
         rollback_safe_4x:
@@ -1144,7 +1314,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
         }
     } else {
         while (n_seq >= 4 && d_ptr < d_end_fast && l_ptr < l_end_safe_4x && d_ptr < d_bounds) {
-            DECODE_GHI_BATCH_4X(DECODE_SEQ_SAFE, return ZXC_ERROR_OVERFLOW, (void)0);
+            DECODE_GHI_BATCH_4X(DECODE_MATCH_SAFE, return ZXC_ERROR_OVERFLOW, (void)0);
         }
     }
 
@@ -1179,7 +1349,10 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
             zxc_decode_copy_match_exact(d_ptr, match_src, offset, ml);
             d_ptr += ml;
         } else {
-            DECODE_SEQ_SAFE(ll, ml, offset);
+            zxc_decode_copy_literals(d_ptr, l_ptr, ll);
+            l_ptr += ll;
+            d_ptr += ll;
+            DECODE_MATCH_SAFE(ml, offset, zxc_decode_copy_match);
         }
         n_seq--;
     }
@@ -1191,7 +1364,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
             const uint8_t* const e_save = extras_ptr;
             uint8_t* const d_save = d_ptr;
             const uint8_t* const l_save = l_ptr;
-            DECODE_GHI_BATCH_4X(DECODE_SEQ_FAST, goto rollback_fast_4x,
+            DECODE_GHI_BATCH_4X(DECODE_MATCH_FAST, goto rollback_fast_4x,
                                 ZXC_PREFETCH_READ(l_ptr + ZXC_CACHE_LINE_SIZE));
             continue;
 
@@ -1204,7 +1377,7 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
         }
     } else {
         while (n_seq >= 4 && d_ptr < d_end_fast && l_ptr < l_end_safe_4x) {
-            DECODE_GHI_BATCH_4X(DECODE_SEQ_FAST, return ZXC_ERROR_OVERFLOW,
+            DECODE_GHI_BATCH_4X(DECODE_MATCH_FAST, return ZXC_ERROR_OVERFLOW,
                                 ZXC_PREFETCH_READ(l_ptr + ZXC_CACHE_LINE_SIZE));
         }
     }
@@ -1248,8 +1421,8 @@ static ZXC_ALWAYS_INLINE int zxc_decode_block_ghi_impl(const zxc_cctx_t* RESTRIC
         if (UNLIKELY(d_ptr < d_bounds && (size_t)(d_ptr - d_floor) < offset))
             return ZXC_ERROR_BAD_OFFSET;
 
-        /* The loop entry check guarantees ll + ml + ZXC_PAD_SIZE bytes of
-         * headroom, so the wild-copy ladder (incl. overlap/fill runs) is safe. */
+        // The loop entry check guarantees ll + ml + ZXC_PAD_SIZE bytes of
+        // headroom, so the wild-copy ladder (incl. overlap/fill runs) is safe.
         zxc_decode_copy_match(d_ptr, offset, ml);
         d_ptr += ml;
         n_seq--;
@@ -1447,9 +1620,9 @@ static ZXC_NOINLINE int zxc_decode_block_ghi_safe(const zxc_cctx_t* RESTRICT ctx
 #undef DECODE_GHI_SEQ
 #undef DECODE_GLO_BATCH_4X
 #undef DECODE_GLO_SEQ
-#undef DECODE_SEQ_FAST
+#undef DECODE_MATCH_FAST
 #undef GLO_OFF8
-#undef DECODE_SEQ_SAFE
+#undef DECODE_MATCH_SAFE
 
 /**
  * @brief Shared chunk-decode body: validates the block header, verifies the
@@ -1477,16 +1650,16 @@ static ZXC_ALWAYS_INLINE int zxc_decompress_chunk_wrapper_body(
 
     const uint8_t type = src[0];
     const uint32_t comp_sz = zxc_le32(src + 3);
-    const int has_crc = ctx->checksum_enabled;
+    const int has_checksum = ctx->checksum_enabled;
 
     // Check bounds: Header + Body + Checksum(if any)
     const size_t expected_sz =
-        (size_t)ZXC_BLOCK_HEADER_SIZE + comp_sz + (has_crc ? ZXC_BLOCK_CHECKSUM_SIZE : 0);
+        (size_t)ZXC_BLOCK_HEADER_SIZE + comp_sz + (has_checksum ? ZXC_BLOCK_CHECKSUM_SIZE : 0);
     if (UNLIKELY(src_sz < expected_sz)) return ZXC_ERROR_SRC_TOO_SMALL;
 
     const uint8_t* data = src + ZXC_BLOCK_HEADER_SIZE;
 
-    if (has_crc) {
+    if (has_checksum) {
         const uint32_t stored = zxc_le32(data + comp_sz);
         const uint32_t calc = zxc_checksum(data, comp_sz, ZXC_CHECKSUM_RAPIDHASH);
         if (UNLIKELY(stored != calc)) return ZXC_ERROR_BAD_CHECKSUM;
@@ -1526,13 +1699,6 @@ static ZXC_ALWAYS_INLINE int zxc_decompress_chunk_wrapper_body(
  *
  * Inlines the plain GLO/GHI decoders via @ref zxc_decompress_chunk_wrapper_body
  * with @c has_dict=0, so it carries no dict code and matches the dict-free build.
- *
- * @param[in,out] ctx     Decompression context.
- * @param[in]     src     Compressed block bytes.
- * @param[in]     src_sz  Size of @p src in bytes.
- * @param[out]    dst     Destination buffer for the decoded block.
- * @param[in]     dst_cap Capacity of @p dst in bytes.
- * @return Bytes written on success, or a negative @ref zxc_error_t.
  */
 // cppcheck-suppress unusedFunction
 int zxc_decompress_chunk_wrapper(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,

--- a/lz/zxc/src/lib/zxc_dict.c
+++ b/lz/zxc/src/lib/zxc_dict.c
@@ -15,9 +15,9 @@
 #include "../../include/zxc_buffer.h"
 #include "zxc_internal.h"
 
-/* -------------------------------------------------------------------------
- *  Dictionary ID
- * ------------------------------------------------------------------------- */
+// -------------------------------------------------------------------------
+//  Dictionary ID
+// -------------------------------------------------------------------------
 
 /**
  * @brief Computes the dictionary identifier for @p dict (and optional table).
@@ -25,47 +25,37 @@
  * Public API; see @c zxc_dict.h. One checksum over the content, chained with
  * the packed Huffman lengths so a single id covers both. Stored in the archive
  * header and re-checked on decode.
- *
- * @param[in] dict         Dictionary content bytes.
- * @param[in] dict_size    Content length in bytes.
- * @param[in] huf_lengths  Optional packed Huffman lengths (@c ZXC_HUF_TABLE_SIZE
- *                         bytes), or NULL to hash the content alone.
- * @return The 32-bit dictionary id, or 0 if @p dict is NULL or empty.
  */
 uint32_t zxc_dict_id(const void* RESTRICT dict, const size_t dict_size,
                      const void* RESTRICT huf_lengths) {
     if (UNLIKELY(!dict || dict_size == 0)) return 0;
-    /* One logical hash over the real bytes only: the content checksum seeds
-     * the table checksum (content and table are not contiguous at the API
-     * level, so chaining avoids both a concat copy and a synthetic buffer). */
+    // One logical hash over the real bytes only: the content checksum seeds
+    // the table checksum (content and table are not contiguous at the API
+    // level, so chaining avoids both a concat copy and a synthetic buffer).
     const uint32_t base = zxc_checksum(dict, dict_size, 0);
     if (huf_lengths == NULL) return base;
     return zxc_checksum_seed(huf_lengths, ZXC_HUF_TABLE_SIZE, base, 0);
 }
 
-/* -------------------------------------------------------------------------
- *  .zxd format: save / load / bound
- *
- *  Layout (ZXC_DICT_HEADER_SIZE = 16 bytes + content + Huffman table):
- *    0x00  4  Magic   (0x9CB0D1C7 LE)
- *    0x04  1  Version (1)
- *    0x05  1  Flags   (bits 0-3: checksum algo id, 0=RapidHash; bits 4-7 reserved)
- *    0x06  2  Content size (u16 LE)
- *    0x08  4  dict_id (u32 LE; covers content AND the Huffman table)
- *    0x0C  2  Reserved (0)
- *    0x0E  2  Header CRC16 (zxc_hash16, computed with bytes 0x0C-0x0F zeroed)
- *    0x10  N  Content bytes
- *    +N    128 Packed Huffman code lengths (always present)
- * ------------------------------------------------------------------------- */
+// -------------------------------------------------------------------------
+//  .zxd format: save / load / bound
+//
+//  Layout (ZXC_DICT_HEADER_SIZE = 16 bytes + content + Huffman table):
+//    0x00  4  Magic   (0x9CB0D1C7 LE)
+//    0x04  1  Version (1)
+//    0x05  1  Flags   (bits 0-3: checksum algo id, 0=RapidHash; bits 4-7 reserved)
+//    0x06  2  Content size (u16 LE)
+//    0x08  4  dict_id (u32 LE; covers content AND the Huffman table)
+//    0x0C  2  Reserved (0)
+//    0x0E  2  Header Checksum (zxc_hash16, computed with 0x0C-0x0F zeroed)
+//    0x10  N  Content bytes
+//    +N    128 Packed Huffman code lengths (always present)
+// -------------------------------------------------------------------------
 
 /**
  * @brief Extracts the stored @c dict_id from a serialized .zxd buffer.
  *
  * Public API; see @c zxc_dict.h. Reads the header field without recomputing it.
- *
- * @param[in] buf       Serialized .zxd bytes.
- * @param[in] buf_size  Size of @p buf in bytes.
- * @return The stored dictionary id, or 0 if @p buf is too small or not a .zxd.
  */
 uint32_t zxc_dict_get_id(const void* buf, const size_t buf_size) {
     if (UNLIKELY(!buf || buf_size < ZXC_DICT_HEADER_SIZE)) return 0;
@@ -78,9 +68,6 @@ uint32_t zxc_dict_get_id(const void* buf, const size_t buf_size) {
  * @brief Worst-case .zxd byte size for a dictionary of @p content_size bytes.
  *
  * Public API; see @c zxc_dict.h. Sizes the buffer for @ref zxc_dict_save.
- *
- * @param[in] content_size  Dictionary content length in bytes.
- * @return Required buffer size: header + content + Huffman table.
  */
 size_t zxc_dict_save_bound(const size_t content_size) {
     return ZXC_DICT_HEADER_SIZE + content_size + ZXC_HUF_TABLE_SIZE;
@@ -91,15 +78,6 @@ size_t zxc_dict_save_bound(const size_t content_size) {
  *
  * Public API; full contract in @c zxc_dict.h. Header, then content, then packed
  * Huffman lengths - layout above.
- *
- * @param[in]  content       Dictionary content bytes.
- * @param[in]  content_size  Content length (<= @c ZXC_DICT_SIZE_MAX).
- * @param[in]  huf_lengths   Packed Huffman lengths (@c ZXC_HUF_TABLE_SIZE bytes).
- * @param[out] buf           Destination .zxd buffer.
- * @param[in]  buf_capacity  Capacity of @p buf (>= @ref zxc_dict_save_bound).
- * @return Bytes written on success, or a negative @ref zxc_error_t
- *         (@ref ZXC_ERROR_NULL_INPUT, @ref ZXC_ERROR_DICT_TOO_LARGE,
- *         @ref ZXC_ERROR_DST_TOO_SMALL).
  */
 int64_t zxc_dict_save(const void* RESTRICT content, const size_t content_size,
                       const void* RESTRICT huf_lengths, void* RESTRICT buf,
@@ -117,9 +95,9 @@ int64_t zxc_dict_save(const void* RESTRICT content, const size_t content_size,
     dst[5] = 0; /* flags: reserved */
     zxc_store_le16(dst + 6, (uint16_t)content_size);
     zxc_store_le32(dst + 8, zxc_dict_id(content, content_size, (const uint8_t*)huf_lengths));
-    zxc_store_le32(dst + 12, 0); /* reserved (0x0C) + CRC16 (0x0E), zeroed before CRC */
-    const uint16_t crc = zxc_hash16(dst);
-    zxc_store_le16(dst + 14, crc);
+    zxc_store_le32(dst + 12, 0); /* reserved (0x0C) + checksum (0x0E), zeroed before hashing */
+    const uint16_t sum = zxc_hash16(dst);
+    zxc_store_le16(dst + 14, sum);
 
     ZXC_MEMCPY(dst + ZXC_DICT_HEADER_SIZE, content, content_size);
     ZXC_MEMCPY(dst + ZXC_DICT_HEADER_SIZE + content_size, huf_lengths, ZXC_HUF_TABLE_SIZE);
@@ -131,17 +109,8 @@ int64_t zxc_dict_save(const void* RESTRICT content, const size_t content_size,
  * @brief Parses a .zxd buffer, returning in-buffer views of content and table.
  *
  * Public API; full contract in @c zxc_dict.h. Validates magic, version, header
- * CRC and dict_id, then points the out-params into @p buf - no copy, so they
+ * checksum and dict_id, then points the out-params into @p buf - no copy, so they
  * stay valid only while @p buf does.
- *
- * @param[in]  buf               Serialized .zxd bytes.
- * @param[in]  buf_size          Size of @p buf in bytes.
- * @param[out] content_out       Receives a pointer to the content bytes.
- * @param[out] content_size_out  Receives the content length.
- * @param[out] huf_out           Receives a pointer to the Huffman table (optional).
- * @param[out] dict_id_out       Receives the validated dict_id (optional).
- * @return @ref ZXC_OK, or a negative @ref zxc_error_t (bad magic / version /
- *         header / checksum, or too small).
  */
 int zxc_dict_load(const void* RESTRICT buf, const size_t buf_size,
                   const void** RESTRICT content_out, size_t* RESTRICT content_size_out,
@@ -162,14 +131,14 @@ int zxc_dict_load(const void* RESTRICT buf, const size_t buf_size,
 
     uint8_t temp[ZXC_DICT_HEADER_SIZE];
     ZXC_MEMCPY(temp, src, sizeof(temp));
-    zxc_store_le32(temp + 12, 0); /* reserved (0x0C) + CRC16 (0x0E), zeroed before CRC */
-    const uint16_t expected_crc = zxc_hash16(temp);
-    if (UNLIKELY(zxc_le16(src + 14) != expected_crc)) return ZXC_ERROR_BAD_HEADER;
+    zxc_store_le32(temp + 12, 0); /* reserved (0x0C) + checksum (0x0E), zeroed before hashing */
+    const uint16_t expected_sum = zxc_hash16(temp);
+    if (UNLIKELY(zxc_le16(src + 14) != expected_sum)) return ZXC_ERROR_BAD_HEADER;
 
     const uint8_t* content = src + ZXC_DICT_HEADER_SIZE;
     const uint8_t* huf = content + content_size;
 
-    /* Verify dict_id matches the (content, table) pair. */
+    // Verify dict_id matches the (content, table) pair.
     const uint32_t id = zxc_dict_id(content, content_size, huf);
     if (UNLIKELY(zxc_le32(src + 8) != id)) return ZXC_ERROR_BAD_CHECKSUM;
 
@@ -186,11 +155,6 @@ int zxc_dict_load(const void* RESTRICT buf, const size_t buf_size,
  *
  * Public API; see @c zxc_dict.h. Locates the table on magic/version/size checks
  * alone, skipping @ref zxc_dict_load's full validation. Aliases @p buf.
- *
- * @param[in] buf       Serialized .zxd bytes.
- * @param[in] buf_size  Size of @p buf in bytes.
- * @return Pointer to the @c ZXC_HUF_TABLE_SIZE-byte table, or NULL if @p buf is
- *         too small or not a valid .zxd.
  */
 const void* zxc_dict_huf(const void* buf, const size_t buf_size) {
     if (UNLIKELY(!buf || buf_size < ZXC_DICT_HEADER_SIZE)) return NULL;
@@ -204,20 +168,20 @@ const void* zxc_dict_huf(const void* buf, const size_t buf_size) {
     return src + ZXC_DICT_HEADER_SIZE + content_size;
 }
 
-/* -------------------------------------------------------------------------
- *  Dictionary training: k-gram frequency selection
- *
- *  Algorithm:
- *  1. Concatenate all samples into a corpus.
- *  2. For each position in the corpus, hash the k-gram (k = MIN_MATCH_LEN)
- *     and count occurrences in a fixed-size hash map.
- *  3. Build candidate segments: each starts at a frequent k-gram and extends
- *     while neighbours stay frequent. Its score is the summed frequency of its
- *     k-grams - its coverage of the corpus.
- *  4. Fill the dictionary greedily in descending coverage, zeroing each pick's
- *     k-grams: one copy serves all future matches, so segments that collapse
- *     are skipped and capacity goes to NEW patterns.
- * ------------------------------------------------------------------------- */
+// -------------------------------------------------------------------------
+//  Dictionary training: k-gram frequency selection
+//
+//  Algorithm:
+//  1. Concatenate all samples into a corpus.
+//  2. For each position in the corpus, hash the k-gram (k = MIN_MATCH_LEN)
+//     and count occurrences in a fixed-size hash map.
+//  3. Build candidate segments: each starts at a frequent k-gram and extends
+//     while neighbours stay frequent. Its score is the summed frequency of its
+//     k-grams - its coverage of the corpus.
+//  4. Fill the dictionary greedily in descending coverage, zeroing each pick's
+//     k-grams: one copy serves all future matches, so segments that collapse
+//     are skipped and capacity goes to NEW patterns.
+// -------------------------------------------------------------------------
 
 /**
  * @brief Hashes the k-gram at @p p into a frequency-table bucket index.
@@ -247,7 +211,7 @@ typedef struct {
  * @brief Restore the min-heap property at @p root over the range @p a[0..n).
  *
  * Sinks @p a[root] until both children are @c >= it, comparing on
- * @ref zxc_dict_seg_t::score. Iterative, so the stack stays O(1).
+ * `zxc_dict_seg_t::score`. Iterative, so the stack stays O(1).
  *
  * @param[in,out] a    Heap-ordered array; @p a[0..n) is treated as the heap.
  * @param[in]     root Index of the element to sift down. Must be @c < n.
@@ -267,7 +231,7 @@ static void zxc_dict_sift_down(zxc_dict_seg_t* RESTRICT a, size_t root, const si
 }
 
 /**
- * @brief Sort @p a[0..n) by @ref zxc_dict_seg_t::score in descending order.
+ * @brief Sort @p a[0..n) by `zxc_dict_seg_t::score` in descending order.
  *
  * In-place heapsort: a min-heap pushes the smallest scores to the tail, so the
  * array ends up descending, which is what the fill step wants. Not @c qsort:
@@ -298,13 +262,6 @@ static void zxc_dict_sort_segs_desc(zxc_dict_seg_t* RESTRICT a, const size_t n) 
  * Public API; full contract in @c zxc_dict.h, algorithm in the note above.
  * Picks are emitted in reverse so the highest-coverage bytes land at the dict's
  * end, where match offsets are smallest.
- *
- * @param[in]  samples        Array of @p n_samples sample buffers.
- * @param[in]  sample_sizes   Array of @p n_samples sample lengths.
- * @param[in]  n_samples      Number of samples.
- * @param[out] dict_buf       Destination for the trained content.
- * @param[in]  dict_capacity  Capacity of @p dict_buf (<= @c ZXC_DICT_SIZE_MAX).
- * @return Trained content length in bytes, or a negative @ref zxc_error_t.
  */
 int64_t zxc_train_dict(const void* const* RESTRICT samples, const size_t* RESTRICT sample_sizes,
                        const size_t n_samples, void* RESTRICT dict_buf,
@@ -313,11 +270,14 @@ int64_t zxc_train_dict(const void* const* RESTRICT samples, const size_t* RESTRI
         return ZXC_ERROR_NULL_INPUT;  // LCOV_EXCL_LINE
     if (UNLIKELY(dict_capacity > ZXC_DICT_SIZE_MAX)) return ZXC_ERROR_DICT_TOO_LARGE;
 
-    /* Step 1: concatenate samples */
+    // Step 1: concatenate samples
     size_t corpus_size = 0;
     for (size_t i = 0; i < n_samples; i++) corpus_size += sample_sizes[i];
     if (UNLIKELY(corpus_size < ZXC_DICT_KGRAM_LEN)) return ZXC_ERROR_SRC_TOO_SMALL;
 
+    int64_t rc;
+    uint16_t* freq = NULL;
+    zxc_dict_seg_t* segs = NULL;
     uint8_t* corpus = (uint8_t*)ZXC_MALLOC(corpus_size);
     if (UNLIKELY(!corpus)) return ZXC_ERROR_MEMORY;
     {
@@ -328,19 +288,16 @@ int64_t zxc_train_dict(const void* const* RESTRICT samples, const size_t* RESTRI
         }
     }
 
-    /* Step 2: count k-gram frequencies */
-    uint16_t* freq = (uint16_t*)ZXC_MALLOC(ZXC_DICT_HASH_SIZE * sizeof(uint16_t));
+    // Step 2: count k-gram frequencies
+    freq = (uint16_t*)ZXC_CALLOC(ZXC_DICT_HASH_SIZE, sizeof(uint16_t));
     if (UNLIKELY(!freq)) {
-        // LCOV_EXCL_START
-        ZXC_FREE(corpus);
-        return ZXC_ERROR_MEMORY;
-        // LCOV_EXCL_STOP
+        rc = ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
+        goto done;              // LCOV_EXCL_LINE
     }
-    ZXC_MEMSET(freq, 0, ZXC_DICT_HASH_SIZE * sizeof(uint16_t));
 
-    /* Sample positions rather than count them all: a full count saturates the
-     * 16-bit counters, the extension test then never stops and segments balloon
-     * into filler. */
+    // Sample positions rather than count them all: a full count saturates the
+    // 16-bit counters, the extension test then never stops and segments balloon
+    // into filler.
     const size_t kgram_limit = corpus_size - ZXC_DICT_KGRAM_LEN + 1;
     size_t freq_stride = kgram_limit / ZXC_DICT_SAMPLE_TARGET;
     if (freq_stride < 1) freq_stride = 1;
@@ -349,21 +306,18 @@ int64_t zxc_train_dict(const void* const* RESTRICT samples, const size_t* RESTRI
         if (freq[h] < UINT16_MAX) freq[h]++;
     }
 
-    /* Step 3: build candidate segments, scored by coverage. Starts are spread
-     * across the whole corpus - a fixed k-gram stride would exhaust the segment
-     * budget in the prefix and never see a large input's tail. */
+    // Step 3: build candidate segments, scored by coverage. Starts are spread
+    // across the whole corpus - a fixed k-gram stride would exhaust the segment
+    // budget in the prefix and never see a large input's tail.
     const size_t max_segs = corpus_size / ZXC_DICT_KGRAM_LEN;
     const size_t seg_alloc = (max_segs < ZXC_DICT_MAX_SEGMENTS) ? max_segs : ZXC_DICT_MAX_SEGMENTS;
     size_t stride = ZXC_DICT_KGRAM_LEN;
     if (seg_alloc > 0 && corpus_size / seg_alloc > stride) stride = corpus_size / seg_alloc;
 
-    zxc_dict_seg_t* segs = (zxc_dict_seg_t*)ZXC_MALLOC(seg_alloc * sizeof(zxc_dict_seg_t));
+    segs = (zxc_dict_seg_t*)ZXC_MALLOC(seg_alloc * sizeof(zxc_dict_seg_t));
     if (UNLIKELY(!segs)) {
-        // LCOV_EXCL_START
-        ZXC_FREE(freq);
-        ZXC_FREE(corpus);
-        return ZXC_ERROR_MEMORY;
-        // LCOV_EXCL_STOP
+        rc = ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
+        goto done;              // LCOV_EXCL_LINE
     }
 
     size_t n_segs = 0;
@@ -372,8 +326,8 @@ int64_t zxc_train_dict(const void* const* RESTRICT samples, const size_t* RESTRI
         const uint16_t f = freq[h];
         if (f < 2) continue;
 
-        /* Extend the segment as long as the next k-gram is also frequent, and
-         * accumulate coverage (summed k-gram frequency) as the score. */
+        // Extend the segment as long as the next k-gram is also frequent, and
+        // accumulate coverage (summed k-gram frequency) as the score.
         uint32_t coverage = f;
         size_t end = i + ZXC_DICT_KGRAM_LEN;
         while (end + ZXC_DICT_KGRAM_LEN <= corpus_size && end - i < 4096) {
@@ -390,18 +344,16 @@ int64_t zxc_train_dict(const void* const* RESTRICT samples, const size_t* RESTRI
     }
 
     if (UNLIKELY(n_segs == 0)) {
-        /* No frequent patterns. Use tail of corpus as dict. */
+        // No frequent patterns. Use tail of corpus as dict.
         const size_t copy = (corpus_size < dict_capacity) ? corpus_size : dict_capacity;
         ZXC_MEMCPY(dict_buf, corpus + corpus_size - copy, copy);
-        ZXC_FREE(freq);
-        ZXC_FREE(segs);
-        ZXC_FREE(corpus);
-        return (int64_t)copy;
+        rc = (int64_t)copy;
+        goto done;
     }
 
-    /* Step 4: pick greedily in descending coverage, zeroing each pick's k-grams
-     * so overlapping patterns aren't copied twice. Picks are compacted in place
-     * into segs[0..n_sel); placement is step 5. */
+    // Step 4: pick greedily in descending coverage, zeroing each pick's k-grams
+    // so overlapping patterns aren't copied twice. Picks are compacted in place
+    // into segs[0..n_sel); placement is step 5.
     zxc_dict_sort_segs_desc(segs, n_segs);
 
     uint8_t* out = (uint8_t*)dict_buf;
@@ -412,8 +364,8 @@ int64_t zxc_train_dict(const void* const* RESTRICT samples, const size_t* RESTRI
         const size_t seg_off = segs[i].offset;
         const size_t seg_end = seg_off + segs[i].length;
 
-        /* Recompute coverage from the decrementing table: skip the segment if
-         * earlier picks have already covered more than half of its k-grams. */
+        // Recompute coverage from the decrementing table: skip the segment if
+        // earlier picks have already covered more than half of its k-grams.
         uint32_t cur = 0;
         for (size_t p = seg_off; p + ZXC_DICT_KGRAM_LEN <= seg_end; p += ZXC_DICT_KGRAM_LEN)
             cur += freq[zxc_dict_hash(corpus + p)];
@@ -422,70 +374,68 @@ int64_t zxc_train_dict(const void* const* RESTRICT samples, const size_t* RESTRI
         size_t copy = segs[i].length;
         if (copy > dict_capacity - total) copy = dict_capacity - total;
 
-        /* One copy in the dictionary serves all future matches: mark this
-         * segment's k-grams as covered so later segments cover new ground. */
+        // One copy in the dictionary serves all future matches: mark this
+        // segment's k-grams as covered so later segments cover new ground.
         for (size_t p = seg_off; p + ZXC_DICT_KGRAM_LEN <= seg_end; p += ZXC_DICT_KGRAM_LEN)
             freq[zxc_dict_hash(corpus + p)] = 0;
 
-        /* Record the pick (n_sel <= i, so this never clobbers an unread entry). */
+        // Record the pick (n_sel <= i, so this never clobbers an unread entry).
         segs[n_sel].offset = (uint32_t)seg_off;
         segs[n_sel].length = (uint16_t)copy;
         n_sel++;
         total += copy;
     }
 
+    // Released early: the emit loop below only needs the picks.
     ZXC_FREE(freq);
+    freq = NULL;
 
-    /* Step 5: emit in reverse so the highest-coverage segment lands at the END
-     * of the dict. The dict sits just before the data, so bytes near its end
-     * have the smallest offsets: cheapest to encode, last to fall out of the
-     * 16-bit window. No padding - short picks just make a shorter dict, whereas
-     * padding would raise the offset of everything after it. */
+    // Step 5: emit in reverse so the highest-coverage segment lands at the END
+    // of the dict. The dict sits just before the data, so bytes near its end
+    // have the smallest offsets: cheapest to encode, last to fall out of the
+    // 16-bit window. No padding - short picks just make a shorter dict, whereas
+    // padding would raise the offset of everything after it.
     size_t filled = 0;
     for (size_t i = n_sel; i-- > 0;) {
         ZXC_MEMCPY(out + filled, corpus + segs[i].offset, segs[i].length);
         filled += segs[i].length;
     }
 
-    /* Nothing selected (every segment subsumed by earlier picks): fall back to
-     * the corpus tail so the dict is never empty, like the n_segs == 0 path. */
+    // Nothing selected (every segment subsumed by earlier picks): fall back to
+    // the corpus tail so the dict is never empty, like the n_segs == 0 path.
     if (UNLIKELY(filled == 0)) {
         const size_t tail = (corpus_size < dict_capacity) ? corpus_size : dict_capacity;
         ZXC_MEMCPY(out, corpus + corpus_size - tail, tail);
         filled = tail;
     }
 
+    rc = (int64_t)filled;
+
+done:
     ZXC_FREE(segs);
+    ZXC_FREE(freq);
     ZXC_FREE(corpus);
-    return (int64_t)filled;
+    return rc;
 }
 
-/* -------------------------------------------------------------------------
- *  Shared literal Huffman table training (Tier-2)
- *
- *  Compresses the samples with the freshly trained dictionary at level
- *  ZXC_LEVEL_DENSITY and histograms the REAL post-LZ literals (cctx
- *  lit_freq_acc hook). Raw bytes are a poor proxy: matches against the dict
- *  remove most repeated content, so the two distributions differ a lot.
- *
- *  Slices are ZXC_DICT_HUF_TRAIN_BLOCK bytes - the small-block regime is where
- *  a shared table pays (per-block headers are unaffordable there) and where
- *  literal density is highest.
- * ------------------------------------------------------------------------- */
+// -------------------------------------------------------------------------
+//  Shared literal Huffman table training (Tier-2)
+//
+//  Compresses the samples with the freshly trained dictionary at level
+//  ZXC_LEVEL_DENSITY and histograms the REAL post-LZ literals (cctx
+//  lit_freq_acc hook). Raw bytes are a poor proxy: matches against the dict
+//  remove most repeated content, so the two distributions differ a lot.
+//
+//  Slices are ZXC_DICT_HUF_TRAIN_BLOCK bytes - the small-block regime is where
+//  a shared table pays (per-block headers are unaffordable there) and where
+//  literal density is highest.
+// -------------------------------------------------------------------------
 
 /**
  * @brief Trains the shared literal Huffman table for a dictionary (Tier-2).
  *
  * Public API; see @c zxc_dict.h and the algorithm note above. Slices are
  * sub-sampled to a fixed budget.
- *
- * @param[in]  samples          Array of @p n_samples sample buffers.
- * @param[in]  sample_sizes     Array of @p n_samples sample lengths.
- * @param[in]  n_samples        Number of samples.
- * @param[in]  dict             Trained dictionary content.
- * @param[in]  dict_size        Dictionary length (<= @c ZXC_DICT_SIZE_MAX).
- * @param[out] huf_lengths_out  Receives the @c ZXC_HUF_TABLE_SIZE packed lengths.
- * @return @ref ZXC_OK, or a negative @ref zxc_error_t.
  */
 int zxc_train_dict_huf(const void* const* RESTRICT samples, const size_t* RESTRICT sample_sizes,
                        const size_t n_samples, const void* RESTRICT dict, const size_t dict_size,
@@ -513,12 +463,12 @@ int zxc_train_dict_huf(const void* const* RESTRICT samples, const size_t* RESTRI
         // LCOV_EXCL_STOP
     }
 
-    /* [dict | slice] concat scratch carved by zxc_cctx_init (mode 1). */
+    // [dict | slice] concat scratch carved by zxc_cctx_init (mode 1).
     uint8_t* const work = cctx.dict_buffer;
     ZXC_MEMCPY(work, dict, dict_size);
 
-    /* Slice stride: process every slice while the corpus fits the budget,
-     * else 1 slice out of `stride` spread evenly across all samples. */
+    // Slice stride: process every slice while the corpus fits the budget,
+    // else 1 slice out of `stride` spread evenly across all samples.
     size_t corpus_total = 0;
     for (size_t s = 0; s < n_samples; s++) corpus_total += sample_sizes[s];
     const size_t stride =
@@ -549,24 +499,24 @@ int zxc_train_dict_huf(const void* const* RESTRICT samples, const size_t* RESTRI
     }
 
     if (rc == ZXC_OK) {
-        /* A low-entropy corpus leaves no post-LZ literals - an empty histogram,
-         * not corrupt input. Detected on the histogram itself, so an all-zero
-         * table is emitted and every block falls back to its own; inferring
-         * "empty" from a build error code could mask a real failure. */
+        // A low-entropy corpus leaves no post-LZ literals - an empty histogram,
+        // not corrupt input. Detected on the histogram itself, so an all-zero
+        // table is emitted and every block falls back to its own; inferring
+        // "empty" from a build error code could mask a real failure.
         uint32_t any = 0;
         for (int i = 0; i < ZXC_HUF_NUM_SYMBOLS; i++) any |= freq[i];
         if (any == 0) {
             ZXC_MEMSET(huf_lengths_out, 0, ZXC_HUF_TABLE_SIZE);
         } else {
-            /* No coverage smoothing: under an 8-bit cap a code over all 256
-             * symbols can only be the degenerate all-8-bit one (Kraft equality),
-             * which compresses nothing. Unseen symbols stay code-less and their
-             * blocks fall back to a per-block table. */
+            // No coverage smoothing: under an 8-bit cap a code over all 256
+            // symbols can only be the degenerate all-8-bit one (Kraft equality),
+            // which compresses nothing. Unseen symbols stay code-less and their
+            // blocks fall back to a per-block table.
             uint8_t code_len[ZXC_HUF_NUM_SYMBOLS];
             rc = zxc_huf_build_code_lengths(freq, code_len, NULL, ZXC_HUF_MAX_CODE_LEN_DENSITY);
             if (rc == ZXC_OK) {
-                /* Dict tables serve the most literal-bound decode path, so the
-                 * flat/length nudge pays off most here. */
+                // Dict tables serve the most literal-bound decode path, so the
+                // flat/length nudge pays off most here.
                 (void)zxc_huf_nudge_code_lengths(freq, code_len, NULL,
                                                  ZXC_HUF_MAX_CODE_LEN_DENSITY);
                 zxc_huf_pack_lengths(code_len, huf_lengths_out);
@@ -579,9 +529,9 @@ int zxc_train_dict_huf(const void* const* RESTRICT samples, const size_t* RESTRI
     return rc;
 }
 
-/* -------------------------------------------------------------------------
- *  All-in-one convenience: samples -> ready-to-write .zxd bytes
- * ------------------------------------------------------------------------- */
+// -------------------------------------------------------------------------
+//  All-in-one convenience: samples -> ready-to-write .zxd bytes
+// -------------------------------------------------------------------------
 
 /**
  * @brief One-shot training: sample buffers in, ready-to-write .zxd bytes out.
@@ -589,23 +539,16 @@ int zxc_train_dict_huf(const void* const* RESTRICT samples, const size_t* RESTRI
  * Public API; see @c zxc_dict.h. Trains the content (@ref zxc_train_dict), then
  * the shared table from that content (@ref zxc_train_dict_huf), then serializes
  * both (@ref zxc_dict_save). The two phases are a real data dependency.
- *
- * @param[in]  samples       Array of @p n_samples sample buffers.
- * @param[in]  sample_sizes  Array of @p n_samples sample lengths.
- * @param[in]  n_samples     Number of samples.
- * @param[out] zxd_buf       Destination .zxd buffer.
- * @param[in]  zxd_capacity  Capacity of @p zxd_buf in bytes.
- * @return Bytes written to @p zxd_buf, or a negative @ref zxc_error_t.
  */
 int64_t zxc_dict_train(const void* const* RESTRICT samples, const size_t* RESTRICT sample_sizes,
                        const size_t n_samples, void* RESTRICT zxd_buf, const size_t zxd_capacity) {
     if (UNLIKELY(!samples || !sample_sizes || n_samples == 0 || !zxd_buf || zxd_capacity == 0))
         return ZXC_ERROR_NULL_INPUT;
 
-    /* Train the content into a temporary buffer (max-content sized), then the
-     * shared table from that content, then serialize both into zxd_buf. The
-     * two-phase training is a real data dependency (the table needs the trained
-     * content to histogram post-LZ literals); this hides it behind one call. */
+    // Train the content into a temporary buffer (max-content sized), then the
+    // shared table from that content, then serialize both into zxd_buf. The
+    // two-phase training is a real data dependency (the table needs the trained
+    // content to histogram post-LZ literals); this hides it behind one call.
     uint8_t* content = (uint8_t*)ZXC_MALLOC(ZXC_DICT_SIZE_MAX);
     if (UNLIKELY(!content)) return ZXC_ERROR_MEMORY;
 

--- a/lz/zxc/src/lib/zxc_dispatch.c
+++ b/lz/zxc/src/lib/zxc_dispatch.c
@@ -22,10 +22,8 @@
 #include "../../include/zxc_seekable.h"
 #include "zxc_internal.h"
 
-/*
- * ZXC_DISABLE_SIMD => force ZXC_ONLY_DEFAULT so the dispatcher never selects
- * an AVX2/AVX512/NEON variant.
- */
+// ZXC_DISABLE_SIMD => force ZXC_ONLY_DEFAULT so the dispatcher never selects
+// an AVX2/AVX512/NEON variant.
 #if defined(ZXC_DISABLE_SIMD) && !defined(ZXC_ONLY_DEFAULT)
 #define ZXC_ONLY_DEFAULT
 #endif
@@ -46,12 +44,10 @@
 #include <sys/auxv.h>
 #endif
 
-/*
- * ============================================================================
- * PROTOTYPES FOR MULTI-VERSIONED VARIANTS
- * ============================================================================
- * These are compiled in separate translation units with different flags.
- */
+// ============================================================================
+// PROTOTYPES FOR MULTI-VERSIONED VARIANTS
+// ============================================================================
+// These are compiled in separate translation units with different flags.
 
 // Decompression Prototypes
 int zxc_decompress_chunk_wrapper_default(const zxc_cctx_t* RESTRICT ctx,
@@ -144,11 +140,9 @@ int zxc_compress_chunk_wrapper_neon32(zxc_cctx_t* RESTRICT ctx, const uint8_t* R
                                       const size_t dst_cap);
 #endif
 
-/*
- * ============================================================================
- * CPU DETECTION LOGIC
- * ============================================================================
- */
+// ============================================================================
+// CPU DETECTION LOGIC
+// ============================================================================
 
 #if (defined(__x86_64__) || defined(_M_X64)) && !defined(ZXC_ONLY_DEFAULT)
 
@@ -171,8 +165,8 @@ static inline uint64_t zxc_xgetbv0(void) {
 #if defined(_MSC_VER)
     return _xgetbv(0);
 #else
-    /* Raw encoding: the xgetbv intrinsic needs -mxsave, which the baseline
-     * translation unit is not compiled with. */
+    // Raw encoding: the xgetbv intrinsic needs -mxsave, which the baseline
+    // translation unit is not compiled with.
     uint32_t lo, hi;
     __asm__ volatile(".byte 0x0f, 0x01, 0xd0" : "=a"(lo), "=d"(hi) : "c"(0));
     return ((uint64_t)hi << 32) | lo;
@@ -231,9 +225,9 @@ static zxc_cpu_feature_t zxc_detect_cpu_features(void) {
             const int bmi2 = (regs[1] >> 8) & 1;  // CPUID.7.0:EBX[8]
             if (regs[1] & (1U << 5)) avx2 = 1;
             // AVX512 also needs XCR0[5..7] (opmask/ZMM)
-            if ((regs[1] & (1U << 16)) && (regs[1] & (1U << 30)) && (regs[2] & (1U << 6)) &&
-                (xcr0 & 0xE0) == 0xE0)
-                avx512 = 1; /* AVX512 tier = F+BW+VBMI2 (variant built with -mavx512vbmi2) */
+            if ((regs[1] & (1U << 16)) && (regs[1] & (1U << 30)) && (regs[2] & (1U << 1)) &&
+                (regs[2] & (1U << 6)) && (xcr0 & 0xE0) == 0xE0)
+                avx512 = 1; /* AVX512 tier = F+BW+VBMI+VBMI2, as the variant is built */
             // The AVX2/AVX512 variants are compiled with BMI1/BMI2/LZCNT enabled,
             // so both gates must prove those bits too. LZCNT (ABM) lives in
             // CPUID.80000001H:ECX[5]; that leaf is architectural on x86-64.
@@ -276,12 +270,10 @@ static zxc_cpu_feature_t zxc_detect_cpu_features(void) {
 }
 // LCOV_EXCL_STOP
 
-/*
- * ============================================================================
- * DISPATCHERS
- * ============================================================================
- * We use a function pointer initialized on first use (lazy initialization).
- */
+// ============================================================================
+// DISPATCHERS
+// ============================================================================
+// We use a function pointer initialized on first use (lazy initialization).
 
 /** @brief Function pointer type for the chunk decompressor. */
 typedef int (*zxc_decompress_func_t)(const zxc_cctx_t* RESTRICT, const uint8_t* RESTRICT,
@@ -299,203 +291,114 @@ static ZXC_ATOMIC zxc_decompress_func_t zxc_decompress_safe_ptr = (zxc_decompres
 /** @brief Lazily-resolved pointer to the best compression variant. */
 static ZXC_ATOMIC zxc_compress_func_t zxc_compress_ptr = (zxc_compress_func_t)0;
 
+// Publication of a resolved pointer, and the matching acquire load. One pair of
+// definitions instead of an #if around every access.
+#if ZXC_USE_C11_ATOMICS
+#define ZXC_DISPATCH_STORE(ptr, val) atomic_store_explicit(&(ptr), (val), memory_order_release)
+#define ZXC_DISPATCH_LOAD(ptr) atomic_load_explicit(&(ptr), memory_order_acquire)
+#else
+#define ZXC_DISPATCH_STORE(ptr, val) ((ptr) = (val))
+#define ZXC_DISPATCH_LOAD(ptr) (ptr)
+#endif
+
+/**
+ * @struct zxc_variant_set_t
+ * @brief The four chunk entry points of one ISA variant, resolved together.
+ *
+ * The three lazy initialisers below differ only in which of these they publish,
+ * so the per-architecture selection ladder lives in one place: adding an ISA
+ * tier is one line here instead of three ladders to keep in step.
+ */
+typedef struct {
+    zxc_decompress_func_t decompress;
+    zxc_decompress_func_t decompress_dict;
+    zxc_decompress_func_t decompress_safe;
+    zxc_compress_func_t compress;
+} zxc_variant_set_t;
+
+/** @brief Returns the variant set of suffix @p sfx from the enclosing function. */
+#define ZXC_RETURN_VARIANT_SET(sfx)                                                    \
+    do {                                                                               \
+        const zxc_variant_set_t v_ = {                                                 \
+            zxc_decompress_chunk_wrapper##sfx, zxc_decompress_chunk_wrapper_dict##sfx, \
+            zxc_decompress_chunk_wrapper_safe##sfx, zxc_compress_chunk_wrapper##sfx};  \
+        return v_;                                                                     \
+    } while (0)
+
+/**
+ * @brief Detects the CPU tier and returns the matching variant set.
+ *
+ * Falls back to the `_default` (baseline) set when no ISA extension applies or
+ * the build is single-variant.
+ */
+// LCOV_EXCL_START
+static zxc_variant_set_t zxc_select_variants(void) {
+    const zxc_cpu_feature_t cpu = zxc_detect_cpu_features();
+    (void)cpu;
+
+#ifndef ZXC_ONLY_DEFAULT
+#if defined(__x86_64__) || defined(_M_X64)
+    if (cpu == ZXC_CPU_AVX512) ZXC_RETURN_VARIANT_SET(_avx512);
+    if (cpu == ZXC_CPU_AVX2) ZXC_RETURN_VARIANT_SET(_avx2);
+#elif defined(__arm__) || defined(_M_ARM)
+    // 32-bit ARM: the only arch with a real runtime NEON probe (getauxval).
+    // cppcheck-suppress knownConditionTrueFalse
+    if (cpu == ZXC_CPU_NEON) ZXC_RETURN_VARIANT_SET(_neon32);
+#endif
+#endif
+    ZXC_RETURN_VARIANT_SET(_default);
+}
+// LCOV_EXCL_STOP
+
+#undef ZXC_RETURN_VARIANT_SET
+
 /**
  * @brief First-call initialiser for the decompression dispatcher.
  *
- * Detects CPU features, selects the best implementation, stores the
- * pointer atomically, then tail-calls into it.
- *
- * @param[in]  ctx      Decompression context (its @c dict_size picks the dict variant).
- * @param[in]  src      Compressed input chunk.
- * @param[in]  src_sz   Size of @p src in bytes.
- * @param[out] dst      Destination buffer for decompressed data.
- * @param[in]  dst_cap  Capacity of @p dst in bytes.
- * @return Result of the selected variant: decompressed size, or negative
- *         @ref zxc_error_t.
+ * Publishes both decompression pointers, then tail-calls the one this context
+ * needs (its @c dict_size picks the dict variant).
  */
 // LCOV_EXCL_START
 static int zxc_decompress_dispatch_init(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                         const size_t src_sz, uint8_t* RESTRICT dst,
                                         const size_t dst_cap) {
-    const zxc_cpu_feature_t cpu = zxc_detect_cpu_features();
-    zxc_decompress_func_t zxc_decompress_ptr_local = NULL;
-    zxc_decompress_func_t zxc_decompress_dict_ptr_local = NULL;
-
-#ifndef ZXC_ONLY_DEFAULT
-#if defined(__x86_64__) || defined(_M_X64)
-    if (cpu == ZXC_CPU_AVX512) {
-        zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_avx512;
-        zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_avx512;
-    } else if (cpu == ZXC_CPU_AVX2) {
-        zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_avx2;
-        zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_avx2;
-    } else {
-        zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_default;
-        zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_default;
-    }
-#elif defined(__arm__) || defined(_M_ARM)
-    // 32-bit ARM: the only arch with a real runtime NEON probe (getauxval).
-    // cppcheck-suppress knownConditionTrueFalse
-    if (cpu == ZXC_CPU_NEON) {
-        zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_neon32;
-        zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_neon32;
-    } else {
-        zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_default;
-        zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_default;
-    }
-#else
-    (void)cpu;
-    zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_default;
-    zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_default;
-#endif
-#else
-    (void)cpu;
-    zxc_decompress_ptr_local = zxc_decompress_chunk_wrapper_default;
-    zxc_decompress_dict_ptr_local = zxc_decompress_chunk_wrapper_dict_default;
-#endif
-
-#if ZXC_USE_C11_ATOMICS
-    atomic_store_explicit(&zxc_decompress_ptr, zxc_decompress_ptr_local, memory_order_release);
-    atomic_store_explicit(&zxc_decompress_dict_ptr, zxc_decompress_dict_ptr_local,
-                          memory_order_release);
-#else
-    zxc_decompress_ptr = zxc_decompress_ptr_local;
-    zxc_decompress_dict_ptr = zxc_decompress_dict_ptr_local;
-#endif
-    return (ctx->dict_size ? zxc_decompress_dict_ptr_local : zxc_decompress_ptr_local)(
-        ctx, src, src_sz, dst, dst_cap);
+    const zxc_variant_set_t v = zxc_select_variants();
+    ZXC_DISPATCH_STORE(zxc_decompress_ptr, v.decompress);
+    ZXC_DISPATCH_STORE(zxc_decompress_dict_ptr, v.decompress_dict);
+    return (ctx->dict_size ? v.decompress_dict : v.decompress)(ctx, src, src_sz, dst, dst_cap);
 }
-// LCOV_EXCL_STOP
 
 /**
- * @brief First-call initialiser for the safe-decompression dispatcher.
- *
- * Mirrors @ref zxc_decompress_dispatch_init but selects the `_safe_*`
- * decoder variants used by @ref zxc_decompress_block_safe.
- *
- * @param[in]  ctx      Decompression context.
- * @param[in]  src      Compressed input chunk.
- * @param[in]  src_sz   Size of @p src in bytes.
- * @param[out] dst      Destination buffer (strict: exact uncompressed size).
- * @param[in]  dst_cap  Capacity of @p dst in bytes.
- * @return Result of the selected variant: decompressed size, or negative
- *         @ref zxc_error_t.
+ * @brief Same, for the `_safe_*` decoder used by @ref zxc_decompress_block_safe.
  */
-// LCOV_EXCL_START
 static int zxc_decompress_safe_dispatch_init(const zxc_cctx_t* RESTRICT ctx,
                                              const uint8_t* RESTRICT src, const size_t src_sz,
                                              uint8_t* RESTRICT dst, const size_t dst_cap) {
-    const zxc_cpu_feature_t cpu = zxc_detect_cpu_features();
-    zxc_decompress_func_t zxc_decompress_safe_ptr_local = NULL;
-
-#ifndef ZXC_ONLY_DEFAULT
-#if defined(__x86_64__) || defined(_M_X64)
-    if (cpu == ZXC_CPU_AVX512)
-        zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_avx512;
-    else if (cpu == ZXC_CPU_AVX2)
-        zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_avx2;
-    else
-        zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_default;
-#elif defined(__arm__) || defined(_M_ARM)
-    // cppcheck-suppress knownConditionTrueFalse
-    if (cpu == ZXC_CPU_NEON)
-        zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_neon32;
-    else
-        zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_default;
-#else
-    (void)cpu;
-    zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_default;
-#endif
-#else
-    (void)cpu;
-    zxc_decompress_safe_ptr_local = zxc_decompress_chunk_wrapper_safe_default;
-#endif
-
-#if ZXC_USE_C11_ATOMICS
-    atomic_store_explicit(&zxc_decompress_safe_ptr, zxc_decompress_safe_ptr_local,
-                          memory_order_release);
-#else
-    zxc_decompress_safe_ptr = zxc_decompress_safe_ptr_local;
-#endif
-    return zxc_decompress_safe_ptr_local(ctx, src, src_sz, dst, dst_cap);
+    const zxc_variant_set_t v = zxc_select_variants();
+    ZXC_DISPATCH_STORE(zxc_decompress_safe_ptr, v.decompress_safe);
+    return v.decompress_safe(ctx, src, src_sz, dst, dst_cap);
 }
-// LCOV_EXCL_STOP
 
-/**
- * @brief First-call initialiser for the compression dispatcher.
- *
- * Detects CPU features, selects the best implementation, stores the
- * pointer atomically, then tail-calls into it.
- *
- * @param[in,out] ctx      Compression context.
- * @param[in]     src      Uncompressed input chunk.
- * @param[in]     src_sz   Size of @p src in bytes.
- * @param[out]    dst      Destination buffer for the compressed chunk.
- * @param[in]     dst_cap  Capacity of @p dst in bytes.
- * @return Result of the selected variant: compressed size, or negative
- *         @ref zxc_error_t.
- */
-// LCOV_EXCL_START
+/** @brief Same, for the compressor. */
 static int zxc_compress_dispatch_init(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                       const size_t src_sz, uint8_t* RESTRICT dst,
                                       const size_t dst_cap) {
-    const zxc_cpu_feature_t cpu = zxc_detect_cpu_features();
-    zxc_compress_func_t zxc_compress_ptr_local = NULL;
-
-#ifndef ZXC_ONLY_DEFAULT
-#if defined(__x86_64__) || defined(_M_X64)
-    if (cpu == ZXC_CPU_AVX512)
-        zxc_compress_ptr_local = zxc_compress_chunk_wrapper_avx512;
-    else if (cpu == ZXC_CPU_AVX2)
-        zxc_compress_ptr_local = zxc_compress_chunk_wrapper_avx2;
-    else
-        zxc_compress_ptr_local = zxc_compress_chunk_wrapper_default;
-#elif defined(__arm__) || defined(_M_ARM)
-    // cppcheck-suppress knownConditionTrueFalse
-    if (cpu == ZXC_CPU_NEON)
-        zxc_compress_ptr_local = zxc_compress_chunk_wrapper_neon32;
-    else
-        zxc_compress_ptr_local = zxc_compress_chunk_wrapper_default;
-#else
-    (void)cpu;
-    zxc_compress_ptr_local = zxc_compress_chunk_wrapper_default;
-#endif
-#else
-    (void)cpu;
-    zxc_compress_ptr_local = zxc_compress_chunk_wrapper_default;
-#endif
-
-#if ZXC_USE_C11_ATOMICS
-    atomic_store_explicit(&zxc_compress_ptr, zxc_compress_ptr_local, memory_order_release);
-#else
-    zxc_compress_ptr = zxc_compress_ptr_local;
-#endif
-    return zxc_compress_ptr_local(ctx, src, src_sz, dst, dst_cap);
+    const zxc_variant_set_t v = zxc_select_variants();
+    ZXC_DISPATCH_STORE(zxc_compress_ptr, v.compress);
+    return v.compress(ctx, src, src_sz, dst, dst_cap);
 }
 // LCOV_EXCL_STOP
 
 /**
  * @brief Public decompression dispatcher (calls lazily-resolved implementation).
- *
- * @param[in,out] ctx    Decompression context.
- * @param[in]     src    Compressed input chunk (header + payload + optional checksum).
- * @param[in]     src_sz Size of @p src in bytes.
- * @param[out]    dst    Destination buffer for decompressed data.
- * @param[in]     dst_cap Capacity of @p dst.
- * @return Decompressed size in bytes, or a negative @ref zxc_error_t code.
  */
 int zxc_decompress_chunk_wrapper(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                  const size_t src_sz, uint8_t* RESTRICT dst, const size_t dst_cap) {
-    /* dict_size is constant for a stream; this per-block branch (outside the decode
-     * loop) routes to the dict variant only when a dictionary is active, so the
-     * no-dict path runs the dict-free chunk wrapper (identical codegen to main). */
-#if ZXC_USE_C11_ATOMICS
-    const zxc_decompress_func_t func = atomic_load_explicit(
-        ctx->dict_size ? &zxc_decompress_dict_ptr : &zxc_decompress_ptr, memory_order_acquire);
-#else
-    const zxc_decompress_func_t func =
-        ctx->dict_size ? zxc_decompress_dict_ptr : zxc_decompress_ptr;
-#endif
+    // dict_size is constant for a stream; this per-block branch (outside the decode
+    // loop) routes to the dict variant only when a dictionary is active, so the
+    // no-dict path runs the dict-free chunk wrapper (identical codegen to main).
+    const zxc_decompress_func_t func = ctx->dict_size ? ZXC_DISPATCH_LOAD(zxc_decompress_dict_ptr)
+                                                      : ZXC_DISPATCH_LOAD(zxc_decompress_ptr);
     if (UNLIKELY(!func)) return zxc_decompress_dispatch_init(ctx, src, src_sz, dst, dst_cap);
     return func(ctx, src, src_sz, dst, dst_cap);
 }
@@ -516,62 +419,42 @@ static int zxc_decompress_chunk_wrapper_safe_public(const zxc_cctx_t* RESTRICT c
                                                     const uint8_t* RESTRICT src,
                                                     const size_t src_sz, uint8_t* RESTRICT dst,
                                                     const size_t dst_cap) {
-#if ZXC_USE_C11_ATOMICS
-    const zxc_decompress_func_t func =
-        atomic_load_explicit(&zxc_decompress_safe_ptr, memory_order_acquire);
-#else
-    const zxc_decompress_func_t func = zxc_decompress_safe_ptr;
-#endif
+    const zxc_decompress_func_t func = ZXC_DISPATCH_LOAD(zxc_decompress_safe_ptr);
     if (UNLIKELY(!func)) return zxc_decompress_safe_dispatch_init(ctx, src, src_sz, dst, dst_cap);
     return func(ctx, src, src_sz, dst, dst_cap);
 }
 
 /**
  * @brief Public compression dispatcher (calls lazily-resolved implementation).
- *
- * @param[in,out] ctx    Compression context.
- * @param[in]     src    Uncompressed input chunk.
- * @param[in]     src_sz Size of @p src in bytes.
- * @param[out]    dst    Destination buffer for compressed data.
- * @param[in]     dst_cap Capacity of @p dst.
- * @return Compressed size in bytes, or a negative @ref zxc_error_t code.
  */
 int zxc_compress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                const size_t src_sz, uint8_t* RESTRICT dst, const size_t dst_cap) {
-#if ZXC_USE_C11_ATOMICS
-    const zxc_compress_func_t func = atomic_load_explicit(&zxc_compress_ptr, memory_order_acquire);
-#else
-    const zxc_compress_func_t func = zxc_compress_ptr;
-#endif
+    const zxc_compress_func_t func = ZXC_DISPATCH_LOAD(zxc_compress_ptr);
     if (UNLIKELY(!func)) return zxc_compress_dispatch_init(ctx, src, src_sz, dst, dst_cap);
     return func(ctx, src, src_sz, dst, dst_cap);
 }
 
-/*
- * ============================================================================
- * HUFFMAN TRAMPOLINES
- * ============================================================================
- * The Huffman codec is built per-variant (default / avx2 / avx512, plus neon32
- * on 32-bit ARM)
- * alongside zxc_compress.c and zxc_decompress.c, so the LZ77 stages and the
- * Huffman stage in a given variant share the same ISA flags (e.g. -mbmi2 on
- * the AVX2/AVX512 variants). The compress/decompress variant TUs resolve
- * their Huffman calls to the matching suffixed symbol at compile time, so
- * the production hot path has zero dispatch overhead.
- *
- * These thin wrappers exist only for tests and external callers that link
- * against the un-suffixed names. They forward to the default (scalar) variant.
- */
+#undef ZXC_DISPATCH_STORE
+#undef ZXC_DISPATCH_LOAD
+
+// ============================================================================
+// HUFFMAN TRAMPOLINES
+// ============================================================================
+// The Huffman codec is built per-variant (default / avx2 / avx512, plus neon32
+// on 32-bit ARM)
+// alongside zxc_compress.c and zxc_decompress.c, so the LZ77 stages and the
+// Huffman stage in a given variant share the same ISA flags (e.g. -mbmi2 on
+// the AVX2/AVX512 variants). The compress/decompress variant TUs resolve
+// their Huffman calls to the matching suffixed symbol at compile time, so
+// the production hot path has zero dispatch overhead.
+//
+// These thin wrappers exist only for tests and external callers that link
+// against the un-suffixed names. They forward to the default (scalar) variant.
 /**
  * @brief Build length-limited per-symbol Huffman code lengths from frequencies.
  *
- * Un-suffixed entry forwarding to @ref zxc_huf_build_code_lengths_default; full
+ * Un-suffixed entry forwarding to `zxc_huf_build_code_lengths_default`; full
  * contract in @c zxc_internal.h.
- *
- * @param[in]  freq      Per-symbol frequency counts.
- * @param[out] code_len  Per-symbol code lengths.
- * @param[in]  scratch   Caller-provided build scratch buffer.
- * @return `ZXC_OK` on success, negative `zxc_error_t` on failure.
  */
 int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT code_len,
                                void* RESTRICT scratch, const int max_code_len) {
@@ -620,11 +503,8 @@ size_t zxc_huf_calc_size_dict(const uint32_t* RESTRICT freq, const uint8_t* REST
 /**
  * @brief Pack per-symbol code lengths into the 128-byte nibble header.
  *
- * Un-suffixed entry forwarding to @ref zxc_huf_pack_lengths_default; full
+ * Un-suffixed entry forwarding to `zxc_huf_pack_lengths_default`; full
  * contract in @c zxc_internal.h.
- *
- * @param[in]  code_len  Per-symbol code lengths (one byte each).
- * @param[out] out       Destination 128-byte packed header.
  */
 void zxc_huf_pack_lengths(const uint8_t* RESTRICT code_len, uint8_t* RESTRICT out) {
     zxc_huf_pack_lengths_default(code_len, out);
@@ -633,38 +513,24 @@ void zxc_huf_pack_lengths(const uint8_t* RESTRICT code_len, uint8_t* RESTRICT ou
 /**
  * @brief Unpack and validate a 128-byte packed lengths header.
  *
- * Un-suffixed entry forwarding to @ref zxc_huf_unpack_lengths_default; full
+ * Un-suffixed entry forwarding to `zxc_huf_unpack_lengths_default`; full
  * contract in @c zxc_internal.h.
- *
- * @param[in]  in        128-byte packed lengths header.
- * @param[out] code_len  Destination per-symbol code lengths.
- * @return `ZXC_OK` on success, `ZXC_ERROR_CORRUPT_DATA` on invalid lengths.
  */
 int zxc_huf_unpack_lengths(const uint8_t* RESTRICT in, uint8_t* RESTRICT code_len) {
     return zxc_huf_unpack_lengths_default(in, code_len);
 }
 
-/*
- * ============================================================================
- * PUBLIC UTILITY API
- * ============================================================================
- * These wrapper functions provide a simplified interface by managing context
- * allocation and looping over blocks. They call the dispatched wrappers above.
- */
+// ============================================================================
+// PUBLIC UTILITY API
+// ============================================================================
+// These wrapper functions provide a simplified interface by managing context
+// allocation and looping over blocks. They call the dispatched wrappers above.
 
 /**
  * @brief Compresses an entire buffer in one call.
  *
  * Manages context allocation internally, loops over blocks, writes the
  * file header / EOF block / footer, and accumulates the global checksum.
- *
- * @param[in]  src              Uncompressed input data.
- * @param[in]  src_size         Size of @p src in bytes.
- * @param[out] dst              Destination buffer (use zxc_compress_bound() to size).
- * @param[in]  dst_capacity     Capacity of @p dst.
- * @param[in]  opts             Compression options (level, block size, checksum,
- *                              dictionary, seekable, threads), or NULL for defaults.
- * @return Total compressed size in bytes, or a negative @ref zxc_error_t code.
  */
 // cppcheck-suppress unusedFunction
 int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* RESTRICT dst,
@@ -673,12 +539,11 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
 
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
     const int seekable = opts ? opts->seekable : 0;
-    const int level = zxc_level_clamp((opts && opts->level > 0) ? opts->level : ZXC_LEVEL_DEFAULT);
-    const size_t block_size =
-        (opts && opts->block_size > 0) ? opts->block_size : ZXC_BLOCK_SIZE_DEFAULT;
+    const int level = ZXC_OPTS_LEVEL(opts, ZXC_LEVEL_DEFAULT);
+    const size_t block_size = ZXC_OPTS_BLOCK_SIZE(opts, ZXC_BLOCK_SIZE_DEFAULT);
     const uint8_t* dict = opts ? (const uint8_t*)opts->dict : NULL;
-    const size_t dict_size = (opts && opts->dict) ? opts->dict_size : 0;
-    const uint8_t* dict_huf = (opts && opts->dict) ? (const uint8_t*)opts->dict_huf : NULL;
+    const size_t dict_size = ZXC_OPTS_DICT_SIZE(opts);
+    const uint8_t* dict_huf = ZXC_OPTS_DICT_HUF(opts);
 
     if (UNLIKELY(dict_size > ZXC_DICT_SIZE_MAX)) return ZXC_ERROR_DICT_TOO_LARGE;
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return ZXC_ERROR_BAD_BLOCK_SIZE;
@@ -705,8 +570,8 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
         // LCOV_EXCL_STOP
     }
 
-    /* Dict input buffer: [dict_content | block_data] for the encoder, carved
-     * into the cctx workspace (NULL when no dictionary is active). */
+    // Dict input buffer: [dict_content | block_data] for the encoder, carved
+    // into the cctx workspace (NULL when no dictionary is active).
     uint8_t* const dict_input = ctx.dict_buffer;
     if (dict_input) ZXC_MEMCPY(dict_input, dict, dict_size);
 
@@ -720,7 +585,7 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
     // LCOV_EXCL_STOP
     op += h_val;
 
-    /* Seekable: dynamic array for per-block compressed sizes */
+    // Seekable: dynamic array for per-block compressed sizes
     uint32_t* seek_comp = NULL;
     uint32_t seek_count = 0;
     uint32_t seek_cap = 0;
@@ -769,7 +634,7 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
             }
         }
 
-        /* Seekable: record compressed block size */
+        // Seekable: record compressed block size
         if (seekable) {
             // LCOV_EXCL_START
             if (UNLIKELY(seek_count >= seek_cap)) {
@@ -806,7 +671,7 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
     // LCOV_EXCL_STOP
     op += eof_val;
 
-    /* Seekable: write seek table between EOF block and footer */
+    // Seekable: write seek table between EOF block and footer
     if (seekable && seek_count > 0) {
         const size_t st_cap = (size_t)(op_end - op);
         const int64_t st_val = zxc_write_seek_table(op, st_cap, seek_comp, seek_count);
@@ -829,10 +694,10 @@ int64_t zxc_compress(const void* RESTRICT src, const size_t src_size, void* REST
     return (int64_t)(op - op_start);
 }
 
-/* Shared frame decode body for zxc_decompress and zxc_decompress_inplace. No
- * RESTRICT between src and dst, so the overlapping case stays defined; the
- * in-place margin still gives each block disjoint regions, and the per-block
- * wrappers keep their own RESTRICT. */
+// Shared frame decode body for zxc_decompress and zxc_decompress_inplace. No
+// RESTRICT between src and dst, so the overlapping case stays defined; the
+// in-place margin still gives each block disjoint regions, and the per-block
+// wrappers keep their own RESTRICT.
 static int64_t zxc_decompress_frame(const uint8_t* src, size_t src_size, uint8_t* dst,
                                     size_t dst_capacity, const zxc_decompress_opts_t* opts);
 
@@ -841,25 +706,17 @@ static int64_t zxc_decompress_frame(const uint8_t* src, size_t src_size, uint8_t
  *
  * Validates the file header and footer, loops over compressed blocks,
  * and verifies the global checksum when enabled.
- *
- * @param[in]  src              Compressed input data.
- * @param[in]  src_size         Size of @p src in bytes.
- * @param[out] dst              Destination buffer for decompressed data.
- * @param[in]  dst_capacity     Capacity of @p dst.
- * @param[in]  opts             Decompression options (checksum verification,
- *                              dictionary, threads), or NULL for defaults.
- * @return Total decompressed size in bytes, or a negative @ref zxc_error_t code.
  */
 // cppcheck-suppress unusedFunction
 int64_t zxc_decompress(const void* RESTRICT src, const size_t src_size, void* RESTRICT dst,
                        const size_t dst_capacity, const zxc_decompress_opts_t* opts) {
-    if (UNLIKELY(!src || src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE ||
-                 (!dst && dst_capacity != 0)))
-        return ZXC_ERROR_NULL_INPUT;
+    if (UNLIKELY(!src || (!dst && dst_capacity != 0))) return ZXC_ERROR_NULL_INPUT;
+    if (UNLIKELY(src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE))
+        return ZXC_ERROR_SRC_TOO_SMALL;
 
     if (UNLIKELY(!dst || dst_capacity == 0)) {
-        /* Empty-frame case (stored size == 0). */
-        if (UNLIKELY(zxc_le32(src) != ZXC_MAGIC_WORD)) return ZXC_ERROR_NULL_INPUT;
+        // Empty-frame case (stored size == 0).
+        if (UNLIKELY(zxc_le32(src) != ZXC_MAGIC_WORD)) return ZXC_ERROR_BAD_MAGIC;
         const uint8_t* footer = (const uint8_t*)src + src_size - ZXC_FILE_FOOTER_SIZE;
         return (zxc_le64(footer) == 0) ? 0 : (int64_t)ZXC_ERROR_DST_TOO_SMALL;
     }
@@ -871,8 +728,8 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
                                     const size_t dst_capacity, const zxc_decompress_opts_t* opts) {
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
     const uint8_t* dict = opts ? (const uint8_t*)opts->dict : NULL;
-    const size_t dict_size = (opts && opts->dict) ? opts->dict_size : 0;
-    const uint8_t* dict_huf = (opts && opts->dict) ? (const uint8_t*)opts->dict_huf : NULL;
+    const size_t dict_size = ZXC_OPTS_DICT_SIZE(opts);
+    const uint8_t* dict_huf = ZXC_OPTS_DICT_HUF(opts);
 
     const uint8_t* ip = src;
     const uint8_t* ip_end = ip + src_size;
@@ -884,14 +741,14 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
 
     int file_has_checksums = 0;
     uint32_t header_dict_id = 0;
-    if (UNLIKELY(zxc_read_file_header(ip, src_size, &runtime_chunk_size, &file_has_checksums,
-                                      &header_dict_id) != ZXC_OK ||
-                 zxc_cctx_init(&ctx, runtime_chunk_size, 0, 0,
-                               file_has_checksums && checksum_enabled, dict_size) != ZXC_OK)) {
-        return ZXC_ERROR_BAD_HEADER;
-    }
+    const int hrc = zxc_read_file_header(ip, src_size, &runtime_chunk_size, &file_has_checksums,
+                                         &header_dict_id);
+    if (UNLIKELY(hrc != ZXC_OK)) return hrc;
+    if (UNLIKELY(zxc_cctx_init(&ctx, runtime_chunk_size, 0, 0,
+                               file_has_checksums && checksum_enabled, dict_size) != ZXC_OK))
+        return ZXC_ERROR_MEMORY;
 
-    /* Dictionary validation */
+    // Dictionary validation
     if (header_dict_id != 0) {
         if (UNLIKELY(!dict || dict_size == 0)) {
             zxc_cctx_free(&ctx);
@@ -913,8 +770,8 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
 
     const size_t work_sz = runtime_chunk_size + ZXC_DECOMPRESS_TAIL_PAD;
 
-    /* Dict decode buffer: [dict_content | decode_space + PAD], carved into the
-     * cctx workspace (NULL when no dictionary is active). */
+    // Dict decode buffer: [dict_content | decode_space + PAD], carved into the
+    // cctx workspace (NULL when no dictionary is active).
     uint8_t* const dict_dec = ctx.dict_buffer;
     if (dict_dec) ZXC_MEMCPY(dict_dec, dict, dict_size);
 
@@ -968,8 +825,8 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
         int res;
         const size_t rem_cap = (size_t)(op_end - op);
         if (dict_dec) {
-            /* Dict path: decode into bounce buffer with dict prefix so match
-             * copies that reference dict content resolve naturally. */
+            // Dict path: decode into bounce buffer with dict prefix so match
+            // copies that reference dict content resolve naturally.
             res = zxc_decompress_chunk_wrapper(&ctx, ip, rem_src, dict_dec + dict_size, work_sz);
             if (LIKELY(res > 0)) {
                 if (UNLIKELY((size_t)res > rem_cap)) {
@@ -1014,6 +871,31 @@ static int64_t zxc_decompress_frame(const uint8_t* src, const size_t src_size, u
 
     zxc_cctx_free(&ctx);
     return (int64_t)(op - op_start);
+}
+
+/**
+ * @brief Whether a footer's decompressed size is reachable for this archive.
+ *
+ * The footer is untrusted and its size becomes the caller's allocation, so it is
+ * capped by what the archive could physically hold: every block costs at least
+ * @ref ZXC_BLOCK_HEADER_SIZE compressed bytes and decodes to at most one block
+ * size. The cap also keeps @ref zxc_inplace_margin's block count from
+ * overflowing. Shared with @ref zxc_get_decompressed_size so the two readers
+ * cannot drift apart.
+ *
+ * Division rather than the usual ceil, which would wrap near @c UINT64_MAX.
+ *
+ * @param[in] dsize      Decompressed size read from the footer.
+ * @param[in] chunk_size Block size from the file header; never 0 after a
+ *                       @ref ZXC_OK from @ref zxc_read_file_header.
+ * @param[in] comp_size  Size of the whole archive in bytes.
+ * @return 1 when @p dsize is reachable, 0 for a forged footer.
+ */
+static int zxc_footer_dsize_plausible(const uint64_t dsize, const size_t chunk_size,
+                                      const size_t comp_size) {
+    const uint64_t blocks_needed =
+        dsize / (uint64_t)chunk_size + (dsize % (uint64_t)chunk_size != 0);
+    return blocks_needed <= (uint64_t)(comp_size / ZXC_BLOCK_HEADER_SIZE);
 }
 
 /**
@@ -1064,23 +946,33 @@ static uint64_t zxc_inplace_margin(const uint64_t dsize, const size_t chunk_size
  * and @ref zxc_decompress_inplace always agree on what a buffer of at least
  * the bound must satisfy.
  *
+ * The footer is untrusted, so its size goes through
+ * @ref zxc_footer_dsize_plausible like @ref zxc_get_decompressed_size does.
+ *
  * @param[in]  comp      Compressed archive; only the header and footer are read.
  * @param[in]  comp_size Size of the archive in bytes. The caller guarantees it
  *                       covers at least the file header and footer.
  * @param[out] dsize     Decompressed size read from the footer.
  * @param[out] margin    In-place margin for @p dsize, from @ref zxc_inplace_margin.
+ * @param[out] floor     Minimum @c off: what has to separate the flush-right
+ *                       archive from the head of the buffer.
  * @return ZXC_OK, or a negative @ref zxc_error_t on an invalid archive.
  */
 static int zxc_inplace_probe(const uint8_t* comp, const size_t comp_size, uint64_t* dsize,
-                             uint64_t* margin) {
-    if (UNLIKELY(zxc_le32(comp) != ZXC_MAGIC_WORD)) return ZXC_ERROR_BAD_MAGIC;
+                             uint64_t* margin, uint64_t* floor) {
     size_t chunk_size = 0;
     int has_cs = 0;
-    uint32_t did = 0;
-    if (UNLIKELY(zxc_read_file_header(comp, comp_size, &chunk_size, &has_cs, &did) != ZXC_OK))
-        return ZXC_ERROR_BAD_HEADER;
-    *dsize = zxc_le64(comp + comp_size - ZXC_FILE_FOOTER_SIZE);
-    *margin = zxc_inplace_margin(*dsize, chunk_size, has_cs);
+
+    const int hr = zxc_read_file_header(comp, comp_size, &chunk_size, &has_cs, NULL);
+    if (UNLIKELY(hr != ZXC_OK)) return (hr == ZXC_ERROR_BAD_MAGIC) ? hr : ZXC_ERROR_BAD_HEADER;
+
+    const uint64_t d = zxc_le64(comp + comp_size - ZXC_FILE_FOOTER_SIZE);
+    if (UNLIKELY(!zxc_footer_dsize_plausible(d, chunk_size, comp_size)))
+        return ZXC_ERROR_CORRUPT_DATA;
+
+    *dsize = d;
+    *margin = zxc_inplace_margin(d, chunk_size, has_cs);
+    *floor = (uint64_t)chunk_size + (uint64_t)ZXC_DECOMPRESS_TAIL_PAD;
     return ZXC_OK;
 }
 
@@ -1094,19 +986,27 @@ static int zxc_inplace_probe(const uint8_t* comp, const size_t comp_size, uint64
  * compressed data placed flush-right, the write cursor never overtaking the
  * read cursor.
  *
- * @param[in] src      Compressed archive (only header + footer are read).
- * @param[in] src_size Size of the archive in bytes.
- * @return Required buffer size in bytes, or 0 if @p src is not a valid archive.
+ * Because src_size is attacker-controlled, inserted padding bytes can slide decoding dangerously
+ * close to the output boundary. Enforcing a minimum bound via src_size + floor maintains the
+ * required separation regardless of archive padding. For authentic archives, this adjustment grows
+ * the bound by at most 16 bytes and guarantees it never shrinks.
  */
 // cppcheck-suppress unusedFunction
 size_t zxc_decompress_inplace_bound(const void* src, const size_t src_size) {
     if (UNLIKELY(!src || src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE)) return 0;
     uint64_t dsize = 0;
     uint64_t margin = 0;
-    if (UNLIKELY(zxc_inplace_probe((const uint8_t*)src, src_size, &dsize, &margin) != ZXC_OK))
+    uint64_t floor = 0;
+    if (UNLIKELY(zxc_inplace_probe((const uint8_t*)src, src_size, &dsize, &margin, &floor) !=
+                 ZXC_OK))
         return 0;
     if (UNLIKELY(margin > (uint64_t)SIZE_MAX || dsize > (uint64_t)SIZE_MAX - margin)) return 0;
-    return (size_t)(dsize + margin);
+    const uint64_t by_payload = dsize + margin;
+
+    if (UNLIKELY(floor > (uint64_t)SIZE_MAX - (uint64_t)src_size)) return 0;
+    const uint64_t by_placement = (uint64_t)src_size + floor;
+
+    return (size_t)(by_payload > by_placement ? by_payload : by_placement);
 }
 
 /**
@@ -1120,14 +1020,6 @@ size_t zxc_decompress_inplace_bound(const void* src, const size_t src_size) {
  * the read cursor, so a single allocation replaces the usual input+output pair.
  * Dictionary archives are supported (they decode through the context's own
  * bounce buffer, which does not alias @p buffer).
- *
- * @param[in,out] buffer           Single work buffer holding the flush-right
- *                                 archive; receives the decompressed output.
- * @param[in]     buffer_capacity  Total size of @p buffer in bytes.
- * @param[in]     comp_size        Size of the compressed archive in bytes.
- * @param[in]     opts             Decompression options, or NULL for defaults.
- * @return Decompressed size in bytes, or a negative @ref zxc_error_t code
- *         (`ZXC_ERROR_DST_TOO_SMALL` if the buffer lacks the safety margin).
  */
 // cppcheck-suppress unusedFunction
 int64_t zxc_decompress_inplace(void* buffer, const size_t buffer_capacity, const size_t comp_size,
@@ -1139,48 +1031,37 @@ int64_t zxc_decompress_inplace(void* buffer, const size_t buffer_capacity, const
     const uint8_t* const comp = buf + (buffer_capacity - comp_size); /* flush-right */
     uint64_t dsize = 0;
     uint64_t margin = 0;
-    if (UNLIKELY(zxc_inplace_probe(comp, comp_size, &dsize, &margin) != ZXC_OK))
-        return ZXC_ERROR_BAD_HEADER;
+    uint64_t floor = 0;
+    const int rc = zxc_inplace_probe(comp, comp_size, &dsize, &margin, &floor);
+    if (UNLIKELY(rc != ZXC_OK)) return rc;
     if (UNLIKELY(dsize > (uint64_t)buffer_capacity || (uint64_t)buffer_capacity - dsize < margin))
         return ZXC_ERROR_DST_TOO_SMALL;
+    /* The check above sizes the buffer against the payload, this one against the
+     * archive where it actually lies. Only the second bounds the read/write gap. */
+    if (UNLIKELY((uint64_t)(buffer_capacity - comp_size) < floor)) return ZXC_ERROR_DST_TOO_SMALL;
     return zxc_decompress_frame(comp, comp_size, buf, buffer_capacity, opts);
 }
 
 /**
  * @brief Reads the decompressed size from a ZXC-compressed buffer.
  *
- * The size is stored in the file footer (last @ref ZXC_FILE_FOOTER_SIZE bytes).
- * The footer is untrusted input, so the value is checked for plausibility
- * against the archive itself: every decoded block costs at least
- * @ref ZXC_BLOCK_HEADER_SIZE compressed bytes and expands to at most one
- * block size, which bounds the ratio an authentic archive can reach. A size
- * beyond that bound (a forged footer) returns 0, so callers sizing an output
- * allocation from this value inherit the check.
- *
- * @param[in] src      Compressed data.
- * @param[in] src_size Size of @p src in bytes.
- * @return Original uncompressed size, or 0 on error or an implausible footer.
+ * The size sits in the file footer (last @ref ZXC_FILE_FOOTER_SIZE bytes) and is
+ * untrusted, so it goes through zxc_footer_dsize_plausible(): a forged size
+ * returns 0, and callers sizing an allocation from it inherit the check.
  */
 uint64_t zxc_get_decompressed_size(const void* src, const size_t src_size) {
     if (UNLIKELY(src_size < ZXC_FILE_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE)) return 0;
 
     const uint8_t* const p = (const uint8_t*)src;
-    if (UNLIKELY(zxc_le32(p) != ZXC_MAGIC_WORD)) return 0;
-
     size_t chunk_size = 0;
     int has_cs = 0;
-    uint32_t did = 0;
-    if (UNLIKELY(zxc_read_file_header(p, src_size, &chunk_size, &has_cs, &did) != ZXC_OK)) return 0;
+
+    if (UNLIKELY(zxc_read_file_header(p, src_size, &chunk_size, &has_cs, NULL) != ZXC_OK)) return 0;
 
     const uint8_t* const footer = p + src_size - ZXC_FILE_FOOTER_SIZE;
     const uint64_t dsize = zxc_le64(footer);
 
-    /* Plausibility: at most src_size / ZXC_BLOCK_HEADER_SIZE blocks, each
-     * decoding to at most chunk_size. The division form keeps the compare
-     * overflow-free - a ceil would wrap on a forged dsize near UINT64_MAX. */
-    const uint64_t blocks_needed =
-        chunk_size ? dsize / (uint64_t)chunk_size + (dsize % (uint64_t)chunk_size != 0) : 0;
-    if (UNLIKELY(blocks_needed > (uint64_t)(src_size / ZXC_BLOCK_HEADER_SIZE))) return 0;
+    if (UNLIKELY(!zxc_footer_dsize_plausible(dsize, chunk_size, src_size))) return 0;
 
     return dsize;
 }
@@ -1190,11 +1071,6 @@ uint64_t zxc_get_decompressed_size(const void* src, const size_t src_size) {
  *
  * Public API; see @c zxc_buffer.h. Validates the magic, then returns the
  * header's @c dict_id field when the dictionary flag is set. Does not decompress.
- *
- * @param[in] src       Start of the compressed archive (>= @c ZXC_FILE_HEADER_SIZE).
- * @param[in] src_size  Size of @p src in bytes.
- * @return The dictionary id, or 0 if @p src is invalid or the archive uses no
- *         dictionary.
  */
 // cppcheck-suppress unusedFunction
 uint32_t zxc_get_dict_id(const void* src, const size_t src_size) {
@@ -1206,17 +1082,15 @@ uint32_t zxc_get_dict_id(const void* src, const size_t src_size) {
     return (p[6] & ZXC_FILE_FLAG_HAS_DICTIONARY) ? zxc_le32(p + 7) : 0;
 }
 
-/*
- * ============================================================================
- * REUSABLE CONTEXT API (Opaque)
- * ============================================================================
- *
- * Provides heap-allocated, opaque contexts that integrators can reuse across
- * multiple compress / decompress calls, eliminating per-call malloc/free
- * overhead.
- */
+// ============================================================================
+// REUSABLE CONTEXT API (Opaque)
+// ============================================================================
+//
+// Provides heap-allocated, opaque contexts that integrators can reuse across
+// multiple compress / decompress calls, eliminating per-call malloc/free
+// overhead.
 
-/* --- Compression --------------------------------------------------------- */
+// --- Compression ---------------------------------------------------------
 
 /**
  * @brief Opaque reusable compression context (public handle @ref zxc_cctx).
@@ -1232,33 +1106,19 @@ struct zxc_cctx_s {
                                1 = caller-supplied static workspace (no-op free,
                                block_size pinned at init) */
     size_t last_block_size; /* block size used for last init */
-    /* Sticky options (remembered from create or last compress call). */
+    // Sticky options (remembered from create or last compress call).
     int stored_level;
     int stored_checksum;
     size_t stored_block_size;
 };
 
-/**
- * @brief Creates a reusable compression context.
- *
- * Public API; full contract in @c zxc_buffer.h. With non-NULL @p opts the
- * internal buffers are pre-allocated for the given level / block size /
- * checksum; with NULL @p opts allocation is deferred to the first
- * @ref zxc_compress_cctx call. The resolved settings become sticky defaults.
- *
- * @param[in] opts  Initial compression options, or NULL to defer allocation.
- * @return A context to release with @ref zxc_free_cctx, or NULL on allocation
- *         failure or invalid @p opts.
- */
 zxc_cctx* zxc_create_cctx(const zxc_compress_opts_t* opts) {
     zxc_cctx* const cctx = (zxc_cctx*)ZXC_CALLOC(1, sizeof(zxc_cctx));
     if (UNLIKELY(!cctx)) return NULL;  // LCOV_EXCL_LINE
 
-    /* Resolve and store sticky defaults. */
-    cctx->stored_level =
-        zxc_level_clamp((opts && opts->level > 0) ? opts->level : ZXC_LEVEL_DEFAULT);
-    cctx->stored_block_size =
-        (opts && opts->block_size > 0) ? opts->block_size : ZXC_BLOCK_SIZE_DEFAULT;
+    // Resolve and store sticky defaults.
+    cctx->stored_level = ZXC_OPTS_LEVEL(opts, ZXC_LEVEL_DEFAULT);
+    cctx->stored_block_size = ZXC_OPTS_BLOCK_SIZE(opts, ZXC_BLOCK_SIZE_DEFAULT);
     cctx->stored_checksum = opts ? opts->checksum_enabled : 0;
 
     if (opts) {
@@ -1283,13 +1143,11 @@ zxc_cctx* zxc_create_cctx(const zxc_compress_opts_t* opts) {
  * Public API; see @c zxc_buffer.h. Frees the inner buffers and the handle.
  * NULL-safe. For a static (caller-workspace) context this is a no-op, since the
  * caller owns the workspace.
- *
- * @param[in] cctx  Context from @ref zxc_create_cctx (may be NULL).
  */
 void zxc_free_cctx(zxc_cctx* cctx) {
     if (UNLIKELY(!cctx)) return;
-    /* Static cctx: handle + inner buffers live inside the caller's workspace,
-     * which we do not own. Free is a no-op; the caller owns the workspace. */
+    // Static cctx: handle + inner buffers live inside the caller's workspace,
+    // which we do not own. Free is a no-op; the caller owns the workspace.
     if (cctx->owns_workspace) return;
     if (cctx->initialized) zxc_cctx_free(&cctx->inner);
     ZXC_FREE(cctx);
@@ -1302,15 +1160,6 @@ void zxc_free_cctx(zxc_cctx* cctx) {
  * the context's sticky defaults, re-initialises the inner buffers only when the
  * block size changes (level / checksum update in place), then writes the file
  * header, the compressed blocks, the EOF block and the footer.
- *
- * @param[in,out] cctx          Reusable compression context.
- * @param[in]     src           Source bytes.
- * @param[in]     src_size      Number of source bytes (must be > 0).
- * @param[out]    dst           Destination buffer for the archive.
- * @param[in]     dst_capacity  Capacity of @p dst in bytes.
- * @param[in]     opts          Per-call option overrides, or NULL for the
- *                              context defaults.
- * @return Archive size in bytes on success, or a negative @ref zxc_error_t.
  */
 int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t src_size,
                           void* RESTRICT dst, const size_t dst_capacity,
@@ -1319,16 +1168,15 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
     if (UNLIKELY(!src || !dst || src_size == 0 || dst_capacity == 0)) return ZXC_ERROR_NULL_INPUT;
 
     const int checksum_enabled = opts ? opts->checksum_enabled : cctx->stored_checksum;
-    const int level = zxc_level_clamp((opts && opts->level > 0) ? opts->level : cctx->stored_level);
-    const size_t block_size =
-        (opts && opts->block_size > 0) ? opts->block_size : cctx->stored_block_size;
+    const int level = ZXC_OPTS_LEVEL(opts, cctx->stored_level);
+    const size_t block_size = ZXC_OPTS_BLOCK_SIZE(opts, cctx->stored_block_size);
 
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return ZXC_ERROR_BAD_BLOCK_SIZE;
 
-    /* Static cctx: block_size is locked at init and the workspace cannot grow,
-     * so reject any opts forcing a re-partition. level and checksum_enabled may
-     * still vary - except a raise into the optimal-parser tier, whose
-     * opt_scratch a workspace carved below ZXC_LEVEL_DENSITY does not carry. */
+    // Static cctx: block_size is locked at init and the workspace cannot grow,
+    // so reject any opts forcing a re-partition. level and checksum_enabled may
+    // still vary - except a raise into the optimal-parser tier, whose
+    // opt_scratch a workspace carved below ZXC_LEVEL_DENSITY does not carry.
     if (UNLIKELY(cctx->owns_workspace && block_size != cctx->last_block_size))
         return ZXC_ERROR_BAD_BLOCK_SIZE;
     if (UNLIKELY(cctx->owns_workspace && level >= ZXC_LEVEL_DENSITY && !cctx->inner.opt_scratch))
@@ -1338,9 +1186,9 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
     cctx->stored_block_size = block_size;
     cctx->stored_checksum = checksum_enabled;
 
-    /* Re-init when block_size changed (it drives the buffer sizes), or when a
-     * level raise into the optimal-parser tier needs an opt_scratch that inits
-     * below ZXC_LEVEL_DENSITY never allocated. */
+    // Re-init when block_size changed (it drives the buffer sizes), or when a
+    // level raise into the optimal-parser tier needs an opt_scratch that inits
+    // below ZXC_LEVEL_DENSITY never allocated.
     if (UNLIKELY(!cctx->initialized || cctx->last_block_size != block_size ||
                  (level >= ZXC_LEVEL_DENSITY && !cctx->inner.opt_scratch))) {
         if (cctx->initialized) {
@@ -1357,12 +1205,12 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
         cctx->last_block_size = block_size;
         cctx->initialized = 1;
     } else {
-        /* Same block_size: update level + checksum without realloc. */
+        // Same block_size: update level + checksum without realloc.
         cctx->inner.compression_level = level;
         cctx->inner.checksum_enabled = checksum_enabled;
     }
 
-    /* Shared context: zxc_compress_block leaves its dictionary here. */
+    // Shared context: zxc_compress_block leaves its dictionary here.
     cctx->inner.dict_size = 0;
 
     zxc_cctx_t* const ctx = &cctx->inner;
@@ -1397,7 +1245,7 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
         pos += chunk_len;
     }
 
-    /* EOF block */
+    // EOF block
     const size_t rem_cap = (size_t)(op_end - op);
     const zxc_block_header_t eof_bh = {
         .block_type = ZXC_BLOCK_EOF, .block_flags = 0, .reserved = 0, .comp_size = 0};
@@ -1416,7 +1264,7 @@ int64_t zxc_compress_cctx(zxc_cctx* cctx, const void* RESTRICT src, const size_t
     return (int64_t)(op - op_start);
 }
 
-/* --- Decompression ------------------------------------------------------- */
+// --- Decompression -------------------------------------------------------
 
 /**
  * @brief Opaque reusable decompression context (public handle @ref zxc_dctx).
@@ -1434,16 +1282,6 @@ struct zxc_dctx_s {
                                block_size pinned at init) */
 };
 
-/**
- * @brief Creates a reusable decompression context.
- *
- * Public API; see @c zxc_buffer.h. The inner buffers are allocated lazily on
- * the first decode (sized from the archive header), so this only allocates the
- * handle itself.
- *
- * @return A context to release with @ref zxc_free_dctx, or NULL on allocation
- *         failure.
- */
 zxc_dctx* zxc_create_dctx(void) {
     zxc_dctx* const dctx = (zxc_dctx*)ZXC_CALLOC(1, sizeof(zxc_dctx));
     return dctx;
@@ -1454,13 +1292,11 @@ zxc_dctx* zxc_create_dctx(void) {
  *
  * Public API; see @c zxc_buffer.h. Frees the inner buffers and the handle.
  * NULL-safe; a no-op for a static (caller-workspace) context.
- *
- * @param[in] dctx  Context from @ref zxc_create_dctx (may be NULL).
  */
 void zxc_free_dctx(zxc_dctx* dctx) {
     if (UNLIKELY(!dctx)) return;
-    /* Static dctx: handle + inner buffers live inside the caller's workspace,
-     * which we do not own. Free is a no-op; the caller owns the workspace. */
+    // Static dctx: handle + inner buffers live inside the caller's workspace,
+    // which we do not own. Free is a no-op; the caller owns the workspace.
     if (dctx->owns_workspace) return;
     if (dctx->initialized) zxc_cctx_free(&dctx->inner);
     ZXC_FREE(dctx);
@@ -1474,14 +1310,6 @@ void zxc_free_dctx(zxc_dctx* dctx) {
  * dict call left a prefix), then decodes each block - straight into @p dst when
  * the tail padding fits, otherwise through a bounce buffer - and verifies the
  * footer size and optional checksum.
- *
- * @param[in,out] dctx          Reusable decompression context.
- * @param[in]     src           Compressed archive bytes.
- * @param[in]     src_size      Archive size (>= @c ZXC_FILE_HEADER_SIZE).
- * @param[out]    dst           Destination for the decompressed output.
- * @param[in]     dst_capacity  Capacity of @p dst in bytes.
- * @param[in]     opts          Per-call options (e.g. checksum), or NULL.
- * @return Decompressed size in bytes on success, or a negative @ref zxc_error_t.
  */
 int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size_t src_size,
                             void* RESTRICT dst, const size_t dst_capacity,
@@ -1504,13 +1332,13 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
                                       NULL) != ZXC_OK))
         return ZXC_ERROR_BAD_HEADER;
 
-    /* Static dctx: block_size is locked at workspace init; reject any
-     * archive whose declared block_size would require a re-partition. */
+    // Static dctx: block_size is locked at workspace init; reject any
+    // archive whose declared block_size would require a re-partition.
     if (UNLIKELY(dctx->owns_workspace && runtime_chunk_size != dctx->last_block_size))
         return ZXC_ERROR_BAD_BLOCK_SIZE;
 
-    /* Re-init when block size changed, or when a prior dict-using call (block
-     * API) left the inner context carrying a dict prefix. */
+    // Re-init when block size changed, or when a prior dict-using call (block
+    // API) left the inner context carrying a dict prefix.
     if (UNLIKELY(!dctx->initialized || dctx->last_block_size != runtime_chunk_size ||
                  dctx->last_dict_size != 0)) {
         if (dctx->initialized) {
@@ -1534,9 +1362,9 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
     zxc_cctx_t* const ctx = &dctx->inner;
     ip += ZXC_FILE_HEADER_SIZE;
 
-    /* work_buf was pre-sized to runtime_chunk_size + ZXC_DECOMPRESS_TAIL_PAD
-     * inside the matching zxc_cctx_init call above; the re-init guard ensures
-     * it stays in sync when chunk_size changes between calls. */
+    // work_buf was pre-sized to runtime_chunk_size + ZXC_DECOMPRESS_TAIL_PAD
+    // inside the matching zxc_cctx_init call above; the re-init guard ensures
+    // it stays in sync when chunk_size changes between calls.
     const size_t work_sz = runtime_chunk_size + ZXC_DECOMPRESS_TAIL_PAD;
 
     while (ip < ip_end) {
@@ -1590,9 +1418,9 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
     return (int64_t)(op - op_start);
 }
 
-/* ========================================================================= */
-/*  Block-Level API (no file framing)                                        */
-/* ========================================================================= */
+// =========================================================================
+// Block-Level API (no file framing)
+// =========================================================================
 
 /**
  * @brief Compresses a single block (no file framing), reusing @p cctx.
@@ -1605,14 +1433,6 @@ int64_t zxc_decompress_dctx(zxc_dctx* dctx, const void* RESTRICT src, const size
  * effective block size changes, or when a per-call level raise into the
  * optimal-parser tier requires the opt_scratch region; static contexts
  * reject both cases instead (the workspace cannot grow).
- *
- * @param[in,out] cctx          Reusable compression context.
- * @param[in]     src           Source block bytes.
- * @param[in]     src_size      Source length (0 < @p src_size <= @c ZXC_BLOCK_SIZE_MAX).
- * @param[out]    dst           Destination buffer for the block payload.
- * @param[in]     dst_capacity  Capacity of @p dst in bytes.
- * @param[in]     opts          Per-call options (level, dict, ...), or NULL.
- * @return Block payload size in bytes on success, or a negative @ref zxc_error_t.
  */
 int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_t src_size,
                            void* RESTRICT dst, const size_t dst_capacity,
@@ -1620,31 +1440,30 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
     if (UNLIKELY(!cctx || !src || !dst || src_size == 0 || dst_capacity == 0))
         return ZXC_ERROR_NULL_INPUT;
 
-    /* Block API processes a single format-conformant block: src_size must not
-     * exceed ZXC_BLOCK_SIZE_MAX. Callers with larger inputs should use the
-     * frame or streaming APIs which chunk transparently. */
+    // Block API processes a single format-conformant block: src_size must not
+    // exceed ZXC_BLOCK_SIZE_MAX. Callers with larger inputs should use the
+    // frame or streaming APIs which chunk transparently.
     if (UNLIKELY(src_size > ZXC_BLOCK_SIZE_MAX)) return ZXC_ERROR_BAD_BLOCK_SIZE;
 
     const int checksum_enabled = opts ? opts->checksum_enabled : cctx->stored_checksum;
-    const int level = zxc_level_clamp((opts && opts->level > 0) ? opts->level : cctx->stored_level);
-    /* For block API, block_size == src_size (the caller compresses one block at a time). */
-    const size_t block_size =
-        (opts && opts->block_size > 0) ? opts->block_size : cctx->stored_block_size;
+    const int level = ZXC_OPTS_LEVEL(opts, cctx->stored_level);
+    // For block API, block_size == src_size (the caller compresses one block at a time).
+    const size_t block_size = ZXC_OPTS_BLOCK_SIZE(opts, cctx->stored_block_size);
     const size_t min_bs = zxc_block_size_ceil(src_size);
 
-    /* Always ensure internal buffers can hold src_size.
-     * When a dictionary is active, offset_bits must accommodate dict + block. */
+    // Always ensure internal buffers can hold src_size.
+    // When a dictionary is active, offset_bits must accommodate dict + block.
     const uint8_t* b_dict = opts ? (const uint8_t*)opts->dict : NULL;
-    const size_t b_dict_size = (opts && opts->dict) ? opts->dict_size : 0;
+    const size_t b_dict_size = ZXC_OPTS_DICT_SIZE(opts);
     const size_t base_block_size = (block_size > min_bs) ? block_size : min_bs;
     const size_t effective_block_size =
         b_dict_size > 0 ? zxc_block_size_ceil(b_dict_size + base_block_size) : base_block_size;
 
-    /* Static cctx: the workspace cannot grow, so reject anything forcing a
-     * re-partition - another block size, or a level raise into the
-     * optimal-parser tier it carries no opt_scratch for. Re-initing on the heap
-     * would break the no-allocation contract and leak: zxc_free_cctx is a no-op
-     * for static contexts. */
+    // Static cctx: the workspace cannot grow, so reject anything forcing a
+    // re-partition - another block size, or a level raise into the
+    // optimal-parser tier it carries no opt_scratch for. Re-initing on the heap
+    // would break the no-allocation contract and leak: zxc_free_cctx is a no-op
+    // for static contexts.
     if (UNLIKELY(cctx->owns_workspace && effective_block_size != cctx->last_block_size))
         return ZXC_ERROR_BAD_BLOCK_SIZE;
     if (UNLIKELY(cctx->owns_workspace && level >= ZXC_LEVEL_DENSITY && !cctx->inner.opt_scratch))
@@ -1654,9 +1473,9 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
     cctx->stored_block_size = effective_block_size;
     cctx->stored_checksum = checksum_enabled;
 
-    /* Re-init when block_size changed, or when a per-call level raise into
-     * the optimal-parser tier requires the opt_scratch region that inits at
-     * level < ZXC_LEVEL_DENSITY do not allocate (using it NULL would crash). */
+    // Re-init when block_size changed, or when a per-call level raise into
+    // the optimal-parser tier requires the opt_scratch region that inits at
+    // level < ZXC_LEVEL_DENSITY do not allocate (using it NULL would crash).
     if (UNLIKELY(!cctx->initialized || cctx->last_block_size != effective_block_size ||
                  (level >= ZXC_LEVEL_DENSITY && !cctx->inner.opt_scratch))) {
         if (cctx->initialized) {
@@ -1681,7 +1500,7 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
 
     int res;
     if (b_dict && b_dict_size > 0) {
-        /* [dict | block] assembled in the cctx-owned dict_buffer */
+        // [dict | block] assembled in the cctx-owned dict_buffer
         uint8_t* const combined = cctx->inner.dict_buffer;
         ZXC_MEMCPY(combined, b_dict, b_dict_size);
         ZXC_MEMCPY(combined + b_dict_size, src, src_size);
@@ -1704,14 +1523,6 @@ int64_t zxc_compress_block(zxc_cctx* cctx, const void* RESTRICT src, const size_
  * With a dictionary in @p opts the decode runs through the [dict | decode]
  * bounce buffer; otherwise it goes straight into @p dst when the tail padding
  * fits, or via @c work_buf when it doesn't.
- *
- * @param[in,out] dctx          Reusable decompression context.
- * @param[in]     src           Compressed block bytes.
- * @param[in]     src_size      Source length (>= @c ZXC_BLOCK_HEADER_SIZE).
- * @param[out]    dst           Destination for the decoded payload.
- * @param[in]     dst_capacity  Capacity of @p dst in bytes.
- * @param[in]     opts          Per-call options (dict, checksum), or NULL.
- * @return Decoded payload size in bytes on success, or a negative @ref zxc_error_t.
  */
 int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const size_t src_size,
                              void* RESTRICT dst, const size_t dst_capacity,
@@ -1719,18 +1530,18 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
     if (UNLIKELY(!dctx || !src || !dst || src_size < ZXC_BLOCK_HEADER_SIZE || dst_capacity == 0))
         return ZXC_ERROR_NULL_INPUT;
 
-    /* One format-conformant block, so the payload cannot exceed
-     * ZXC_BLOCK_SIZE_MAX; dst_capacity is bounded to that plus the tail-pad the
-     * wild copies need. Larger outputs belong to the frame or streaming APIs. */
+    // One format-conformant block, so the payload cannot exceed
+    // ZXC_BLOCK_SIZE_MAX; dst_capacity is bounded to that plus the tail-pad the
+    // wild copies need. Larger outputs belong to the frame or streaming APIs.
     if (UNLIKELY(dst_capacity > ZXC_BLOCK_SIZE_MAX + ZXC_DECOMPRESS_TAIL_PAD))
         return ZXC_ERROR_BAD_BLOCK_SIZE;
 
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
 
     const uint8_t* dict = opts ? (const uint8_t*)opts->dict : NULL;
-    const size_t dict_size = (opts && opts->dict) ? opts->dict_size : 0;
+    const size_t dict_size = ZXC_OPTS_DICT_SIZE(opts);
 
-    /* Derive the block_size from dst_capacity (callers know the original size) */
+    // Derive the block_size from dst_capacity (callers know the original size)
     const size_t block_size = zxc_block_size_ceil(dst_capacity);
     if (UNLIKELY(!dctx->initialized || dctx->last_block_size != block_size ||
                  dctx->last_dict_size != dict_size)) {
@@ -1753,13 +1564,13 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
     zxc_cctx_t* const ctx = &dctx->inner;
     ctx->dict_size = dict_size;
 
-    /* work_buf was pre-sized to block_size + ZXC_DECOMPRESS_TAIL_PAD inside
-     * the matching zxc_cctx_init call above. */
+    // work_buf was pre-sized to block_size + ZXC_DECOMPRESS_TAIL_PAD inside
+    // the matching zxc_cctx_init call above.
     const size_t work_sz = block_size + ZXC_DECOMPRESS_TAIL_PAD;
 
     int res;
     if (dict && dict_size > 0) {
-        /* [dict | decode] assembled in the cctx-owned dict_buffer */
+        // [dict | decode] assembled in the cctx-owned dict_buffer
         uint8_t* const dec_buf = ctx->dict_buffer;
         ZXC_MEMCPY(dec_buf, dict, dict_size);
         res = zxc_decompress_chunk_wrapper(ctx, (const uint8_t*)src, src_size, dec_buf + dict_size,
@@ -1772,7 +1583,7 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
         res = zxc_decompress_chunk_wrapper(ctx, (const uint8_t*)src, src_size, (uint8_t*)dst,
                                            dst_capacity);
     } else {
-        /* Bounce through work_buf when output can't absorb wild copies. */
+        // Bounce through work_buf when output can't absorb wild copies.
         res = zxc_decompress_chunk_wrapper(ctx, (const uint8_t*)src, src_size, ctx->work_buf,
                                            ctx->work_buf_cap);
         if (LIKELY(res > 0)) {
@@ -1791,14 +1602,6 @@ int64_t zxc_decompress_block(zxc_dctx* dctx, const void* RESTRICT src, const siz
  * use the strict safe decoder (no bounce buffer, no +ZXC_DECOMPRESS_TAIL_PAD).
  *
  * Public API; full contract in @c zxc_buffer.h.
- *
- * @param[in,out] dctx          Reusable decompression context.
- * @param[in]     src           Compressed block bytes.
- * @param[in]     src_size      Source length (>= @c ZXC_BLOCK_HEADER_SIZE).
- * @param[out]    dst           Destination for the decoded payload.
- * @param[in]     dst_capacity  Exact uncompressed size (<= @c ZXC_BLOCK_SIZE_MAX).
- * @param[in]     opts          Per-call options (dict, checksum), or NULL.
- * @return Decoded payload size in bytes on success, or a negative @ref zxc_error_t.
  */
 int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* RESTRICT src, const size_t src_size,
                                   void* RESTRICT dst, const size_t dst_capacity,
@@ -1806,21 +1609,21 @@ int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* RESTRICT src, cons
     if (UNLIKELY(!dctx || !src || !dst || src_size < ZXC_BLOCK_HEADER_SIZE || dst_capacity == 0))
         return ZXC_ERROR_NULL_INPUT;
 
-    /* Strict-tail variant: dst_capacity matches the exact uncompressed size */
+    // Strict-tail variant: dst_capacity matches the exact uncompressed size
     if (UNLIKELY(dst_capacity > ZXC_BLOCK_SIZE_MAX)) return ZXC_ERROR_BAD_BLOCK_SIZE;
 
-    /* A dict needs the [dict|payload] bounce; route to the bounce-capable path. */
+    // A dict needs the [dict|payload] bounce; route to the bounce-capable path.
     if (opts && opts->dict && opts->dict_size > 0) {
         return zxc_decompress_block(dctx, src, src_size, dst, dst_capacity, opts);
     }
 
     const uint8_t type = ((const uint8_t*)src)[0];
-    /* RAW never wild-writes past dst_capacity: route to the existing fast API. */
+    // RAW never wild-writes past dst_capacity: route to the existing fast API.
     if (type == ZXC_BLOCK_RAW) {
         return zxc_decompress_block(dctx, src, src_size, dst, dst_capacity, opts);
     }
 
-    /* GLO/GHI: use the strict-tail decoder (no bounce buffer required). */
+    // GLO/GHI: use the strict-tail decoder (no bounce buffer required).
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
     const size_t block_size = zxc_block_size_ceil(dst_capacity);
     if (UNLIKELY(!dctx->initialized || dctx->last_block_size != block_size ||
@@ -1847,19 +1650,17 @@ int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* RESTRICT src, cons
     return (int64_t)res;
 }
 
-/*
- * ============================================================================
- * STATIC CONTEXT API (caller-allocated workspace)
- * ============================================================================
- * Places the public handle struct at the start of the workspace, then carves
- * the persistent buffer (via zxc_cctx_init_in_workspace) in the remaining
- * cache-line-aligned tail.  The caller owns the whole workspace; free
- * functions become no-ops via the owns_workspace flag.
- */
+// ============================================================================
+// STATIC CONTEXT API (caller-allocated workspace)
+// ============================================================================
+// Places the public handle struct at the start of the workspace, then carves
+// the persistent buffer (via zxc_cctx_init_in_workspace) in the remaining
+// cache-line-aligned tail.  The caller owns the whole workspace; free
+// functions become no-ops via the owns_workspace flag.
 
-/* Size occupied by the opaque handle at the start of the workspace, rounded
- * up to a cache-line boundary so the persistent buffer (which expects 64 B
- * alignment for the hot zones) starts aligned. */
+// Size occupied by the opaque handle at the start of the workspace, rounded
+// up to a cache-line boundary so the persistent buffer (which expects 64 B
+// alignment for the hot zones) starts aligned.
 #define ZXC_STATIC_CCTX_HDR_SIZE ZXC_ALIGN_CL(sizeof(struct zxc_cctx_s))
 #define ZXC_STATIC_DCTX_HDR_SIZE ZXC_ALIGN_CL(sizeof(struct zxc_dctx_s))
 
@@ -1869,10 +1670,6 @@ int64_t zxc_decompress_block_safe(zxc_dctx* dctx, const void* RESTRICT src, cons
  * Public API; see @c zxc_buffer.h. Sum of the cache-line-aligned handle header
  * and the persistent buffer that @ref zxc_init_static_cctx carves for the given
  * @p block_size / @p level. Performs no allocation.
- *
- * @param[in] block_size  Block size the context will be pinned to.
- * @param[in] level       Compression level.
- * @return Required workspace size in bytes, or 0 if the parameters are invalid.
  */
 size_t zxc_static_cctx_workspace_size(const size_t block_size, const int level) {
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return 0;
@@ -1882,21 +1679,6 @@ size_t zxc_static_cctx_workspace_size(const size_t block_size, const int level) 
     return ZXC_STATIC_CCTX_HDR_SIZE + inner_sz;
 }
 
-/**
- * @brief Initialises a compression context inside a caller-supplied workspace.
- *
- * Public API; full contract in @c zxc_buffer.h. Places the opaque handle at the
- * start of @p workspace and carves the persistent buffer in the aligned tail -
- * no heap allocation. The block size is pinned for the context's lifetime, and
- * @ref zxc_free_cctx becomes a no-op (the caller owns @p workspace).
- *
- * @param[in] workspace       Caller buffer (>= @ref zxc_static_cctx_workspace_size).
- * @param[in] workspace_size  Capacity of @p workspace in bytes.
- * @param[in] opts            Compression options (non-NULL: level, block_size,
- *                            checksum).
- * @return A ready context owned by @p workspace, or NULL on invalid input or an
- *         undersized workspace.
- */
 zxc_cctx* zxc_init_static_cctx(void* RESTRICT workspace, const size_t workspace_size,
                                const zxc_compress_opts_t* RESTRICT opts) {
     if (UNLIKELY(!workspace || !opts)) return NULL;
@@ -1935,9 +1717,6 @@ zxc_cctx* zxc_init_static_cctx(void* RESTRICT workspace, const size_t workspace_
  * Public API; see @c zxc_buffer.h. Sum of the cache-line-aligned handle header
  * and the persistent buffer that @ref zxc_init_static_dctx carves for the given
  * @p block_size. Performs no allocation.
- *
- * @param[in] block_size  Block size the context will be pinned to.
- * @return Required workspace size in bytes, or 0 if @p block_size is invalid.
  */
 size_t zxc_static_dctx_workspace_size(const size_t block_size) {
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return 0;
@@ -1946,20 +1725,6 @@ size_t zxc_static_dctx_workspace_size(const size_t block_size) {
     return ZXC_STATIC_DCTX_HDR_SIZE + inner_sz;
 }
 
-/**
- * @brief Initialises a decompression context inside a caller-supplied workspace.
- *
- * Public API; full contract in @c zxc_buffer.h. Places the opaque handle at the
- * start of @p workspace and carves the persistent buffer in the aligned tail -
- * no heap allocation. The block size is pinned, so decoded archives must match
- * it; @ref zxc_free_dctx becomes a no-op (the caller owns @p workspace).
- *
- * @param[in] workspace       Caller buffer (>= @ref zxc_static_dctx_workspace_size).
- * @param[in] workspace_size  Capacity of @p workspace in bytes.
- * @param[in] block_size      Block size to pin the context to.
- * @return A ready context owned by @p workspace, or NULL on invalid input or an
- *         undersized workspace.
- */
 zxc_dctx* zxc_init_static_dctx(void* RESTRICT workspace, const size_t workspace_size,
                                const size_t block_size) {
     if (UNLIKELY(!workspace)) return NULL;
@@ -1973,8 +1738,8 @@ zxc_dctx* zxc_init_static_dctx(void* RESTRICT workspace, const size_t workspace_
     ZXC_MEMSET(dctx, 0, sizeof(*dctx));
 
     uint8_t* const inner_ws = (uint8_t*)workspace + ZXC_STATIC_DCTX_HDR_SIZE;
-    /* mode == 0 init: checksum_enabled is updated per-call from the file
-     * header flags, so it does not need to be locked at workspace init. */
+    // mode == 0 init: checksum_enabled is updated per-call from the file
+    // header flags, so it does not need to be locked at workspace init.
     if (UNLIKELY(zxc_cctx_init_in_workspace(&dctx->inner, inner_ws, inner_sz, block_size, 0, 0, 0,
                                             0, 0) != ZXC_OK))
         return NULL;

--- a/lz/zxc/src/lib/zxc_driver.c
+++ b/lz/zxc/src/lib/zxc_driver.c
@@ -37,134 +37,28 @@
 #include "../../include/zxc_seekable.h"
 #include "../../include/zxc_stream.h"
 #include "zxc_internal.h"
+#include "zxc_threads.h"
 
-/*
- * ============================================================================
- * WINDOWS THREADING EMULATION
- * ============================================================================
- * Maps POSIX pthread calls to the Windows Native API, so one threading logic
- * compiles on Linux/macOS and Windows.
- */
+// ============================================================================
+// PLATFORM SHIMS
+// ============================================================================
+// Threading comes from zxc_threads.h (POSIX names everywhere, Win32 underneath);
+// only the file-positioning names are remapped here, next to their users.
 #if defined(_WIN32)
 #include <io.h> /* _get_osfhandle, _fileno (used by zxc_seekable_open_file) */
 #include <malloc.h>
-#include <process.h>
 #include <sys/types.h>
 #include <windows.h>
 
 // Map POSIX file positioning functions to Windows equivalents
 #define fseeko _fseeki64
 #define ftello _ftelli64
-
-/**
- * @brief Returns the logical-processor count (backs the @c sysconf shim below).
- * @return Number of processors reported by @c GetSystemInfo.
- */
-static int zxc_get_num_procs(void) {
-    SYSTEM_INFO sysinfo;
-    GetSystemInfo(&sysinfo);
-    return sysinfo.dwNumberOfProcessors;
-}
-
-typedef CRITICAL_SECTION pthread_mutex_t;
-typedef CONDITION_VARIABLE pthread_cond_t;
-typedef HANDLE pthread_t;
-
-#define pthread_mutex_init(m, a) InitializeCriticalSection(m)
-#define pthread_mutex_destroy(m) DeleteCriticalSection(m)
-#define pthread_mutex_lock(m) EnterCriticalSection(m)
-#define pthread_mutex_unlock(m) LeaveCriticalSection(m)
-
-#define pthread_cond_init(c, a) InitializeConditionVariable(c)
-#define pthread_cond_destroy(c) (void)(0)
-#define pthread_cond_wait(c, m) SleepConditionVariableCS(c, m, INFINITE)
-#define pthread_cond_signal(c) WakeConditionVariable(c)
-#define pthread_cond_broadcast(c) WakeAllConditionVariable(c)
-
-/**
- * @brief Trampoline payload bridging the POSIX @c void*(*)(void*) worker
- *        signature to the @c _beginthreadex entry point.
- *
- * Heap-allocated by the @c pthread_create shim and freed by
- * @ref zxc_win_thread_entry once the captured worker has started.
- */
-typedef struct {
-    void* (*func)(void*); /* worker to invoke */
-    void* arg;            /* argument forwarded to @c func */
-} zxc_win_thread_arg_t;
-
-/**
- * @brief @c _beginthreadex entry point: unpacks the trampoline payload, frees
- *        it, then runs the captured POSIX-style worker.
- *
- * @param[in] p  Heap @ref zxc_win_thread_arg_t handed over by the creator;
- *               ownership transfers to this function.
- * @return Always 0 (the worker's @c void* result is discarded, as on POSIX).
- */
-static unsigned __stdcall zxc_win_thread_entry(void* p) {
-    zxc_win_thread_arg_t* a = (zxc_win_thread_arg_t*)p;
-    void* (*f)(void*) = a->func;
-    void* arg = a->arg;
-    ZXC_FREE(a);
-    f(arg);
-    return 0;
-}
-
-/**
- * @brief @c pthread_create shim: spawns @p start_routine(@p arg) via
- *        @c _beginthreadex, matching the POSIX prototype.
- *
- * @param[out] thread        Receives the thread handle on success.
- * @param[in]  attr          Unused (POSIX attribute object); ignored.
- * @param[in]  start_routine Worker to run on the new thread.
- * @param[in]  arg           Opaque argument forwarded to @p start_routine.
- * @return 0 on success, @ref ZXC_ERROR_MEMORY on allocation or spawn failure.
- */
-static int pthread_create(pthread_t* thread, const void* attr, void* (*start_routine)(void*),
-                          void* arg) {
-    (void)attr;
-    zxc_win_thread_arg_t* wrapper = ZXC_MALLOC(sizeof(zxc_win_thread_arg_t));
-    if (UNLIKELY(!wrapper)) return ZXC_ERROR_MEMORY;
-    wrapper->func = start_routine;
-    wrapper->arg = arg;
-    uintptr_t handle = _beginthreadex(NULL, 0, zxc_win_thread_entry, wrapper, 0, NULL);
-    if (UNLIKELY(handle == 0)) {
-        ZXC_FREE(wrapper);
-        return ZXC_ERROR_MEMORY;
-    }
-    *thread = (HANDLE)handle;
-    return 0;
-}
-
-/**
- * @brief @c pthread_join shim: blocks until @p thread finishes, then closes its
- *        handle.
- *
- * @param[in] thread  Handle from a successful @c pthread_create.
- * @param[in] retval  Unused (POSIX exit-value out-param); ignored.
- * @return Always 0.
- */
-static int pthread_join(pthread_t thread, void** retval) {
-    (void)retval;
-    WaitForSingleObject(thread, INFINITE);
-    CloseHandle(thread);
-    return 0;
-}
-
-#define sysconf(x) zxc_get_num_procs()
-#define _SC_NPROCESSORS_ONLN 0
-
-#else
-#include <pthread.h>
-#include <unistd.h>
 #endif
 
-/*
- * ============================================================================
- * STREAMING ENGINE (Producer / Worker / Consumer)
- * ============================================================================
- * Implements a Ring Buffer architecture to parallelize block processing.
- */
+// ============================================================================
+// STREAMING ENGINE (Producer / Worker / Consumer)
+// ============================================================================
+// Implements a Ring Buffer architecture to parallelize block processing.
 
 /**
  * @enum job_status_t
@@ -286,7 +180,11 @@ typedef int (*zxc_chunk_processor_t)(zxc_cctx_t* RESTRICT ctx, const uint8_t* RE
  * @var zxc_stream_ctx_t::compression_mode
  *      Indicates the operation mode (e.g., compression or decompression).
  * @var zxc_stream_ctx_t::io_error
- *      Atomic flag to signal if an I/O error occurred during processing.
+ *      Atomic flag telling every thread to stop. Set for any failure, not just
+ *      I/O, because the wait loops poll it without holding the lock.
+ * @var zxc_stream_ctx_t::fail_code
+ *      The first failure's actual error code, kept so a corrupt archive is not
+ *      reported as an I/O problem. Written under @c lock, first writer wins.
  * @var zxc_stream_ctx_t::processor
  *      Function pointer or object responsible for the actual chunk processing
  * logic.
@@ -329,6 +227,7 @@ typedef struct {
     int shutdown_workers;
     int compression_mode;
     ZXC_ATOMIC int io_error;
+    int fail_code;
     zxc_chunk_processor_t processor;
     int write_idx;
     int compression_level;
@@ -389,32 +288,19 @@ typedef struct {
 } writer_args_t;
 
 /**
- * @brief Worker thread function for parallel stream processing.
+ * @brief Worker thread: pull a job, process it, hand it to the writer.
  *
- * This function serves as the entry point for worker threads in the ZXC
- * streaming compression/decompression context. It continuously retrieves jobs
- * from a shared work queue, processes them using a thread-local compression
- * context (`zxc_cctx_t`), and signals the writer thread upon completion.
+ * Sleeps on @c cond_worker until @c worker_queue has a job, then runs
+ * @c ctx->processor over it and marks it @c JOB_STATUS_PROCESSED. Each worker
+ * owns a thread-local @c zxc_cctx_t so the parallel part never touches a shared
+ * context.
  *
- * **Worker Lifecycle & Synchronization:**
- * 1. **Initialization:** Allocates a thread-local `zxc_cctx_t` to avoid lock
- * contention during compression/decompression.
- * 2. **Wait Loop:** Uses `pthread_cond_wait` on `cond_worker` to sleep until a
- * job is available in the `worker_queue`.
- * 3. **Job Retrieval:** Dequeues a job ID from the ring buffer. The
- * `worker_queue` acts as a load balancer.
- * 4. **Processing:** Calls `ctx->processor` (the compression/decompression
- * function) on the job's data. This is the CPU-intensive part and runs in
- * parallel.
- * 5. **Completion:** Updates `job->status` to `JOB_STATUS_PROCESSED`.
- * 6. **Signaling:** If the processed job is the *next* one expected by the
- * writer
- *    (`jid == ctx->write_idx`), it signals `cond_writer`. This optimization
- * prevents unnecessary wake-ups of the writer thread for out-of-order
- * completions.
+ * The writer is signalled only when the finished job is the one it is waiting
+ * for (@c jid == @c ctx->write_idx). Jobs completing out of order stay silent,
+ * which keeps the writer from waking up on work it cannot yet emit.
  *
- * @param[in] arg A pointer to the shared stream context (`zxc_stream_ctx_t`).
- * @return Always returns NULL.
+ * @param[in] arg The shared @c zxc_stream_ctx_t.
+ * @return Always NULL.
  */
 static void* zxc_stream_worker(void* arg) {
     zxc_stream_ctx_t* const ctx = (zxc_stream_ctx_t*)arg;
@@ -443,7 +329,7 @@ static void* zxc_stream_worker(void* arg) {
 
     cctx.compression_level = ctx->compression_level;
 
-    /* Per-worker dict buffer for assembling [dict | block_data] */
+    // Per-worker dict buffer for assembling [dict | block_data]
     const size_t dsz = ctx->dict_size;
     uint8_t* const dict_work = cctx.dict_buffer;
     if (dict_work) ZXC_MEMCPY(dict_work, ctx->dict, dsz);
@@ -480,6 +366,8 @@ static void* zxc_stream_worker(void* arg) {
         job->result_sz = UNLIKELY(res < 0) ? 0 : (size_t)res;
         job->status = JOB_STATUS_PROCESSED;
         if (UNLIKELY(res < 0)) {
+            // Keep the codec's own diagnosis; io_error only stops the others.
+            if (!ctx->fail_code) ctx->fail_code = res;
             ctx->io_error = 1;
             pthread_cond_broadcast(&ctx->cond_writer);
             pthread_cond_broadcast(&ctx->cond_reader);
@@ -556,7 +444,7 @@ static void* zxc_async_writer(void* arg) {
         }
         args->total_bytes += (int64_t)result_sz;
 
-        /* Seekable: record compressed block size */
+        // Seekable: record compressed block size
         if (args->seek_comp && ctx->compression_mode == 1) {
             if (UNLIKELY(args->seek_count >= args->seek_cap)) {
                 args->seek_cap = args->seek_cap * 2;
@@ -592,6 +480,239 @@ static void* zxc_async_writer(void* arg) {
         pthread_mutex_unlock(&ctx->lock);
     }
     return NULL;
+}
+
+/**
+ * @brief Tears the engine down after a setup failure and reports the error.
+ *
+ * Stops and joins whatever workers were started, destroys the ring's
+ * synchronisation objects and releases every allocation made so far. Each
+ * failure point returns through here, so the destruction order lives in one
+ * place; all pointers may be NULL.
+ */
+// LCOV_EXCL_START
+static int64_t zxc_stream_engine_fail(zxc_stream_ctx_t* ctx, pthread_t* workers, const int started,
+                                      uint8_t* mem_block, uint32_t* seek_comp, const int64_t code) {
+    if (started > 0) {
+        pthread_mutex_lock(&ctx->lock);
+        ctx->shutdown_workers = 1;
+        pthread_cond_broadcast(&ctx->cond_worker);
+        pthread_mutex_unlock(&ctx->lock);
+        for (int i = 0; i < started; i++) pthread_join(workers[i], NULL);
+    }
+    pthread_cond_destroy(&ctx->cond_writer);
+    pthread_cond_destroy(&ctx->cond_worker);
+    pthread_cond_destroy(&ctx->cond_reader);
+    pthread_mutex_destroy(&ctx->lock);
+    ZXC_FREE(workers);
+    ZXC_FREE(seek_comp);
+    ZXC_ALIGNED_FREE(mem_block);
+    return code;
+}
+// LCOV_EXCL_STOP
+
+/**
+ * @brief Reads the input and feeds the ring until the stream ends.
+ *
+ * Returns the ring index the terminator job goes to.
+ */
+static int zxc_stream_read_loop(zxc_stream_ctx_t* ctx, FILE* f_in, const int mode,
+                                const size_t chunk_sz, uint64_t* total_src_bytes,
+                                uint32_t* d_global_hash) {
+    int read_idx = 0;
+    int read_eof = 0;
+
+    while (!read_eof && !ctx->io_error) {
+        zxc_stream_job_t* const job = &ctx->jobs[read_idx];
+        pthread_mutex_lock(&ctx->lock);
+        while (job->status != JOB_STATUS_FREE && !ctx->io_error)
+            pthread_cond_wait(&ctx->cond_reader, &ctx->lock);
+        pthread_mutex_unlock(&ctx->lock);
+
+        if (UNLIKELY(ctx->io_error)) break;
+
+        size_t read_sz = 0;
+        if (mode == 1) {
+            read_sz = fread(job->in_buf, 1, chunk_sz, f_in);
+            *total_src_bytes += read_sz;
+            if (UNLIKELY(read_sz == 0)) read_eof = 1;
+        } else {
+            uint8_t bh_buf[ZXC_BLOCK_HEADER_SIZE];
+            size_t h_read = fread(bh_buf, 1, ZXC_BLOCK_HEADER_SIZE, f_in);
+            if (UNLIKELY(h_read < ZXC_BLOCK_HEADER_SIZE)) {
+                read_eof = 1;
+            } else {
+                zxc_block_header_t bh;
+                if (UNLIKELY(zxc_read_block_header(bh_buf, ZXC_BLOCK_HEADER_SIZE, &bh) != ZXC_OK)) {
+                    ctx->io_error = 1;
+                    if (!ctx->fail_code) ctx->fail_code = ZXC_ERROR_CORRUPT_DATA;
+                    read_eof = 1;
+                    goto _job_prepared;
+                }
+
+                if (bh.block_type == ZXC_BLOCK_EOF) {
+                    if (UNLIKELY(bh.comp_size != 0)) {
+                        // LCOV_EXCL_START
+                        ctx->io_error = 1;
+                        read_eof = 1;
+                        goto _job_prepared;
+                        // LCOV_EXCL_STOP
+                    }
+                    read_eof = 1;
+                    read_sz = 0;
+                    goto _job_prepared;
+                }
+
+                const int has_checksum = ctx->file_has_checksum;
+                const size_t checksum_sz = (has_checksum ? ZXC_BLOCK_CHECKSUM_SIZE : 0);
+                const uint64_t total_len =
+                    (uint64_t)bh.comp_size + checksum_sz + ZXC_BLOCK_HEADER_SIZE;
+                if (UNLIKELY(total_len > (uint64_t)job->in_cap)) {
+                    ctx->io_error = 1;
+                    break;
+                }
+                const size_t body_total = (size_t)bh.comp_size + checksum_sz;
+
+                ZXC_MEMCPY(job->in_buf, bh_buf, ZXC_BLOCK_HEADER_SIZE);
+
+                // Single fread for body + checksum (reduces syscalls)
+                const size_t body_read =
+                    fread(job->in_buf + ZXC_BLOCK_HEADER_SIZE, 1, body_total, f_in);
+
+                if (UNLIKELY(body_read != body_total)) {
+                    ctx->io_error = 1;
+                    break;
+                } else if (has_checksum) {
+                    // Update Global Hash for Decompression
+                    const uint32_t b_checksum =
+                        zxc_le32(job->in_buf + ZXC_BLOCK_HEADER_SIZE + bh.comp_size);
+                    *d_global_hash = zxc_hash_combine_rotate(*d_global_hash, b_checksum);
+                }
+                read_sz = ZXC_BLOCK_HEADER_SIZE + body_read;
+            }
+        }
+    _job_prepared:
+        if (UNLIKELY(read_eof && read_sz == 0)) break;
+
+        job->in_sz = read_sz;
+        pthread_mutex_lock(&ctx->lock);
+        job->status = JOB_STATUS_FILLED;
+        ctx->worker_queue[ctx->wq_head] = read_idx;
+        ctx->wq_head = (ctx->wq_head + 1) % ctx->ring_size;
+        ctx->wq_count++;
+        read_idx = (read_idx + 1) % ctx->ring_size;
+        pthread_cond_signal(&ctx->cond_worker);
+        pthread_mutex_unlock(&ctx->lock);
+
+        if (UNLIKELY(read_sz < chunk_sz && mode == 1)) read_eof = 1;
+    }
+    return read_idx;
+}
+
+/**
+ * @brief Closes a compressed stream: EOF block, optional seek table, footer.
+ *
+ * Runs once the writer thread has drained, so it appends straight to the file.
+ */
+static void zxc_stream_finish_compress(zxc_stream_ctx_t* ctx, writer_args_t* w, FILE* f_out,
+                                       const uint64_t total_src_bytes, const int checksum_enabled) {
+    // EOF block
+    uint8_t eof_buf[ZXC_BLOCK_HEADER_SIZE];
+    const zxc_block_header_t eof_bh = {
+        .block_type = ZXC_BLOCK_EOF, .block_flags = 0, .reserved = 0, .comp_size = 0};
+    zxc_write_block_header(eof_buf, ZXC_BLOCK_HEADER_SIZE, &eof_bh);
+    if (UNLIKELY(f_out &&
+                 fwrite(eof_buf, 1, ZXC_BLOCK_HEADER_SIZE, f_out) != ZXC_BLOCK_HEADER_SIZE))
+        ctx->io_error = 1;  // LCOV_EXCL_LINE
+    else
+        w->total_bytes += ZXC_BLOCK_HEADER_SIZE;
+
+    // Seekable: write SEK block between EOF and footer
+    if (!ctx->io_error && w->seek_comp && w->seek_count > 0) {
+        const size_t st_size = zxc_seek_table_size(w->seek_count);
+        uint8_t* const st_buf = (uint8_t*)ZXC_MALLOC(st_size);
+        if (UNLIKELY(!st_buf)) {
+            ctx->io_error = 1;                                       // LCOV_EXCL_LINE
+            if (!ctx->fail_code) ctx->fail_code = ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
+        } else {
+            const int64_t st_val =
+                zxc_write_seek_table(st_buf, st_size, w->seek_comp, w->seek_count);
+            if (UNLIKELY(st_val <= 0 ||
+                         (f_out && fwrite(st_buf, 1, (size_t)st_val, f_out) != (size_t)st_val)))
+                ctx->io_error = 1;  // LCOV_EXCL_LINE
+            else
+                w->total_bytes += st_val;
+            ZXC_FREE(st_buf);
+        }
+    }
+
+    // Footer
+    uint8_t footer_buf[ZXC_FILE_FOOTER_SIZE];
+    zxc_write_file_footer(footer_buf, ZXC_FILE_FOOTER_SIZE, total_src_bytes, w->global_hash,
+                          checksum_enabled);
+    if (UNLIKELY(f_out &&
+                 fwrite(footer_buf, 1, ZXC_FILE_FOOTER_SIZE, f_out) != ZXC_FILE_FOOTER_SIZE))
+        ctx->io_error = 1;
+    else
+        w->total_bytes += ZXC_FILE_FOOTER_SIZE;
+}
+
+/**
+ * @brief Consumes and validates the trailer of a decompressed stream.
+ */
+static void zxc_stream_finish_decompress(zxc_stream_ctx_t* ctx, const writer_args_t* w, FILE* f_in,
+                                         const uint32_t d_global_hash, const int checksum_enabled) {
+    // After the EOF block, the stream may contain:
+    //   (a) [FOOTER 12B]                  - no seekable table
+    //   (b) [SEK header 8B] [payload] [FOOTER 12B] - seekable archive
+    uint8_t peek_buf[ZXC_BLOCK_HEADER_SIZE];
+    uint8_t footer[ZXC_FILE_FOOTER_SIZE];
+
+    if (UNLIKELY(fread(peek_buf, 1, ZXC_BLOCK_HEADER_SIZE, f_in) != ZXC_BLOCK_HEADER_SIZE)) {
+        ctx->io_error = 1;
+    } else {
+        zxc_block_header_t peek_bh;
+        const int is_sek =
+            (zxc_read_block_header(peek_buf, ZXC_BLOCK_HEADER_SIZE, &peek_bh) == ZXC_OK &&
+             peek_bh.block_type == ZXC_BLOCK_SEK);
+
+        if (is_sek) {
+            // Drain the SEK payload (read + discard)
+            size_t remaining = (size_t)peek_bh.comp_size;
+            uint8_t discard[512];
+            while (remaining > 0 && !ctx->io_error) {
+                const size_t chunk = remaining < sizeof(discard) ? remaining : sizeof(discard);
+                if (UNLIKELY(fread(discard, 1, chunk, f_in) != chunk)) ctx->io_error = 1;
+                remaining -= chunk;
+            }
+            // Read full 12-byte footer
+            if (!ctx->io_error &&
+                UNLIKELY(fread(footer, 1, ZXC_FILE_FOOTER_SIZE, f_in) != ZXC_FILE_FOOTER_SIZE))
+                ctx->io_error = 1;  // LCOV_EXCL_LINE
+        } else {
+            // peek_buf contains the first 8 bytes of the 12-byte footer.
+            // Read the remaining 4 bytes and assemble.
+            ZXC_MEMCPY(footer, peek_buf, ZXC_BLOCK_HEADER_SIZE);
+            const size_t tail = ZXC_FILE_FOOTER_SIZE - ZXC_BLOCK_HEADER_SIZE; /* 4 */
+            if (UNLIKELY(fread(footer + ZXC_BLOCK_HEADER_SIZE, 1, tail, f_in) != tail))
+                ctx->io_error = 1;  // LCOV_EXCL_LINE
+        }
+    }
+
+    // Verify Footer Content: Source Size and Global Checksum
+    if (!ctx->io_error) {
+        const int size_ok = (zxc_le64(footer) == (uint64_t)w->total_bytes);
+        int valid = size_ok;
+        if (valid && checksum_enabled && ctx->file_has_checksum)
+            valid = (zxc_le32(footer + sizeof(uint64_t)) == d_global_hash);
+        if (UNLIKELY(!valid)) {
+            // A footer that disagrees with what we produced is corruption,
+            // not an I/O fault; tell the two apart for the caller.
+            if (!ctx->fail_code)
+                ctx->fail_code = size_ok ? ZXC_ERROR_BAD_CHECKSUM : ZXC_ERROR_CORRUPT_DATA;
+            ctx->io_error = 1;
+        }
+    }
 }
 
 /**
@@ -665,10 +786,12 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
         // Decompression Mode: Read and validate file header
         uint8_t h[ZXC_FILE_HEADER_SIZE];
         uint32_t header_dict_id = 0;
-        if (UNLIKELY(fread(h, 1, ZXC_FILE_HEADER_SIZE, f_in) != ZXC_FILE_HEADER_SIZE ||
-                     zxc_read_file_header(h, ZXC_FILE_HEADER_SIZE, &runtime_chunk_sz, &file_has_chk,
-                                          &header_dict_id) != ZXC_OK))
-            return ZXC_ERROR_BAD_HEADER;
+        if (UNLIKELY(fread(h, 1, ZXC_FILE_HEADER_SIZE, f_in) != ZXC_FILE_HEADER_SIZE))
+            return ZXC_ERROR_SRC_TOO_SMALL;
+
+        const int hrc = zxc_read_file_header(h, ZXC_FILE_HEADER_SIZE, &runtime_chunk_sz,
+                                             &file_has_chk, &header_dict_id);
+        if (UNLIKELY(hrc != ZXC_OK)) return hrc;
 
         if (header_dict_id != 0) {
             if (UNLIKELY(!dict || dict_size == 0)) return ZXC_ERROR_DICT_REQUIRED;
@@ -677,7 +800,7 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
         }
     }
 
-    int num_threads = (n_threads > 0) ? n_threads : (int)sysconf(_SC_NPROCESSORS_ONLN);
+    int num_threads = (n_threads > 0) ? n_threads : zxc_num_procs();
     if (num_threads > ZXC_MAX_THREADS) num_threads = ZXC_MAX_THREADS;
     // Reserve 1 thread for Writer/Reader overhead if possible
     const int num_workers = (num_threads > 1) ? num_threads - 1 : 1;
@@ -685,6 +808,7 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     ctx.compression_mode = mode;
     ctx.processor = func;
     ctx.io_error = 0;
+    ctx.fail_code = 0;
     ctx.compression_level = level;
     ctx.ring_size = (size_t)num_workers * 4U;
     ctx.chunk_size = runtime_chunk_sz;
@@ -708,14 +832,10 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     const size_t alloc_out = (raw_alloc_out + ZXC_ALIGNMENT_MASK) & ~ZXC_ALIGNMENT_MASK;
 
     const size_t per_job_sz = sizeof(zxc_stream_job_t) + sizeof(int) + alloc_in + alloc_out;
-    const size_t alloc_size = ctx.ring_size * per_job_sz;
-    uint8_t* const mem_block = ZXC_ALIGNED_MALLOC(alloc_size, ZXC_CACHE_LINE_SIZE);
-    if (UNLIKELY(!mem_block || per_job_sz > SIZE_MAX / ctx.ring_size)) {
-        // LCOV_EXCL_START
-        ZXC_ALIGNED_FREE(mem_block);
-        return ZXC_ERROR_MEMORY;
-        // LCOV_EXCL_STOP
-    }
+    if (UNLIKELY(per_job_sz > SIZE_MAX / ctx.ring_size)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
+
+    uint8_t* const mem_block = ZXC_ALIGNED_MALLOC(ctx.ring_size * per_job_sz, ZXC_CACHE_LINE_SIZE);
+    if (UNLIKELY(!mem_block)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
 
     uint8_t* ptr = mem_block;
     ctx.jobs = (zxc_stream_job_t*)ptr;
@@ -745,164 +865,50 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     pthread_cond_init(&ctx.cond_writer, NULL);
 
     pthread_t* const workers = ZXC_MALLOC((size_t)num_workers * sizeof(pthread_t));
-    if (UNLIKELY(!workers)) {
-        // LCOV_EXCL_START
-        ZXC_ALIGNED_FREE(mem_block);
-        return ZXC_ERROR_MEMORY;
-        // LCOV_EXCL_STOP
-    }
+    if (UNLIKELY(!workers))
+        return zxc_stream_engine_fail(&ctx, NULL, 0, mem_block, NULL,  // LCOV_EXCL_LINE
+                                      ZXC_ERROR_MEMORY);               // LCOV_EXCL_LINE
     int started_workers = 0;
     for (int i = 0; i < num_workers; i++) {
         if (UNLIKELY(pthread_create(&workers[i], NULL, zxc_stream_worker, &ctx) != 0)) break;
         started_workers++;
     }
-    if (UNLIKELY(started_workers == 0)) {
-        // LCOV_EXCL_START
-        pthread_cond_destroy(&ctx.cond_writer);
-        pthread_cond_destroy(&ctx.cond_worker);
-        pthread_cond_destroy(&ctx.cond_reader);
-        pthread_mutex_destroy(&ctx.lock);
-        ZXC_FREE(workers);
-        ZXC_ALIGNED_FREE(mem_block);
-        return ZXC_ERROR_MEMORY;
-        // LCOV_EXCL_STOP
-    }
+    if (UNLIKELY(started_workers == 0))
+        return zxc_stream_engine_fail(&ctx, workers, 0, mem_block, NULL,  // LCOV_EXCL_LINE
+                                      ZXC_ERROR_MEMORY);                  // LCOV_EXCL_LINE
 
     writer_args_t w_args = {&ctx, f_out, 0, 0, 0, NULL, 0, 0};
 
-    /* Seekable: allocate initial block-size tracking array */
+    // Seekable: allocate initial block-size tracking array
     if (mode == 1 && seekable) {
         w_args.seek_cap = 64;
         w_args.seek_comp = (uint32_t*)ZXC_MALLOC(w_args.seek_cap * sizeof(uint32_t));
-        // LCOV_EXCL_START
-        if (UNLIKELY(!w_args.seek_comp)) {
-            pthread_mutex_lock(&ctx.lock);
-            ctx.shutdown_workers = 1;
-            pthread_cond_broadcast(&ctx.cond_worker);
-            pthread_mutex_unlock(&ctx.lock);
-            for (int i = 0; i < started_workers; i++) pthread_join(workers[i], NULL);
-            pthread_cond_destroy(&ctx.cond_writer);
-            pthread_cond_destroy(&ctx.cond_worker);
-            pthread_cond_destroy(&ctx.cond_reader);
-            pthread_mutex_destroy(&ctx.lock);
-            ZXC_FREE(workers);
-            ZXC_ALIGNED_FREE(mem_block);
-            return ZXC_ERROR_MEMORY;
-        }
-        // LCOV_EXCL_STOP
+        if (UNLIKELY(!w_args.seek_comp))
+            return zxc_stream_engine_fail(&ctx, workers, started_workers,  // LCOV_EXCL_LINE
+                                          mem_block,                       // LCOV_EXCL_LINE
+                                          NULL,                            // LCOV_EXCL_LINE
+                                          ZXC_ERROR_MEMORY);               // LCOV_EXCL_LINE
     }
 
-    if (mode == 1 && f_out) {
-        uint8_t h[ZXC_FILE_HEADER_SIZE];
-        zxc_write_file_header(h, ZXC_FILE_HEADER_SIZE, runtime_chunk_sz, checksum_enabled,
-                              (dict && dict_size) ? zxc_dict_id(dict, dict_size, dict_huf) : 0);
-        if (UNLIKELY(fwrite(h, 1, ZXC_FILE_HEADER_SIZE, f_out) != ZXC_FILE_HEADER_SIZE))
-            ctx.io_error = 1;
-
+    if (mode == 1) {
+        if (f_out) {
+            uint8_t h[ZXC_FILE_HEADER_SIZE];
+            zxc_write_file_header(h, ZXC_FILE_HEADER_SIZE, runtime_chunk_sz, checksum_enabled,
+                                  (dict && dict_size) ? zxc_dict_id(dict, dict_size, dict_huf) : 0);
+            if (UNLIKELY(fwrite(h, 1, ZXC_FILE_HEADER_SIZE, f_out) != ZXC_FILE_HEADER_SIZE))
+                ctx.io_error = 1;
+        }
         w_args.total_bytes = ZXC_FILE_HEADER_SIZE;
     }
     pthread_t writer_th;
-    if (UNLIKELY(pthread_create(&writer_th, NULL, zxc_async_writer, &w_args) != 0)) {
-        // LCOV_EXCL_START
-        pthread_mutex_lock(&ctx.lock);
-        ctx.shutdown_workers = 1;
-        pthread_cond_broadcast(&ctx.cond_worker);
-        pthread_mutex_unlock(&ctx.lock);
-        for (int i = 0; i < started_workers; i++) pthread_join(workers[i], NULL);
-        pthread_cond_destroy(&ctx.cond_writer);
-        pthread_cond_destroy(&ctx.cond_worker);
-        pthread_cond_destroy(&ctx.cond_reader);
-        pthread_mutex_destroy(&ctx.lock);
-        ZXC_FREE(workers);
-        ZXC_ALIGNED_FREE(mem_block);
-        return ZXC_ERROR_MEMORY;
-        // LCOV_EXCL_STOP
-    }
+    if (UNLIKELY(pthread_create(&writer_th, NULL, zxc_async_writer, &w_args) != 0))
+        return zxc_stream_engine_fail(&ctx, workers, started_workers, mem_block,  // LCOV_EXCL_LINE
+                                      w_args.seek_comp,                           // LCOV_EXCL_LINE
+                                      ZXC_ERROR_MEMORY);                          // LCOV_EXCL_LINE
 
-    int read_idx = 0;
-    int read_eof = 0;
     uint64_t total_src_bytes = 0;
-
-    // Reader Loop: Reads from file, prepares jobs, pushes to worker queue.
-    while (!read_eof && !ctx.io_error) {
-        zxc_stream_job_t* const job = &ctx.jobs[read_idx];
-        pthread_mutex_lock(&ctx.lock);
-        while (job->status != JOB_STATUS_FREE && !ctx.io_error)
-            pthread_cond_wait(&ctx.cond_reader, &ctx.lock);
-        pthread_mutex_unlock(&ctx.lock);
-
-        if (UNLIKELY(ctx.io_error)) break;
-
-        size_t read_sz = 0;
-        if (mode == 1) {
-            read_sz = fread(job->in_buf, 1, runtime_chunk_sz, f_in);
-            total_src_bytes += read_sz;
-            if (UNLIKELY(read_sz == 0)) read_eof = 1;
-        } else {
-            uint8_t bh_buf[ZXC_BLOCK_HEADER_SIZE];
-            size_t h_read = fread(bh_buf, 1, ZXC_BLOCK_HEADER_SIZE, f_in);
-            if (UNLIKELY(h_read < ZXC_BLOCK_HEADER_SIZE)) {
-                read_eof = 1;
-            } else {
-                zxc_block_header_t bh;
-                if (UNLIKELY(zxc_read_block_header(bh_buf, ZXC_BLOCK_HEADER_SIZE, &bh) != ZXC_OK)) {
-                    read_eof = 1;
-                    goto _job_prepared;
-                }
-
-                if (bh.block_type == ZXC_BLOCK_EOF) {
-                    if (UNLIKELY(bh.comp_size != 0)) {
-                        ctx.io_error = 1;
-                        goto _job_prepared;
-                    }
-                    read_eof = 1;
-                    read_sz = 0;
-                    goto _job_prepared;
-                }
-
-                const int has_crc = ctx.file_has_checksum;
-                const size_t checksum_sz = (has_crc ? ZXC_BLOCK_CHECKSUM_SIZE : 0);
-                const size_t body_total = bh.comp_size + checksum_sz;
-                const size_t total_len = ZXC_BLOCK_HEADER_SIZE + body_total;
-
-                if (UNLIKELY(total_len > job->in_cap)) {
-                    ctx.io_error = 1;
-                    break;
-                }
-
-                ZXC_MEMCPY(job->in_buf, bh_buf, ZXC_BLOCK_HEADER_SIZE);
-
-                // Single fread for body + checksum (reduces syscalls)
-                const size_t body_read =
-                    fread(job->in_buf + ZXC_BLOCK_HEADER_SIZE, 1, body_total, f_in);
-
-                if (UNLIKELY(body_read != body_total)) {
-                    ctx.io_error = 1;
-                    break;
-                } else if (has_crc) {
-                    // Update Global Hash for Decompression
-                    const uint32_t b_crc =
-                        zxc_le32(job->in_buf + ZXC_BLOCK_HEADER_SIZE + bh.comp_size);
-                    d_global_hash = zxc_hash_combine_rotate(d_global_hash, b_crc);
-                }
-                read_sz = ZXC_BLOCK_HEADER_SIZE + body_read;
-            }
-        }
-    _job_prepared:
-        if (UNLIKELY(read_eof && read_sz == 0)) break;
-
-        job->in_sz = read_sz;
-        pthread_mutex_lock(&ctx.lock);
-        job->status = JOB_STATUS_FILLED;
-        ctx.worker_queue[ctx.wq_head] = read_idx;
-        ctx.wq_head = (ctx.wq_head + 1) % ctx.ring_size;
-        ctx.wq_count++;
-        read_idx = (read_idx + 1) % ctx.ring_size;
-        pthread_cond_signal(&ctx.cond_worker);
-        pthread_mutex_unlock(&ctx.lock);
-
-        if (UNLIKELY(read_sz < runtime_chunk_sz && mode == 1)) read_eof = 1;
-    }
+    const int read_idx =
+        zxc_stream_read_loop(&ctx, f_in, mode, runtime_chunk_sz, &total_src_bytes, &d_global_hash);
 
     zxc_stream_job_t* const end_job = &ctx.jobs[read_idx];
     pthread_mutex_lock(&ctx.lock);
@@ -925,96 +931,18 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
     pthread_cond_destroy(&ctx.cond_reader);
     pthread_mutex_destroy(&ctx.lock);
 
-    // Write EOF Block + optional Seek Table + Footer if compression and no error
-    if (mode == 1 && !ctx.io_error && w_args.total_bytes >= 0) {
-        /* EOF block */
-        uint8_t eof_buf[ZXC_BLOCK_HEADER_SIZE];
-        const zxc_block_header_t eof_bh = {
-            .block_type = ZXC_BLOCK_EOF, .block_flags = 0, .reserved = 0, .comp_size = 0};
-        zxc_write_block_header(eof_buf, ZXC_BLOCK_HEADER_SIZE, &eof_bh);
-        if (UNLIKELY(f_out &&
-                     fwrite(eof_buf, 1, ZXC_BLOCK_HEADER_SIZE, f_out) != ZXC_BLOCK_HEADER_SIZE))
-            ctx.io_error = 1;
-        else
-            w_args.total_bytes += ZXC_BLOCK_HEADER_SIZE;
-
-        /* Seekable: write SEK block between EOF and footer */
-        if (!ctx.io_error && w_args.seek_comp && w_args.seek_count > 0) {
-            const size_t st_size = zxc_seek_table_size(w_args.seek_count);
-            uint8_t* const st_buf = (uint8_t*)ZXC_MALLOC(st_size);
-            if (st_buf) {
-                const int64_t st_val =
-                    zxc_write_seek_table(st_buf, st_size, w_args.seek_comp, w_args.seek_count);
-                if (st_val > 0 && f_out &&
-                    fwrite(st_buf, 1, (size_t)st_val, f_out) == (size_t)st_val)
-                    w_args.total_bytes += st_val;
-                ZXC_FREE(st_buf);
-            }
-        }
-
-        /* Footer */
-        uint8_t footer_buf[ZXC_FILE_FOOTER_SIZE];
-        zxc_write_file_footer(footer_buf, ZXC_FILE_FOOTER_SIZE, total_src_bytes, w_args.global_hash,
-                              checksum_enabled);
-        if (UNLIKELY(f_out &&
-                     fwrite(footer_buf, 1, ZXC_FILE_FOOTER_SIZE, f_out) != ZXC_FILE_FOOTER_SIZE))
-            ctx.io_error = 1;
-        else
-            w_args.total_bytes += ZXC_FILE_FOOTER_SIZE;
-    } else if (mode == 0 && !ctx.io_error) {
-        /*
-         * After the EOF block, the stream may contain:
-         *   (a) [FOOTER 12B]                  - no seekable table
-         *   (b) [SEK header 8B] [payload] [FOOTER 12B] - seekable archive
-         */
-        uint8_t peek_buf[ZXC_BLOCK_HEADER_SIZE];
-        uint8_t footer[ZXC_FILE_FOOTER_SIZE];
-
-        if (UNLIKELY(fread(peek_buf, 1, ZXC_BLOCK_HEADER_SIZE, f_in) != ZXC_BLOCK_HEADER_SIZE)) {
-            ctx.io_error = 1;
-        } else {
-            zxc_block_header_t peek_bh;
-            const int is_sek =
-                (zxc_read_block_header(peek_buf, ZXC_BLOCK_HEADER_SIZE, &peek_bh) == ZXC_OK &&
-                 peek_bh.block_type == ZXC_BLOCK_SEK);
-
-            if (is_sek) {
-                /* Drain the SEK payload (read + discard) */
-                size_t remaining = (size_t)peek_bh.comp_size;
-                uint8_t discard[512];
-                while (remaining > 0 && !ctx.io_error) {
-                    const size_t chunk = remaining < sizeof(discard) ? remaining : sizeof(discard);
-                    if (UNLIKELY(fread(discard, 1, chunk, f_in) != chunk)) ctx.io_error = 1;
-                    remaining -= chunk;
-                }
-                /* Read full 12-byte footer */
-                if (!ctx.io_error &&
-                    UNLIKELY(fread(footer, 1, ZXC_FILE_FOOTER_SIZE, f_in) != ZXC_FILE_FOOTER_SIZE))
-                    ctx.io_error = 1;
-            } else {
-                /* peek_buf contains the first 8 bytes of the 12-byte footer.
-                 * Read the remaining 4 bytes and assemble. */
-                ZXC_MEMCPY(footer, peek_buf, ZXC_BLOCK_HEADER_SIZE);
-                const size_t tail = ZXC_FILE_FOOTER_SIZE - ZXC_BLOCK_HEADER_SIZE; /* 4 */
-                if (UNLIKELY(fread(footer + ZXC_BLOCK_HEADER_SIZE, 1, tail, f_in) != tail))
-                    ctx.io_error = 1;
-            }
-        }
-
-        /* Verify Footer Content: Source Size and Global Checksum */
-        if (!ctx.io_error) {
-            int valid = (zxc_le64(footer) == (uint64_t)w_args.total_bytes);
-            if (valid && checksum_enabled && ctx.file_has_checksum)
-                valid = (zxc_le32(footer + sizeof(uint64_t)) == d_global_hash);
-            if (UNLIKELY(!valid)) ctx.io_error = 1;
-        }
-    }
+    if (mode == 1 && !ctx.io_error && w_args.total_bytes >= 0)
+        zxc_stream_finish_compress(&ctx, &w_args, f_out, total_src_bytes, checksum_enabled);
+    else if (mode == 0 && !ctx.io_error)
+        zxc_stream_finish_decompress(&ctx, &w_args, f_in, d_global_hash, checksum_enabled);
 
     ZXC_FREE(w_args.seek_comp);
     ZXC_FREE(workers);
     ZXC_ALIGNED_FREE(mem_block);
 
-    if (UNLIKELY(ctx.io_error)) return ZXC_ERROR_IO;
+    // fail_code carries the real cause when there is one; a bare io_error flag
+    // means the failure really was a read/write.
+    if (UNLIKELY(ctx.io_error)) return ctx.fail_code ? ctx.fail_code : ZXC_ERROR_IO;
 
     return w_args.total_bytes;
 }
@@ -1026,11 +954,6 @@ static int64_t zxc_stream_engine_run(FILE* f_in, FILE* f_out, const int n_thread
  * level, block size, checksums, seekable, dictionary) with their defaults, then
  * drives @ref zxc_stream_engine_run in compression mode with the
  * compress chunk processor.
- *
- * @param[in]  f_in   Input stream (must be non-NULL).
- * @param[out] f_out  Output stream (NULL performs a dry run / size estimate).
- * @param[in]  opts   Compression options, or NULL for all defaults.
- * @return Total bytes written on success, or a negative @ref zxc_error_t.
  */
 int64_t zxc_stream_compress(FILE* f_in, FILE* f_out, const zxc_compress_opts_t* opts) {
     if (UNLIKELY(!f_in)) return ZXC_ERROR_NULL_INPUT;
@@ -1038,18 +961,17 @@ int64_t zxc_stream_compress(FILE* f_in, FILE* f_out, const zxc_compress_opts_t* 
     const int n_threads = opts ? opts->n_threads : 0;
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
     const int seekable = opts ? opts->seekable : 0;
-    const int level = (opts && opts->level > 0) ? opts->level : ZXC_LEVEL_DEFAULT;
-    const size_t block_size =
-        (opts && opts->block_size > 0) ? opts->block_size : ZXC_BLOCK_SIZE_DEFAULT;
+    const int level = ZXC_OPTS_LEVEL(opts, ZXC_LEVEL_DEFAULT);
+    const size_t block_size = ZXC_OPTS_BLOCK_SIZE(opts, ZXC_BLOCK_SIZE_DEFAULT);
     const uint8_t* dict = opts ? (const uint8_t*)opts->dict : NULL;
-    const size_t dict_size = (opts && opts->dict) ? opts->dict_size : 0;
+    const size_t dict_size = ZXC_OPTS_DICT_SIZE(opts);
     zxc_progress_callback_t cb = opts ? opts->progress_cb : NULL;
     void* ud = opts ? opts->user_data : NULL;
 
     if (UNLIKELY(!zxc_validate_block_size(block_size))) return ZXC_ERROR_BAD_BLOCK_SIZE;
     if (UNLIKELY(dict_size > ZXC_DICT_SIZE_MAX)) return ZXC_ERROR_DICT_TOO_LARGE;
 
-    const uint8_t* dict_huf = (opts && opts->dict) ? (const uint8_t*)opts->dict_huf : NULL;
+    const uint8_t* dict_huf = ZXC_OPTS_DICT_HUF(opts);
     return zxc_stream_engine_run(f_in, f_out, n_threads, 1, level, block_size, checksum_enabled,
                                  seekable, zxc_compress_chunk_wrapper, cb, ud, dict, dict_size,
                                  dict_huf);
@@ -1062,11 +984,6 @@ int64_t zxc_stream_compress(FILE* f_in, FILE* f_out, const zxc_compress_opts_t* 
  * checksums, dictionary), then drives @ref zxc_stream_engine_run in
  * decompression mode with the decompress chunk processor. The block size and
  * level are recovered from the archive header, not from @p opts.
- *
- * @param[in]  f_in   Input (compressed) stream (must be non-NULL).
- * @param[out] f_out  Output (decompressed) stream.
- * @param[in]  opts   Decompression options, or NULL for all defaults.
- * @return Total bytes written on success, or a negative @ref zxc_error_t.
  */
 int64_t zxc_stream_decompress(FILE* f_in, FILE* f_out, const zxc_decompress_opts_t* opts) {
     if (UNLIKELY(!f_in)) return ZXC_ERROR_NULL_INPUT;
@@ -1074,11 +991,11 @@ int64_t zxc_stream_decompress(FILE* f_in, FILE* f_out, const zxc_decompress_opts
     const int n_threads = opts ? opts->n_threads : 0;
     const int checksum_enabled = opts ? opts->checksum_enabled : 0;
     const uint8_t* dict = opts ? (const uint8_t*)opts->dict : NULL;
-    const size_t dict_size = (opts && opts->dict) ? opts->dict_size : 0;
+    const size_t dict_size = ZXC_OPTS_DICT_SIZE(opts);
     zxc_progress_callback_t cb = opts ? opts->progress_cb : NULL;
     void* ud = opts ? opts->user_data : NULL;
 
-    const uint8_t* dict_huf = (opts && opts->dict) ? (const uint8_t*)opts->dict_huf : NULL;
+    const uint8_t* dict_huf = ZXC_OPTS_DICT_HUF(opts);
     return zxc_stream_engine_run(f_in, f_out, n_threads, 0, 0, 0, checksum_enabled, 0,
                                  (zxc_chunk_processor_t)zxc_decompress_chunk_wrapper, cb, ud, dict,
                                  dict_size, dict_huf);
@@ -1090,11 +1007,6 @@ int64_t zxc_stream_decompress(FILE* f_in, FILE* f_out, const zxc_decompress_opts
  * Public API; see @c zxc_stream.h. Validates the file magic, reads the 64-bit
  * decompressed-size field from the footer, and restores the caller's original
  * stream position before returning. Does not decompress any data.
- *
- * @param[in] f_in  Compressed stream (must be non-NULL and seekable).
- * @return Decompressed size in bytes, or a negative @ref zxc_error_t
- *         (@ref ZXC_ERROR_BAD_MAGIC, @ref ZXC_ERROR_SRC_TOO_SMALL,
- *         @ref ZXC_ERROR_IO).
  */
 int64_t zxc_stream_get_decompressed_size(FILE* f_in) {
     if (UNLIKELY(!f_in)) return ZXC_ERROR_NULL_INPUT;
@@ -1133,14 +1045,12 @@ int64_t zxc_stream_get_decompressed_size(FILE* f_in) {
     return (int64_t)zxc_le64(footer);
 }
 
-/*
- * ============================================================================
- * SEEKABLE FILE* WRAPPER
- * ============================================================================
- * Adapts a FILE* into a thread-safe zxc_reader_t (pread, or ReadFile +
- * OVERLAPPED on Windows). It lives here rather than in zxc_seekable.c so that
- * file stays freestanding.
- */
+// ============================================================================
+// SEEKABLE FILE* WRAPPER
+// ============================================================================
+// Adapts a FILE* into a thread-safe zxc_reader_t (pread, or ReadFile +
+// OVERLAPPED on Windows). It lives here rather than in zxc_seekable.c so that
+// file stays freestanding.
 
 #if defined(_WIN32)
 /** @brief Reader context for the Win32 @c FILE* adapter (OS file handle + size). */
@@ -1155,7 +1065,7 @@ typedef struct {
  * Win32 implementation: a positioned @c ReadFile via @c OVERLAPPED, so
  * concurrent worker threads never race on a shared file cursor.
  *
- * @param[in]  vctx    @ref zxc_stdio_ctx_t carrying the file handle.
+ * @param[in]  vctx    `zxc_stdio_ctx_t` carrying the file handle.
  * @param[out] dst     Destination buffer (at least @p len bytes).
  * @param[in]  len     Number of bytes to read.
  * @param[in]  offset  Absolute byte offset to read from.
@@ -1166,7 +1076,7 @@ static int64_t zxc_stdio_read_at(void* vctx, void* dst, size_t len, uint64_t off
     zxc_stdio_ctx_t* const ctx = (zxc_stdio_ctx_t*)vctx;
     OVERLAPPED ov;
     ZXC_MEMSET(&ov, 0, sizeof(ov));
-    ov.Offset = (DWORD)(offset & 0xFFFFFFFFu);
+    ov.Offset = (DWORD)(offset & 0xFFFFFFFFU);
     ov.OffsetHigh = (DWORD)(offset >> 32);
     DWORD bytes_read = 0;
     if (!ReadFile(ctx->handle, dst, (DWORD)len, &bytes_read, &ov)) return ZXC_ERROR_IO;
@@ -1187,7 +1097,7 @@ typedef struct {
  * POSIX implementation: a single @c pread, which carries its own offset and so
  * is safe to call concurrently from multiple worker threads on one descriptor.
  *
- * @param[in]  vctx    @ref zxc_stdio_ctx_t carrying the file descriptor.
+ * @param[in]  vctx    `zxc_stdio_ctx_t` carrying the file descriptor.
  * @param[out] dst     Destination buffer (at least @p len bytes).
  * @param[in]  len     Number of bytes to read.
  * @param[in]  offset  Absolute byte offset to read from.
@@ -1209,15 +1119,11 @@ static int64_t zxc_stdio_read_at(void* vctx, void* dst, size_t len, uint64_t off
  * delegates to @ref zxc_seekable_open_reader. The reader context is heap-owned
  * and handed to the returned handle via @ref zxc_seekable_attach_owned_ctx, so
  * @ref zxc_seekable_free releases it.
- *
- * @param[in] f  Open, seekable file handle.
- * @return A handle to release with @ref zxc_seekable_free, or NULL on bad input,
- *         an I/O error, or a missing / malformed seek table.
  */
 zxc_seekable* zxc_seekable_open_file(FILE* f) {
     if (UNLIKELY(!f)) return NULL;
 
-    /* Snapshot the caller's file position so we can restore it. */
+    // Snapshot the caller's file position so we can restore it.
     const long long saved_pos = ftello(f);
     if (UNLIKELY(saved_pos < 0)) return NULL;  // LCOV_EXCL_LINE
 
@@ -1247,7 +1153,7 @@ zxc_seekable* zxc_seekable_open_file(FILE* f) {
         return NULL;
     }
 
-    /* Hand the ctx lifetime over to the seekable handle. */
+    // Hand the ctx lifetime over to the seekable handle.
     zxc_seekable_attach_owned_ctx(s, ctx);
     return s;
 }

--- a/lz/zxc/src/lib/zxc_huffman.c
+++ b/lz/zxc/src/lib/zxc_huffman.c
@@ -31,13 +31,11 @@
  * private to this translation unit.
  */
 
-/*
- * Function Multi-Versioning Support
- * With ZXC_FUNCTION_SUFFIX defined (e.g. _avx2), each variant TU gets its own
- * copy under a unique symbol, which the runtime dispatcher routes to. The
- * defines precede zxc_internal.h so the header's prototypes take the same
- * suffix as the definitions below.
- */
+// Function Multi-Versioning Support
+// With ZXC_FUNCTION_SUFFIX defined (e.g. _avx2), each variant TU gets its own
+// copy under a unique symbol, which the runtime dispatcher routes to. The
+// defines precede zxc_internal.h so the header's prototypes take the same
+// suffix as the definitions below.
 #ifdef ZXC_FUNCTION_SUFFIX
 #define ZXC_CAT_IMPL(x, y) x##y
 #define ZXC_CAT(x, y) ZXC_CAT_IMPL(x, y)
@@ -52,9 +50,9 @@
 #define zxc_huf_decode_section_dict ZXC_CAT(zxc_huf_decode_section_dict, ZXC_FUNCTION_SUFFIX)
 #endif
 
-/* Mark the primary variant (only _default, or a no-suffix build) so ISA-
- * independent cold code compiles once, not in every per-ISA copy. Keyed off the
- * suffix value, so every build gets it with no extra flag. */
+// Mark the primary variant (only _default, or a no-suffix build) so ISA-
+// independent cold code compiles once, not in every per-ISA copy. Keyed off the
+// suffix value, so every build gets it with no extra flag.
 #ifdef ZXC_FUNCTION_SUFFIX
 #define ZXC_PRIMARY__default 1
 #define ZXC_PRIMARY_CAT_(a, b) a##b
@@ -70,17 +68,16 @@
 #include "zxc_internal.h"
 #include "zxc_pivco_tables.h"
 
-/* ===========================================================================
- * Length-limited Huffman: boundary package-merge
- * ===========================================================================
- *
- * Builds optimal length-limited Huffman code lengths (max length
- * ZXC_HUF_MAX_CODE_LEN_ULTRA) on 256-symbol alphabets. Package-merge is run for
- * ZXC_HUF_MAX_CODE_LEN_ULTRA levels; each level holds up to 2N items (leaves +
- * paired packages). Selection of the cheapest 2N - 2 items at level
- * ZXC_HUF_MAX_CODE_LEN_ULTRA gives the appearance count of each leaf, which is
- * its code length.
- */
+// ===========================================================================
+// Length-limited Huffman: boundary package-merge
+// ===========================================================================
+//
+// Builds optimal length-limited Huffman code lengths (max length
+// ZXC_HUF_MAX_CODE_LEN_ULTRA) on 256-symbol alphabets. Package-merge is run for
+// ZXC_HUF_MAX_CODE_LEN_ULTRA levels; each level holds up to 2N items (leaves +
+// paired packages). Selection of the cheapest 2N - 2 items at level
+// ZXC_HUF_MAX_CODE_LEN_ULTRA gives the appearance count of each leaf, which is
+// its code length.
 
 typedef zxc_huf_pm_item_t pm_item_t;
 
@@ -109,8 +106,8 @@ typedef zxc_huf_pm_frame_t frame_t;
  * @param[in]     n       Number of leaves; @c n < 2 is effectively a no-op.
  */
 static void pm_leaves_sort(pm_leaf_t* RESTRICT leaves, const int n) {
-    /* One bucket per possible value of floor(log2(weight)) for a 32-bit
-     * weight, i.e. 32 buckets. */
+    // One bucket per possible value of floor(log2(weight)) for a 32-bit
+    // weight, i.e. 32 buckets.
     enum { NUM_BUCKETS = 32 };
     int count[NUM_BUCKETS];
     int offset[NUM_BUCKETS + 1]; /* +1 sentinel = n, avoids end-of-bucket branch. */
@@ -162,15 +159,6 @@ static void pm_leaves_sort(pm_leaf_t* RESTRICT leaves, const int n) {
  * Symbols with `freq[i] == 0` get `code_len[i] == 0`; every other symbol
  * receives a length in `[1, ZXC_HUF_MAX_CODE_LEN_ULTRA]`. The single-present-symbol
  * case is handled as a degenerate code of length 1.
- *
- * @param[in]  freq     Frequency table indexed by symbol (0..255).
- * @param[out] code_len Output code-length array, written in full.
- * @param[in]  scratch  Optional scratch of `ZXC_HUF_BUILD_SCRATCH_SIZE` bytes
- *                      (carved into items / counts / stack regions). If
- *                      `NULL`, the function allocates its own working memory
- *                      for the duration of the call.
- * @return `ZXC_OK` on success, `ZXC_ERROR_MEMORY` or `ZXC_ERROR_CORRUPT_DATA`
- *         on failure.
  */
 int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT code_len,
                                void* RESTRICT scratch, const int max_code_len) {
@@ -193,12 +181,12 @@ int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT 
 
     pm_leaves_sort(leaves, n);
 
-    /* Callers pass max_code_len >= 8, and n <= 256 <= 2^max_code_len, so the
-     * length limit is always feasible (a full 8-bit code covers all 256 symbols). */
+    // Callers pass max_code_len >= 8, and n <= 256 <= 2^max_code_len, so the
+    // length limit is always feasible (a full 8-bit code covers all 256 symbols).
     const int max_per_level = 2 * n;
 
-    /* Working buffers: either carve from caller-provided scratch (sized for
-     * the worst-case alphabet) or fall back to per-call malloc/free. */
+    // Working buffers: either carve from caller-provided scratch (sized for
+    // the worst-case alphabet) or fall back to per-call malloc/free.
     pm_item_t* items;
     int* counts;
     frame_t* stack;
@@ -234,7 +222,7 @@ int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT 
     }
 #define ITEM(k, i) items[(size_t)(k) * (size_t)max_per_level + (size_t)(i)]
 
-    /* Level 0 (logical level 1): the leaves themselves, already sorted. */
+    // Level 0 (logical level 1): the leaves themselves, already sorted.
     for (int i = 0; i < n; i++) {
         ITEM(0, i).weight = leaves[i].w;
         ITEM(0, i).left = -1;
@@ -243,8 +231,8 @@ int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT 
     }
     counts[0] = n;
 
-    /* Levels 1..max_code_len-1: merge sorted leaves with sorted packages from the previous
-     * level. */
+    // Levels 1..max_code_len-1: merge sorted leaves with sorted packages from the previous
+    // level.
     for (int k = 1; k < max_code_len; k++) {
         const int prev = counts[k - 1];
         const int packs = prev / 2;
@@ -275,14 +263,14 @@ int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT 
         counts[k] = n_lvl;
     }
 
-    /* Step 3: take first 2n-2 items at level max_code_len-1; trace back, counting leaf
-     * appearances. */
+    // Step 3: take first 2n-2 items at level max_code_len-1; trace back, counting leaf
+    // appearances.
     int n_take = 2 * n - 2;
     if (n_take > counts[max_code_len - 1]) n_take = counts[max_code_len - 1];
 
-    /* Worst case stack depth: (max_code_len * n_take) frames; bounded by
-     * max_code_len * 2n <= ZXC_HUF_MAX_CODE_LEN_ULTRA * 2n. `stack` was set up earlier from
-     * scratch (or the local malloc fallback), sized for the ceiling. */
+    // Worst case stack depth: (max_code_len * n_take) frames; bounded by
+    // max_code_len * 2n <= ZXC_HUF_MAX_CODE_LEN_ULTRA * 2n. `stack` was set up earlier from
+    // scratch (or the local malloc fallback), sized for the ceiling.
     int sp = 0;
     for (int i = 0; i < n_take; i++) {
         stack[sp].lvl = (int8_t)(max_code_len - 1);
@@ -313,31 +301,30 @@ int zxc_huf_build_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT 
     return ZXC_OK;
 }
 
-/* ===========================================================================
- * Encoder-side joint flat/length nudge (idea: pivco-huffman issue #20)
- * ===========================================================================
- *
- * Package-merge minimizes bits alone; the PivCo decoder's cost also depends on
- * the SHAPE of the length histogram (pass count = max_depth + 1, and maximal
- * complete subtrees collapse into single unpacks -- see the decode section).
- * The functions below reshape the class counts toward power-of-two boundaries
- * and shallower caps under an adoption guard, trading a bounded ratio loss for
- * fewer modeled decode level-touches.
- *
- * Everything is exact integer arithmetic on the canonical code space. With
- * leaves assigned in (length, symbol) ascending order -- the canonical rule of
- * zxc_pivco_tree_build -- the depth-l leaves occupy one contiguous ALIGNED run
- * [S_{l-1}, S_l) of the code space at 2^-11 slot granularity, where
- * S_l = sum_{j<=l} bl_count[j] << (11-j) (each prior term is divisible by
- * 2^(12-l), so runs start on even slot boundaries). The maximal dyadic (buddy)
- * blocks of each run are EXACTLY the decoder's maximal flat subtrees, so any
- * candidate histogram is priced without building a tree.
- *
- * Compiled once in the primary variant: this is ISA-independent cold encoder
- * policy, and a single copy guarantees cross-ISA identical archives. For an
- * A/B build without the nudge, override the guard from CFLAGS
- * (-DZXC_HUF_NUDGE_MERGE_Q8=0 rejects every candidate).
- */
+// ===========================================================================
+// Encoder-side joint flat/length nudge (idea: pivco-huffman issue #20)
+// ===========================================================================
+//
+// Package-merge minimizes bits alone; the PivCo decoder's cost also depends on
+// the SHAPE of the length histogram (pass count = max_depth + 1, and maximal
+// complete subtrees collapse into single unpacks -- see the decode section).
+// The functions below reshape the class counts toward power-of-two boundaries
+// and shallower caps under an adoption guard, trading a bounded ratio loss for
+// fewer modeled decode level-touches.
+//
+// Everything is exact integer arithmetic on the canonical code space. With
+// leaves assigned in (length, symbol) ascending order -- the canonical rule of
+// zxc_pivco_tree_build -- the depth-l leaves occupy one contiguous ALIGNED run
+// [S_{l-1}, S_l) of the code space at 2^-11 slot granularity, where
+// S_l = sum_{j<=l} bl_count[j] << (11-j) (each prior term is divisible by
+// 2^(12-l), so runs start on even slot boundaries). The maximal dyadic (buddy)
+// blocks of each run are EXACTLY the decoder's maximal flat subtrees, so any
+// candidate histogram is priced without building a tree.
+//
+// Compiled once in the primary variant: this is ISA-independent cold encoder
+// policy, and a single copy guarantees cross-ISA identical archives. For an
+// A/B build without the nudge, override the guard from CFLAGS
+// (-DZXC_HUF_NUDGE_MERGE_Q8=0 rejects every candidate).
 #if defined(ZXC_VARIANT_PRIMARY)
 
 /** @brief Modeled cost of one code-length candidate (see zxc_huf_nudge_eval). */
@@ -551,7 +538,7 @@ static void zxc_huf_nudge_walk(const uint32_t* RESTRICT blc0, const uint64_t* RE
         cand[n_cand].c = c_base;
         cand[n_cand++].flat_d = 0;
         if (c_base < n_rem) {
-            /* Shape the internal-node count i = s - c toward few set bits. */
+            // Shape the internal-node count i = s - c toward few set bits.
             const uint32_t i_base = s - c_base;
             const uint32_t i_dn = 1U << zxc_log2_u32(i_base);
             const uint32_t rest = i_base - i_dn;
@@ -567,8 +554,8 @@ static void zxc_huf_nudge_walk(const uint32_t* RESTRICT blc0, const uint64_t* RE
                     cand[n_cand++].flat_d = 0;
                 }
             }
-            /* Uniform finish: c leaves here, the rest as i complete depth-D
-             * subtrees (c*(2^D - 1) == s*2^D - n_rem must divide exactly). */
+            // Uniform finish: c leaves here, the rest as i complete depth-D
+            // subtrees (c*(2^D - 1) == s*2^D - n_rem must divide exactly).
             for (int d = 1; d <= cap - l && n_cand < 6; d++) {
                 const uint64_t den = ((uint64_t)1 << d) - 1;
                 const int64_t num = (int64_t)((uint64_t)s << d) - (int64_t)n_rem;
@@ -718,7 +705,7 @@ static int zxc_huf_nudge_dp_solve(const uint64_t* RESTRICT pfg, const int m, con
                 const uint64_t j0 = jcur[from];
                 if (j0 == UINT64_MAX) continue;
                 if (s == n_rem) {
-                    /* Forced finish: fill every slot, close the tree here. */
+                    // Forced finish: fill every slot, close the tree here.
                     const uint64_t j =
                         j0 + zxc_huf_nudge_dp_run_j(lu, lc, g_log2, s, s, pfg, (uint32_t)k) +
                         (uint64_t)ZXC_HUF_NUDGE_LAMBDA_Q8 * (uint64_t)ZXC_HUF_NUDGE_LEVEL_COST *
@@ -792,13 +779,6 @@ static void zxc_huf_nudge_assign(const uint32_t* RESTRICT blc, const int16_t* RE
         for (uint32_t k = 0; k < blc[l]; k++) cand_len[sym_order[r++]] = (uint8_t)l;
 }
 
-/**
- * @brief Modeled (bits, level-touches) decode cost of one code-length vector.
- *
- * Introspection hook over the exact evaluator (canonical-order weighting);
- * full contract in zxc_internal.h. The unit tests cross-check it against the
- * real tree built by the decoder.
- */
 void zxc_huf_nudge_cost(const uint8_t* RESTRICT code_len, const uint32_t* RESTRICT freq,
                         uint64_t* RESTRICT bits, uint64_t* RESTRICT touches) {
     uint32_t blc[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
@@ -811,30 +791,23 @@ void zxc_huf_nudge_cost(const uint8_t* RESTRICT code_len, const uint32_t* RESTRI
     *touches = c.touches;
 }
 
-/**
- * @brief Optionally reshape freshly built code lengths for faster PivCo decode.
- *
- * Candidate generation (walk, reduced-cap rebuilds, slot-ledger DP), exact
- * pricing and the adoption guard; full contract in zxc_internal.h. On
- * rejection @p code_len is left byte-for-byte untouched.
- */
 int zxc_huf_nudge_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT code_len,
                                void* RESTRICT scratch, const int max_code_len) {
     enum { LU = ZXC_HUF_MAX_CODE_LEN_ULTRA };
     uint32_t blc0[LU + 1];
     const int n = zxc_huf_nudge_classes(code_len, blc0);
-    /* Degenerate alphabets have no shape freedom (and n == 1 is format-pinned
-     * to code length exactly 1): leave them untouched. */
+    // Degenerate alphabets have no shape freedom (and n == 1 is format-pinned
+    // to code length exactly 1): leave them untouched.
     if (n < 4) return 0;
 
-    /* Baseline cost, exact (canonical-order frequency weighting). */
+    // Baseline cost, exact (canonical-order frequency weighting).
     uint64_t pf[ZXC_HUF_NUM_SYMBOLS + 1];
     zxc_huf_nudge_pf_canonical(code_len, freq, blc0, pf);
     zxc_huf_nudge_cost_t c0;
     zxc_huf_nudge_eval(blc0, pf, &c0);
 
-    /* Frequency-rank order shared by every candidate (rank 0 = most frequent;
-     * pm_leaves_sort is ascending, ties on symbol, so read it backwards). */
+    // Frequency-rank order shared by every candidate (rank 0 = most frequent;
+    // pm_leaves_sort is ascending, ties on symbol, so read it backwards).
     pm_leaf_t leaves[ZXC_HUF_NUM_SYMBOLS];
     int k = 0;
     for (int s = 0; s < ZXC_HUF_NUM_SYMBOLS; s++) {
@@ -852,9 +825,9 @@ int zxc_huf_nudge_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT 
         pf_rank[r + 1] = pf_rank[r] + leaves[n - 1 - r].w;
     }
 
-    /* Candidates: the greedy ledger walk, package-merge rebuilt at reduced caps
-     * (the pass loop runs max_depth + 1 times, so depth cuts attack the decoder's
-     * biggest fixed cost), and the slot-ledger DP below. All Kraft-exact. */
+    // Candidates: the greedy ledger walk, package-merge rebuilt at reduced caps
+    // (the pass loop runs max_depth + 1 times, so depth cuts attack the decoder's
+    // biggest fixed cost), and the slot-ledger DP below. All Kraft-exact.
     uint8_t cand[4][ZXC_HUF_NUM_SYMBOLS];
     int n_cand = 0;
     {
@@ -879,12 +852,12 @@ int zxc_huf_nudge_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT 
         }
     }
 
-    /* Slot-ledger DP: optimal class counts under the rank-weighted model, over
-     * groups of 2^G frequency-adjacent symbols (G = 0 is exact; coarser tiers
-     * keep the plane cache-resident, bounding the call to a few hundred us).
-     * When G does not divide n the lightest group is padded with zero-freq
-     * ghost leaves on unused byte values - wire-legal, empty runs, and the
-     * evaluator prices the burnt code space like anything else. */
+    // Slot-ledger DP: optimal class counts under the rank-weighted model, over
+    // groups of 2^G frequency-adjacent symbols (G = 0 is exact; coarser tiers
+    // keep the plane cache-resident, bounding the call to a few hundred us).
+    // When G does not divide n the lightest group is padded with zero-freq
+    // ghost leaves on unused byte values - wire-legal, empty runs, and the
+    // evaluator prices the burnt code space like anything else.
     {
         const int g_log2 = n <= 64 ? 0 : (n <= 128 ? 1 : 2);
         const int g = 1 << g_log2;
@@ -927,15 +900,15 @@ int zxc_huf_nudge_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT 
         }
     }
 
-    /* Adopt the cheapest candidate clearing both guard rails and strictly
-     * beating the baseline J; otherwise leave code_len byte-for-byte alone, so a
-     * rejection never depends on package-merge tie assignment. */
+    // Adopt the cheapest candidate clearing both guard rails and strictly
+    // beating the baseline J; otherwise leave code_len byte-for-byte alone, so a
+    // rejection never depends on package-merge tie assignment.
     const uint64_t j0 = zxc_huf_nudge_j(&c0);
     uint64_t best_j = j0;
     int best = -1;
     for (int ci = 0; ci < n_cand; ci++) {
-        /* Every live symbol must keep a code; ghost-padded candidates carry
-         * MORE nonzero lengths than n, which is fine. */
+        // Every live symbol must keep a code; ghost-padded candidates carry
+        // MORE nonzero lengths than n, which is fine.
         int valid = 1;
         for (int s = 0; s < ZXC_HUF_NUM_SYMBOLS; s++) {
             if (freq[s] != 0 && cand[ci][s] == 0) {
@@ -963,21 +936,10 @@ int zxc_huf_nudge_code_lengths(const uint32_t* RESTRICT freq, uint8_t* RESTRICT 
 }
 #endif /* ZXC_VARIANT_PRIMARY */
 
-/* ===========================================================================
- * 128-byte length header: 256 x 4-bit lengths, low nibble first.
- * =========================================================================*/
+// ===========================================================================
+// 128-byte length header: 256 x 4-bit lengths, low nibble first.
+// =========================================================================
 
-/**
- * @brief Pack per-symbol code lengths into the 128-byte (4-bit nibble) header.
- *
- * The packing is little-endian within each byte: low nibble holds
- * `code_len[2*i]`, high nibble holds `code_len[2*i + 1]`. The function
- * silently truncates any length > 15; callers must enforce the cap of
- * `ZXC_HUF_MAX_CODE_LEN_ULTRA` (<= 15) before calling.
- *
- * @param[in]  code_len Per-symbol code lengths (length `ZXC_HUF_NUM_SYMBOLS`).
- * @param[out] out      Output header buffer of `ZXC_HUF_TABLE_SIZE` bytes.
- */
 void zxc_huf_pack_lengths(const uint8_t* RESTRICT code_len, uint8_t* RESTRICT out) {
     for (int i = 0; i < ZXC_HUF_NUM_SYMBOLS; i += 2) {
         const uint8_t lo = code_len[i] & 0x0F;
@@ -986,18 +948,6 @@ void zxc_huf_pack_lengths(const uint8_t* RESTRICT code_len, uint8_t* RESTRICT ou
     }
 }
 
-/**
- * @brief Unpack and structurally validate a 128-byte packed lengths header.
- *
- * Inverts ::zxc_huf_pack_lengths and validates the two structural invariants:
- * no length exceeds `ZXC_HUF_MAX_CODE_LEN_ULTRA`, and at least one symbol is
- * present. (Kraft consistency is checked later by the tree build.)
- *
- * @param[in]  in       128-byte packed lengths header.
- * @param[out] code_len Output code-length array of length `ZXC_HUF_NUM_SYMBOLS`.
- * @return `ZXC_OK` on success, `ZXC_ERROR_CORRUPT_DATA` if a length is too
- *         large or the table is empty.
- */
 int zxc_huf_unpack_lengths(const uint8_t* RESTRICT in, uint8_t* RESTRICT code_len) {
     int max_len = 0;
     int n_present = 0;
@@ -1017,43 +967,42 @@ int zxc_huf_unpack_lengths(const uint8_t* RESTRICT in, uint8_t* RESTRICT code_le
     return ZXC_OK;
 }
 
-/* ===========================================================================
- * PivCo-Huffman section codec (enc 2/3)
- * ===========================================================================
- *
- * Level-ordered layout and the merge-based decode are from PivCo-Huffman
- * by Marcin Zukowski (https://github.com/MarcinZukowski/pivco-huffman).
- * Implemented independently here.
- *
- * Layout: [128-byte packed code lengths (literal sections only)] then, for
- * every EMITTING node of the canonical code tree in BFS order, that node's
- * run: one branch bit per symbol routed through the node (0 = left child,
- * 1 = right), in sequence order -- or, for flat subtree roots, D packed bits
- * per symbol (bit j = branch at relative depth j). Runs are LSB-first within
- * bytes and byte-padded; descendants of a flat root emit nothing.
- *
- * The decoder recovers each node's symbol count for free: the root handles
- * n symbols, and popcounting a node's bits yields its right child's count.
- * Reconstruction runs bottom-up, one level at a time: leaves are runs of a
- * single symbol; an internal node MERGES its two children's sequences under
- * the control of its bits. Merges are branch-free shuffles (16 outputs per
- * step on AArch64 via a two-register TBL, 8 on ARMv7 via VTBL4, 64 on
- * AVX-512-VBMI2 via vpexpandb), which is what makes this layout
- * decode faster than the serial bit-chain of the classic 4-stream layout on
- * any target with a 16-byte shuffle.
- *
- * Level buffers ping-pong between `scratch` (odd depths) and `dst` (even
- * depths, final output at depth 0), so one n-sized scratch suffices. Both
- * buffers need read slack past `n` (speculative 16-byte kernel loads):
- * ZXC_PAD_SIZE on dst (already true for lit/token buffers), and
- * ZXC_PIVCO_SCRATCH_PAD on scratch.
- */
+// ===========================================================================
+// PivCo-Huffman section codec (enc 2/3)
+// ===========================================================================
+//
+// Level-ordered layout and the merge-based decode are from PivCo-Huffman
+// by Marcin Zukowski (https://github.com/MarcinZukowski/pivco-huffman).
+// Implemented independently here.
+//
+// Layout: [128-byte packed code lengths (literal sections only)] then, for
+// every EMITTING node of the canonical code tree in BFS order, that node's
+// run: one branch bit per symbol routed through the node (0 = left child,
+// 1 = right), in sequence order -- or, for flat subtree roots, D packed bits
+// per symbol (bit j = branch at relative depth j). Runs are LSB-first within
+// bytes and byte-padded; descendants of a flat root emit nothing.
+//
+// The decoder recovers each node's symbol count for free: the root handles
+// n symbols, and popcounting a node's bits yields its right child's count.
+// Reconstruction runs bottom-up, one level at a time: leaves are runs of a
+// single symbol; an internal node MERGES its two children's sequences under
+// the control of its bits. Merges are branch-free shuffles (16 outputs per
+// step on AArch64 via a two-register TBL, 8 on ARMv7 via VTBL4, 64 on
+// AVX-512-VBMI2 via vpexpandb), which is what makes this layout
+// decode faster than the serial bit-chain of the classic 4-stream layout on
+// any target with a 16-byte shuffle.
+//
+// Level buffers ping-pong between `scratch` (odd depths) and `dst` (even
+// depths, final output at depth 0), so one n-sized scratch suffices. Both
+// buffers need read slack past `n` (speculative 16-byte kernel loads):
+// ZXC_PAD_SIZE on dst (already true for lit/token buffers), and
+// ZXC_PIVCO_SCRATCH_PAD on scratch.
 
 static ZXC_ALWAYS_INLINE int zxc_pivco_popcnt32(const uint32_t v) {
 #if defined(__GNUC__) || defined(__clang__)
     return __builtin_popcount(v);
 #else
-    /* Portable SWAR popcount for MSVC */
+    // Portable SWAR popcount for MSVC
     uint32_t x = v - ((v >> 1) & 0x55555555U);
     x = (x & 0x33333333U) + ((x >> 2) & 0x33333333U);
     x = (x + (x >> 4)) & 0x0F0F0F0FU;
@@ -1100,8 +1049,8 @@ static int zxc_pivco_tree_build(const uint8_t* RESTRICT code_len, zxc_pivco_tree
             kraft += bl_count[l] << (ZXC_HUF_MAX_CODE_LEN_ULTRA - l);
         if (UNLIKELY(kraft != (1U << ZXC_HUF_MAX_CODE_LEN_ULTRA))) return -1;
     } else {
-        /* Degenerate single-symbol table: the format pins the lone symbol at code
-         * length exactly 1, so reject longer unary chains. */
+        // Degenerate single-symbol table: the format pins the lone symbol at code
+        // length exactly 1, so reject longer unary chains.
         if (UNLIKELY(bl_count[1] != 1)) return -1;
     }
 
@@ -1145,9 +1094,9 @@ static int zxc_pivco_tree_build(const uint8_t* RESTRICT code_len, zxc_pivco_tree
     }
     t->max_depth = max_depth;
 
-    /* BFS order (parents before children, left before right): this is both
-     * the wire order of the node bit runs and the property that makes each
-     * parent's children CONTIGUOUS in the next level's sequence buffer. */
+    // BFS order (parents before children, left before right): this is both
+    // the wire order of the node bit runs and the property that makes each
+    // parent's children CONTIGUOUS in the next level's sequence buffer.
     int head = 0;
     int tail = 0;
     t->bfs[tail++] = 0;
@@ -1168,9 +1117,9 @@ static int zxc_pivco_tree_build(const uint8_t* RESTRICT code_len, zxc_pivco_tree
     }
     for (int d = depth + 1; d <= max_depth + 1; d++) t->lvl_start[d] = (int16_t)tail;
 
-    /* Flat-subtree detection: min/max leaf depth per node in one reverse-BFS
-     * sweep, then maximality by masking descendants of the first flat node on
-     * each root-to-leaf path. */
+    // Flat-subtree detection: min/max leaf depth per node in one reverse-BFS
+    // sweep, then maximality by masking descendants of the first flat node on
+    // each root-to-leaf path.
     {
         int8_t mn[ZXC_PIVCO_MAX_NODES];
         int8_t mx[ZXC_PIVCO_MAX_NODES];
@@ -1196,9 +1145,9 @@ static int zxc_pivco_tree_build(const uint8_t* RESTRICT code_len, zxc_pivco_tree
             const int nid = t->bfs[i];
             t->flat_d[nid] = 0;
             if (i == 0) t->covered[nid] = 0; /* root */
-            /* Any complete subtree unpacks flat, beating the merge cascade
-             * (FORMAT RULE, both sides): D = 2-6 have SIMD unpackers, D >= 7 the
-             * scalar one. (D = 1 is a leaf pair, handled on the merge path.) */
+            // Any complete subtree unpacks flat, beating the merge cascade
+            // (FORMAT RULE, both sides): D = 2-6 have SIMD unpackers, D >= 7 the
+            // scalar one. (D = 1 is a leaf pair, handled on the merge path.)
             if (!t->covered[nid] && t->nd[nid].sym < 0 && mn[nid] == mx[nid] && mn[nid] >= 2)
                 t->flat_d[nid] = (uint8_t)mn[nid];
             const int ch0 = t->nd[nid].child[0];
@@ -1274,9 +1223,9 @@ size_t zxc_huf_calc_size(const uint32_t* RESTRICT freq, const uint8_t* RESTRICT 
  */
 size_t zxc_huf_calc_size_dict(const uint32_t* RESTRICT freq, const uint8_t* RESTRICT code_len,
                               const zxc_pivco_tree_t* RESTRICT tree) {
-    /* Encodability is part of the estimate: a histogram symbol the table has no
-     * code for would be silently ignored below and undercount. Report the
-     * candidate unencodable instead. */
+    // Encodability is part of the estimate: a histogram symbol the table has no
+    // code for would be silently ignored below and undercount. Report the
+    // candidate unencodable instead.
     for (int k = 0; k < ZXC_HUF_NUM_SYMBOLS; k++)
         if (UNLIKELY(freq[k] != 0 && code_len[k] == 0)) return SIZE_MAX;
     uint32_t count[ZXC_PIVCO_MAX_NODES];
@@ -1302,18 +1251,18 @@ static int zxc_pivco_encode_core(const uint8_t* RESTRICT literals, const size_t 
                                  uint8_t* RESTRICT dst, const size_t dst_cap,
                                  const int with_header) {
     if (UNLIKELY(n_literals == 0)) return ZXC_ERROR_CORRUPT_DATA;
-    /* Every literal present in the histogram must have a code (a dict table
-     * may lack codes for symbols unseen in training: the caller then falls
-     * back to a per-block table, but a direct call must fail loudly). */
+    // Every literal present in the histogram must have a code (a dict table
+    // may lack codes for symbols unseen in training: the caller then falls
+    // back to a per-block table, but a direct call must fail loudly).
     for (int k = 0; k < ZXC_HUF_NUM_SYMBOLS; k++)
         if (UNLIKELY(freq[k] != 0 && code_len[k] == 0)) return ZXC_ERROR_CORRUPT_DATA;
 
     uint32_t count[ZXC_PIVCO_MAX_NODES];
     zxc_pivco_counts(t, freq, count);
 
-    /* Byte offsets of every wire-visible internal node's run, in BFS order:
-     * bitmap runs (1 bit/symbol) or, for flat roots, packed code runs
-     * (flat_d bits/symbol). Covered nodes have no run. */
+    // Byte offsets of every wire-visible internal node's run, in BFS order:
+    // bitmap runs (1 bit/symbol) or, for flat roots, packed code runs
+    // (flat_d bits/symbol). Covered nodes have no run.
     uint32_t bit_off[ZXC_PIVCO_MAX_NODES];
     size_t payload = 0;
     for (int i = 0; i < t->n_nodes; i++) {
@@ -1323,18 +1272,37 @@ static int zxc_pivco_encode_core(const uint8_t* RESTRICT literals, const size_t 
         payload += zxc_pivco_run_bytes(count[nid], t->flat_d[nid]);
     }
     const size_t hdr = with_header ? (size_t)ZXC_HUF_TABLE_SIZE : 0;
-    /* +2: the packed-code emitter uses a 3-byte read-modify-write that may
-     * touch up to 2 bytes past the payload end. */
+    // +2: the packed-code emitter uses a 3-byte read-modify-write that may
+    // touch up to 2 bytes past the payload end.
     if (UNLIKELY(hdr + payload + 2 > dst_cap)) return ZXC_ERROR_DST_TOO_SMALL;
 
     if (with_header) zxc_huf_pack_lengths(code_len, dst);
     uint8_t* const out = dst + hdr;
     ZXC_MEMSET(out, 0, payload + 2);
 
-    /* Per-node bit cursors, emitting MSB-first while descending. At a flat root,
-     * emit the symbol's packed D-bit residual in one shot and stop. Batching the
-     * per-bit read-modify-write buys nothing: accumulators would still touch
-     * memory once per bit, and flat roots already absorb the dense levels. */
+    // Residual = low fd bits of the canonical code, bit-reversed so that packed
+    // bit j is the branch taken at level j. It depends on the symbol alone, so
+    // reverse it once per symbol rather than once per literal. Keyed on the
+    // histogram: sections start at ZXC_HUF_MIN_LITERALS, where walking all 256
+    // would cost more than it saves.
+    uint16_t resid[ZXC_HUF_NUM_SYMBOLS];
+    for (int s = 0; s < ZXC_HUF_NUM_SYMBOLS; s++) {
+        resid[s] = 0;
+        if (freq[s] == 0) continue;
+        const uint32_t c = codes[s];
+        int cur = 0;
+        for (int d = code_len[s] - 1; d >= 0 && !t->flat_d[cur]; d--)
+            cur = t->nd[cur].child[(c >> d) & 1U];
+        const int fd = t->flat_d[cur];
+        uint32_t r = 0;
+        for (int j = 0; j < fd; j++) r |= ((c >> (fd - 1 - j)) & 1U) << j;
+        resid[s] = (uint16_t)r;
+    }
+
+    // Per-node bit cursors, emitting MSB-first while descending. At a flat root,
+    // emit the symbol's packed D-bit residual in one shot and stop. Batching the
+    // per-bit read-modify-write buys nothing: accumulators would still touch
+    // memory once per bit, and flat roots already absorb the dense levels.
     uint32_t wpos[ZXC_PIVCO_MAX_NODES];
     ZXC_MEMSET(wpos, 0, (size_t)t->n_nodes * sizeof(uint32_t));
     for (size_t i = 0; i < n_literals; i++) {
@@ -1344,16 +1312,12 @@ static int zxc_pivco_encode_core(const uint8_t* RESTRICT literals, const size_t 
         for (int d = code_len[s] - 1; d >= 0; d--) {
             const int fd = t->flat_d[cur];
             if (fd) {
-                /* residual = low fd bits of the canonical code, bit-reversed
-                 * so that packed bit j is the branch taken at level j. */
-                uint32_t r = 0;
-                for (int j = 0; j < fd; j++) r |= ((c >> (fd - 1 - j)) & 1U) << j;
                 const uint32_t p = wpos[cur];
                 wpos[cur] += (uint32_t)fd;
                 uint8_t* q = out + bit_off[cur] + (p >> 3);
                 const uint32_t sh = p & 7U;
                 uint32_t w = (uint32_t)q[0] | ((uint32_t)q[1] << 8) | ((uint32_t)q[2] << 16);
-                w |= r << sh; /* fd <= 11, sh <= 7 -> fits 24 bits */
+                w |= (uint32_t)resid[s] << sh; /* fd <= 11, sh <= 7 -> fits 24 bits */
                 q[0] = (uint8_t)w;
                 q[1] = (uint8_t)(w >> 8);
                 q[2] = (uint8_t)(w >> 16);
@@ -1411,9 +1375,65 @@ int zxc_huf_encode_section_dict(const uint8_t* RESTRICT literals, const size_t n
                                  0);
 }
 
-/* ISA-independent cold dict setup: emit once in the primary variant, not in
- * every per-ISA copy (dead weight). zxc_pivco_tree_build stays per-variant. */
+/**
+ * @brief Flags the children of every leaf-pair parent.
+ *
+ * A parent whose two children are both leaves emits their runs from its own
+ * bits (XOR-blend), so those children are never reconstructed.
+ */
+static ZXC_ALWAYS_INLINE void zxc_pivco_mark_leaf_pairs(const zxc_pivco_tree_t* RESTRICT t,
+                                                        uint8_t* RESTRICT skip) {
+    ZXC_MEMSET(skip, 0, ZXC_PIVCO_MAX_NODES);
+    for (int i = 0; i < t->n_nodes; i++) {
+        const zxc_pivco_node_t* nd = &t->nd[t->bfs[i]];
+        if (nd->sym >= 0) continue;
+        const int ch0 = nd->child[0];
+        const int ch1 = nd->child[1];
+        if (ch0 >= 0 && ch1 >= 0 && t->nd[ch0].sym >= 0 && t->nd[ch1].sym >= 0) {
+            skip[ch0] = 1;
+            skip[ch1] = 1;
+        }
+    }
+}
+
+/**
+ * @brief Builds the code-to-symbol table of a flat subtree.
+ *
+ * The subtree is complete of depth D, so its 2^D codes index the table
+ * directly. Built once at attach for a dictionary tree, per block otherwise.
+ */
+static ZXC_ALWAYS_INLINE void zxc_pivco_build_c2s(const zxc_pivco_tree_t* RESTRICT t, const int nid,
+                                                  uint8_t* RESTRICT c2s) {
+    int16_t stk_n[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
+    uint16_t stk_p[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
+    uint8_t stk_l[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
+    int sp = 0;
+    stk_n[0] = (int16_t)nid;
+    stk_p[0] = 0;
+    stk_l[0] = 0;
+    while (sp >= 0) {
+        const int cn = stk_n[sp];
+        const uint32_t cp = stk_p[sp];
+        const int cl = stk_l[sp];
+        sp--;
+        if (t->nd[cn].sym >= 0) {
+            c2s[cp] = (uint8_t)t->nd[cn].sym;
+            continue;
+        }
+        sp++;
+        stk_n[sp] = t->nd[cn].child[0];
+        stk_p[sp] = (uint16_t)cp;
+        stk_l[sp] = (uint8_t)(cl + 1);
+        sp++;
+        stk_n[sp] = t->nd[cn].child[1];
+        stk_p[sp] = (uint16_t)(cp | (1U << cl));
+        stk_l[sp] = (uint8_t)(cl + 1);
+    }
+}
+
+// ISA-independent cold dict setup
 #if defined(ZXC_VARIANT_PRIMARY)
+
 /**
  * @brief Precompute the topology-derived decoder tables for @p t.
  *
@@ -1425,52 +1445,17 @@ int zxc_huf_encode_section_dict(const uint8_t* RESTRICT literals, const size_t n
  */
 static void zxc_pivco_decode_aux_build(const zxc_pivco_tree_t* RESTRICT t,
                                        zxc_pivco_decode_aux_t* RESTRICT aux) {
-    ZXC_MEMSET(aux->skip, 0, sizeof(aux->skip));
-    for (int i = 0; i < t->n_nodes; i++) {
-        const zxc_pivco_node_t* nd = &t->nd[t->bfs[i]];
-        if (nd->sym >= 0) continue;
-        const int ch0 = nd->child[0];
-        const int ch1 = nd->child[1];
-        if (ch0 >= 0 && ch1 >= 0 && t->nd[ch0].sym >= 0 && t->nd[ch1].sym >= 0) {
-            aux->skip[ch0] = 1;
-            aux->skip[ch1] = 1;
-        }
-    }
+    zxc_pivco_mark_leaf_pairs(t, aux->skip);
 
-    /* Flat subtrees have disjoint leaves, so the concatenated tables fit in
-     * ZXC_HUF_NUM_SYMBOLS pool entries (see zxc_pivco_decode_aux_t). */
+    // Flat subtrees have disjoint leaves, so the concatenated tables fit in
+    // ZXC_HUF_NUM_SYMBOLS pool entries (see zxc_pivco_decode_aux_t).
     uint32_t pool_off = 0;
     for (int i = 0; i < t->n_nodes; i++) {
         const int nid = t->bfs[i];
         if (t->covered[nid] || !t->flat_d[nid]) continue;
         aux->c2s_off[nid] = (uint16_t)pool_off;
-        uint8_t* const c2s = aux->c2s_pool + pool_off;
+        zxc_pivco_build_c2s(t, nid, aux->c2s_pool + pool_off);
         pool_off += 1U << t->flat_d[nid];
-        int16_t stk_n[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
-        uint16_t stk_p[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
-        uint8_t stk_l[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
-        int sp = 0;
-        stk_n[0] = (int16_t)nid;
-        stk_p[0] = 0;
-        stk_l[0] = 0;
-        while (sp >= 0) {
-            const int cn = stk_n[sp];
-            const uint32_t cp = stk_p[sp];
-            const int cl = stk_l[sp];
-            sp--;
-            if (t->nd[cn].sym >= 0) {
-                c2s[cp] = (uint8_t)t->nd[cn].sym;
-                continue;
-            }
-            sp++;
-            stk_n[sp] = t->nd[cn].child[0];
-            stk_p[sp] = (uint16_t)cp;
-            stk_l[sp] = (uint8_t)(cl + 1);
-            sp++;
-            stk_n[sp] = t->nd[cn].child[1];
-            stk_p[sp] = (uint16_t)(cp | (1U << cl));
-            stk_l[sp] = (uint8_t)(cl + 1);
-        }
     }
 }
 
@@ -1494,6 +1479,20 @@ int zxc_huf_dict_tree_build(const uint8_t* RESTRICT packed_lengths, zxc_pivco_tr
 #endif /* ZXC_VARIANT_PRIMARY */
 
 /**
+ * @brief Advances the merge cursors past one fixed-width step.
+ *
+ * Every fixed-width arm closes the same way: the step took @c pc bytes from the
+ * right child and the rest from the left. Operates on the enclosing loop's
+ * @c lp, @c rp and @c i, and expands @c pc twice, so pass a named value.
+ */
+#define ZXC_PIVCO_MERGE_STEP(w, pc) \
+    do {                            \
+        rp += (size_t)(pc);         \
+        lp += (size_t)((w) - (pc)); \
+        i += (w);                   \
+    } while (0)
+
+/**
  * @brief Merge two adjacent child sequences under control bits.
  *
  * src[0..nl) is the left sequence, src[nl..nl+nr) the right one (children are
@@ -1512,8 +1511,8 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_merge(uint8_t* RESTRICT out, const uint8
     size_t lp = 0;
     size_t rp = 0;
 #if defined(ZXC_USE_NEON64)
-    /* 16 outputs per step: two-register TBL over {L[0..15], R[0..15]} with the
-     * signed-index tables (see zxc_pivco_tables.h). */
+    // 16 outputs per step: two-register TBL over {L[0..15], R[0..15]} with the
+    // signed-index tables (see zxc_pivco_tables.h).
     while (i + 16 <= n) {
         const uint8_t b0 = bits[i >> 3];
         const uint8_t b1 = bits[(i >> 3) + 1];
@@ -1525,35 +1524,67 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_merge(uint8_t* RESTRICT out, const uint8
         const uint8x8_t ib = vld1_u8(zxc_pivco_idxb_pre[pc0][b1]);
         vst1q_u8(out + i, vqtbl2q_u8(tb, vcombine_u8(ia, ib)));
         const int pc = pc0 + zxc_pivco_popcnt32(b1);
-        rp += (size_t)pc;
-        lp += (size_t)(16 - pc);
-        i += 16;
+        ZXC_PIVCO_MERGE_STEP(16, pc);
     }
 #else /* x86 tiers */
 #if defined(ZXC_USE_AVX512) && defined(__AVX512VBMI2__)
-    /* 64 outputs per step: the merge IS a pair of byte expands - L's bytes fill
-     * the control word's 0-bit lanes, R's the 1-bit lanes. Masked loads keep the
-     * speculative reads fault-safe without extra buffer slack. */
+    // 64 outputs per step: the merge IS a pair of byte expands - L's bytes fill
+    // the control word's 0-bit lanes, R's the 1-bit lanes. The masked expand
+    // loads only touch the bytes they consume, so the speculative reads stay
+    // fault-safe without extra buffer slack.
+    const __m512i zero = _mm512_setzero_si512();
     while (i + 64 <= n) {
         uint64_t ctrl;
         ZXC_MEMCPY(&ctrl, bits + (i >> 3), 8);
-        const int pc = zxc_pivco_popcnt64(ctrl);
-        const __mmask64 lmask = (pc == 0) ? ~(__mmask64)0 : (((__mmask64)1 << (64 - pc)) - 1U);
-        const __mmask64 rmask = (pc == 64) ? ~(__mmask64)0 : (((__mmask64)1 << pc) - 1U);
-        const __m512i vl = _mm512_maskz_loadu_epi8(lmask, (const void*)(L + lp));
-        const __m512i vr = _mm512_maskz_loadu_epi8(rmask, (const void*)(R + rp));
-        const __m512i outl = _mm512_maskz_expand_epi8((__mmask64)~ctrl, vl);
-        const __m512i outv = _mm512_mask_expand_epi8(outl, (__mmask64)ctrl, vr);
+        const __m512i vl =
+            _mm512_mask_expandloadu_epi8(zero, (__mmask64)~ctrl, (const void*)(L + lp));
+        const __m512i outv =
+            _mm512_mask_expandloadu_epi8(vl, (__mmask64)ctrl, (const void*)(R + rp));
         _mm512_storeu_si512((void*)(out + i), outv);
-        rp += (size_t)pc;
-        lp += (size_t)(64 - pc);
-        i += 64;
+        const int pc = zxc_pivco_popcnt64(ctrl);
+        ZXC_PIVCO_MERGE_STEP(64, pc);
     }
 #endif
 #if defined(ZXC_USE_AVX512) || defined(ZXC_USE_AVX2) || \
     (defined(ZXC_USE_SSE2) && defined(__SSSE3__))
-    /* 16 outputs/step: pshufb(L, ix+0x70) | pshufb(R, ix-16) selects L[ix] or
-     * R[ix-16] (out-of-range lanes zero out); 32/step unrolls it twice. */
+    // 16 outputs/step: pshufb(L, ix+0x70) | pshufb(R, ix-16) selects L[ix] or
+    // R[ix-16] (out-of-range lanes zero out); 32/step unrolls it twice.
+#if defined(ZXC_USE_AVX2)
+    // Same thing at 256 bits, 32 outputs/step. Both selects take the index
+    // unbiased: table lanes all sit in [0, 31], so pshufb masks to 4 bits and
+    // bit 4 is the L/R selector - shifted into the sign it drives the blend,
+    // and both bias vectors go away. L and R stay two 128-bit loads: the
+    // second cursor is lp + (16 - pcA), never lp + 16.
+    while (i + 32 <= n) {
+        const uint8_t* cb = bits + (i >> 3);
+        const int pcA0 = zxc_pivco_popcnt32(cb[0]);
+        const int pcA = pcA0 + zxc_pivco_popcnt32(cb[1]);
+        const int pcB0 = zxc_pivco_popcnt32(cb[2]);
+        const int pcB = pcB0 + zxc_pivco_popcnt32(cb[3]);
+        const size_t lpB = lp + (size_t)(16 - pcA);
+        const size_t rpB = rp + (size_t)pcA;
+        const __m256i vl = _mm256_inserti128_si256(
+            _mm256_castsi128_si256(_mm_loadu_si128((const __m128i*)(const void*)(L + lp))),
+            _mm_loadu_si128((const __m128i*)(const void*)(L + lpB)), 1);
+        const __m256i vr = _mm256_inserti128_si256(
+            _mm256_castsi128_si256(_mm_loadu_si128((const __m128i*)(const void*)(R + rp))),
+            _mm_loadu_si128((const __m128i*)(const void*)(R + rpB)), 1);
+        const __m128i ixA = _mm_unpacklo_epi64(
+            _mm_loadl_epi64((const __m128i*)(const void*)zxc_pivco_idxa_u8[cb[0]]),
+            _mm_loadl_epi64((const __m128i*)(const void*)zxc_pivco_idxb_pre[pcA0][cb[1]]));
+        const __m128i ixB = _mm_unpacklo_epi64(
+            _mm_loadl_epi64((const __m128i*)(const void*)zxc_pivco_idxa_u8[cb[2]]),
+            _mm_loadl_epi64((const __m128i*)(const void*)zxc_pivco_idxb_pre[pcB0][cb[3]]));
+        const __m256i ix = _mm256_inserti128_si256(_mm256_castsi128_si256(ixA), ixB, 1);
+        _mm256_storeu_si256(
+            (__m256i*)(void*)(out + i),
+            _mm256_blendv_epi8(_mm256_shuffle_epi8(vl, ix), _mm256_shuffle_epi8(vr, ix),
+                               _mm256_slli_epi16(ix, 3)));
+        lp = lpB + (size_t)(16 - pcB);
+        rp = rpB + (size_t)pcB;
+        i += 32;
+    }
+#else
     while (i + 32 <= n) {
         const uint8_t* cb = bits + (i >> 3);
         const int pcA0 = zxc_pivco_popcnt32(cb[0]);
@@ -1586,6 +1617,7 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_merge(uint8_t* RESTRICT out, const uint8
         rp = rpB + (size_t)pcB;
         i += 32;
     }
+#endif
     while (i + 16 <= n) {
         const uint8_t b0 = bits[i >> 3];
         const uint8_t b1 = bits[(i >> 3) + 1];
@@ -1600,14 +1632,12 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_merge(uint8_t* RESTRICT out, const uint8
         const __m128i selr = _mm_shuffle_epi8(vr, _mm_sub_epi8(ix, _mm_set1_epi8(16)));
         _mm_storeu_si128((__m128i*)(void*)(out + i), _mm_or_si128(sell, selr));
         const int pc = pc0 + zxc_pivco_popcnt32(b1);
-        rp += (size_t)pc;
-        lp += (size_t)(16 - pc);
-        i += 16;
+        ZXC_PIVCO_MERGE_STEP(16, pc);
     }
 #elif defined(ZXC_USE_NEON32)
-    /* 8 outputs per step: four-register VTBL over {L[0..7], -, R[0..7], -}. The
-     * shared index tables address a 32-lane view, and an 8-output step only
-     * touches lanes 0..7 and 16..23, so the two spare d-registers stay zero. */
+    // 8 outputs per step: four-register VTBL over {L[0..7], -, R[0..7], -}. The
+    // shared index tables address a 32-lane view, and an 8-output step only
+    // touches lanes 0..7 and 16..23, so the two spare d-registers stay zero.
     while (i + 8 <= n) {
         const uint8_t b = bits[i >> 3];
         uint8x8x4_t tb;
@@ -1617,15 +1647,13 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_merge(uint8_t* RESTRICT out, const uint8
         tb.val[3] = vdup_n_u8(0);
         vst1_u8(out + i, vtbl4_u8(tb, vld1_u8(zxc_pivco_idxa_u8[b])));
         const int pc = zxc_pivco_popcnt32(b);
-        rp += (size_t)pc;
-        lp += (size_t)(8 - pc);
-        i += 8;
+        ZXC_PIVCO_MERGE_STEP(8, pc);
     }
 #endif
 #endif /* x86 tiers */
-    /* Portable 8-output path: byte selects from a 24-byte scratch laid out
-     * as the low half of the 32-lane view the shared index tables assume
-     * (L at offset 0, R at offset 16). */
+    // Portable 8-output path: byte selects from a 24-byte scratch laid out
+    // as the low half of the 32-lane view the shared index tables assume
+    // (L at offset 0, R at offset 16).
     while (i + 8 <= n) {
         const uint8_t b = bits[i >> 3];
         uint8_t comb[24];
@@ -1634,9 +1662,7 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_merge(uint8_t* RESTRICT out, const uint8
         const uint8_t* ix = zxc_pivco_idxa_u8[b];
         for (int j = 0; j < 8; j++) out[i + (size_t)j] = comb[ix[j]];
         const int pc = zxc_pivco_popcnt32(b);
-        rp += (size_t)pc;
-        lp += (size_t)(8 - pc);
-        i += 8;
+        ZXC_PIVCO_MERGE_STEP(8, pc);
     }
     while (i < n) {
         const int bit = (bits[i >> 3] >> (i & 7)) & 1;
@@ -1644,35 +1670,21 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_merge(uint8_t* RESTRICT out, const uint8
     }
 }
 
+#undef ZXC_PIVCO_MERGE_STEP
+
 /**
  * @brief Decode a flat subtree's packed D-bit code run into symbols.
  *
  * codes are packed LSB-first, D in [2, ZXC_HUF_MAX_CODE_LEN_ULTRA]; c2s maps
- * a packed path to its leaf symbol. SIMD paths cover the frequent D = 2 / 4
- * (in-register unpack + single 16-byte table lookup); the scalar bit-reader
- * handles every D.
+ * a packed path to its leaf symbol. SIMD paths cover D = 2..6 (in-register
+ * unpack, then one table lookup over the subtree's 2^D entries); the scalar
+ * bit-reader handles every D.
  */
 static void zxc_pivco_unpack_flat(uint8_t* RESTRICT out, const size_t n, const int D,
                                   const uint8_t* RESTRICT bits, const uint8_t* RESTRICT c2s) {
     size_t i = 0;
 #if defined(ZXC_USE_NEON64)
-    if (D == 4) {
-        const uint8x16_t vc2s = vld1q_u8(c2s); /* 16 entries */
-        static const uint8_t rep2[16] = {0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7};
-        static const int8_t sh4[16] = {0, -4, 0, -4, 0, -4, 0, -4, 0, -4, 0, -4, 0, -4, 0, -4};
-        const uint8x16_t vrep = vld1q_u8(rep2);
-        const int8x16_t vsh = vld1q_s8(sh4);
-        const uint8x16_t vmask = vdupq_n_u8(0x0F);
-        while (i + 16 <= n) {
-            uint8x16_t raw = vdupq_n_u8(0);
-            raw = vreinterpretq_u8_u64(
-                vsetq_lane_u64(zxc_le64(bits + ((i * 4) >> 3)), vreinterpretq_u64_u8(raw), 0));
-            const uint8x16_t rep = vqtbl1q_u8(raw, vrep);
-            const uint8x16_t codes = vandq_u8(vshlq_u8(rep, vsh), vmask);
-            vst1q_u8(out + i, vqtbl1q_u8(vc2s, codes));
-            i += 16;
-        }
-    } else if (D == 2) {
+    if (D == 2) {
         uint8_t c2s16[16];
         for (int k = 0; k < 16; k++) c2s16[k] = c2s[k & 3];
         const uint8x16_t vc2s = vld1q_u8(c2s16);
@@ -1691,9 +1703,9 @@ static void zxc_pivco_unpack_flat(uint8_t* RESTRICT out, const size_t n, const i
             i += 16;
         }
     } else if (D == 3) {
-        /* Odd D straddle bytes: build a 16-bit window {byte_j,byte_j+1} per lane
-         * (byte_j = Di>>3), right-shift by Di&7, mask D bits. 16/step, two u16x8
-         * halves sharing the shift vector. D=3: 6 source bytes. */
+        // Odd D straddle bytes: build a 16-bit window {byte_j,byte_j+1} per lane
+        // (byte_j = Di>>3), right-shift by Di&7, mask D bits. 16/step, two u16x8
+        // halves sharing the shift vector. D=3: 6 source bytes.
         uint8_t c2s16[16];
         for (int k = 0; k < 16; k++) c2s16[k] = c2s[k & 7];
         const uint8x16_t vc2s = vld1q_u8(c2s16); /* 8 entries, padded to 16 */
@@ -1720,11 +1732,25 @@ static void zxc_pivco_unpack_flat(uint8_t* RESTRICT out, const size_t n, const i
             vst1q_u8(out + i, vqtbl1q_u8(vc2s, vcombine_u8(cA, cB)));
             i += 16;
         }
+    } else if (D == 4) {
+        const uint8x16_t vc2s = vld1q_u8(c2s); /* 16 entries */
+        static const uint8_t rep2[16] = {0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7};
+        static const int8_t sh4[16] = {0, -4, 0, -4, 0, -4, 0, -4, 0, -4, 0, -4, 0, -4, 0, -4};
+        const uint8x16_t vrep = vld1q_u8(rep2);
+        const int8x16_t vsh = vld1q_s8(sh4);
+        const uint8x16_t vmask = vdupq_n_u8(0x0F);
+        while (i + 16 <= n) {
+            uint8x16_t raw = vdupq_n_u8(0);
+            raw = vreinterpretq_u8_u64(
+                vsetq_lane_u64(zxc_le64(bits + ((i * 4) >> 3)), vreinterpretq_u64_u8(raw), 0));
+            const uint8x16_t rep = vqtbl1q_u8(raw, vrep);
+            const uint8x16_t codes = vandq_u8(vshlq_u8(rep, vsh), vmask);
+            vst1q_u8(out + i, vqtbl1q_u8(vc2s, codes));
+            i += 16;
+        }
     } else if (D == 5) {
-        /* Same window scheme as D=3; c2s has 32 entries (vqtbl2q). 10 bytes. */
-        uint8x16x2_t vc2s;
-        vc2s.val[0] = vld1q_u8(c2s);
-        vc2s.val[1] = vld1q_u8(c2s + 16);
+        // Same window scheme as D=3; c2s has 32 entries (vqtbl2q). 10 bytes.
+        const uint8x16x2_t vc2s = vld1q_u8_x2(c2s);
         static const uint8_t idxA[16] = {0, 1, 0, 1, 1, 2, 1, 2, 2, 3, 3, 4, 3, 4, 4, 5};
         static const uint8_t idxB[16] = {5, 6, 5, 6, 6, 7, 6, 7, 7, 8, 8, 9, 8, 9, 9, 10};
         static const int16_t sh8[8] = {0, -5, -2, -7, -4, -1, -6, -3};
@@ -1749,12 +1775,8 @@ static void zxc_pivco_unpack_flat(uint8_t* RESTRICT out, const size_t n, const i
             i += 16;
         }
     } else if (D == 6) {
-        /* Same window scheme as D=3; c2s has 64 entries (vqtbl4q). 12 bytes. */
-        uint8x16x4_t vc2s;
-        vc2s.val[0] = vld1q_u8(c2s);
-        vc2s.val[1] = vld1q_u8(c2s + 16);
-        vc2s.val[2] = vld1q_u8(c2s + 32);
-        vc2s.val[3] = vld1q_u8(c2s + 48);
+        // Same window scheme as D=3; c2s has 64 entries (vqtbl4q). 12 bytes.
+        const uint8x16x4_t vc2s = vld1q_u8_x4(c2s);
         static const uint8_t idxA[16] = {0, 1, 0, 1, 1, 2, 2, 3, 3, 4, 3, 4, 4, 5, 5, 6};
         static const uint8_t idxB[16] = {6, 7, 6, 7, 7, 8, 8, 9, 9, 10, 9, 10, 10, 11, 11, 12};
         static const int16_t sh8[8] = {0, -6, -4, -2, 0, -6, -4, -2};
@@ -1780,27 +1802,9 @@ static void zxc_pivco_unpack_flat(uint8_t* RESTRICT out, const size_t n, const i
         }
     }
 #elif defined(ZXC_USE_NEON32)
-    /* d-register mirrors of the AArch64 kernels: 8 codes per step, c2s lookup
-     * via VTBL (16-entry table = two d-registers). */
-    if (D == 4) {
-        uint8x8x2_t vc2s;
-        vc2s.val[0] = vld1_u8(c2s);
-        vc2s.val[1] = vld1_u8(c2s + 8);
-        static const uint8_t rep2[8] = {0, 0, 1, 1, 2, 2, 3, 3};
-        static const int8_t sh4[8] = {0, -4, 0, -4, 0, -4, 0, -4};
-        const uint8x8_t vrep = vld1_u8(rep2);
-        const int8x8_t vsh = vld1_s8(sh4);
-        const uint8x8_t vmask = vdup_n_u8(0x0F);
-        while (i + 8 <= n) {
-            uint32_t w;
-            ZXC_MEMCPY(&w, bits + ((i * 4) >> 3), 4);
-            const uint8x8_t raw = vreinterpret_u8_u32(vdup_n_u32(w));
-            const uint8x8_t rep = vtbl1_u8(raw, vrep);
-            const uint8x8_t codes = vand_u8(vshl_u8(rep, vsh), vmask);
-            vst1_u8(out + i, vtbl2_u8(vc2s, codes));
-            i += 8;
-        }
-    } else if (D == 2) {
+    // d-register mirrors of the AArch64 kernels: 8 codes per step, c2s lookup
+    // via VTBL (16-entry table = two d-registers).
+    if (D == 2) {
         uint8_t c2s8[8];
         for (int k = 0; k < 8; k++) c2s8[k] = c2s[k & 3];
         const uint8x8_t vc2s = vld1_u8(c2s8);
@@ -1819,10 +1823,10 @@ static void zxc_pivco_unpack_flat(uint8_t* RESTRICT out, const size_t n, const i
             i += 8;
         }
     } else if (D == 3) {
-        /* 8 codes/step. 3-bit codes straddle bytes, so build a 16-bit window
-         * {byte_j, byte_j+1} per lane via two VTBLs, then extract bits [s,s+3)
-         * by multiply-by-2^(13-s) then >>13 - ARMv7 has no per-lane u16 variable
-         * shift. 8 codes fit in 3 source bytes. */
+        // 8 codes/step. 3-bit codes straddle bytes, so build a 16-bit window
+        // {byte_j, byte_j+1} per lane via two VTBLs, then extract bits [s,s+3)
+        // by multiply-by-2^(13-s) then >>13 - ARMv7 has no per-lane u16 variable
+        // shift. 8 codes fit in 3 source bytes.
         const uint8x8_t vc2s = vld1_u8(c2s); /* 8 entries (2^3) */
         static const uint8_t idxlo[8] = {0, 1, 0, 1, 0, 1, 1, 2};
         static const uint8_t idxhi[8] = {1, 2, 1, 2, 2, 3, 2, 3};
@@ -1843,8 +1847,29 @@ static void zxc_pivco_unpack_flat(uint8_t* RESTRICT out, const size_t n, const i
             vst1_u8(out + i, vtbl1_u8(vc2s, vmovn_u16(codes16)));
             i += 8;
         }
+    } else if (D == 4) {
+        /* Register by register: GCC has no AArch32 vld1_u8_x2/_x4 before 14.
+         * Loaded once per call, so the tuple form bought nothing anyway. */
+        uint8x8x2_t vc2s;
+        vc2s.val[0] = vld1_u8(c2s);
+        vc2s.val[1] = vld1_u8(c2s + 8);
+        static const uint8_t rep2[8] = {0, 0, 1, 1, 2, 2, 3, 3};
+        static const int8_t sh4[8] = {0, -4, 0, -4, 0, -4, 0, -4};
+        const uint8x8_t vrep = vld1_u8(rep2);
+        const int8x8_t vsh = vld1_s8(sh4);
+        const uint8x8_t vmask = vdup_n_u8(0x0F);
+        while (i + 8 <= n) {
+            uint32_t w;
+            ZXC_MEMCPY(&w, bits + ((i * 4) >> 3), 4);
+            const uint8x8_t raw = vreinterpret_u8_u32(vdup_n_u32(w));
+            const uint8x8_t rep = vtbl1_u8(raw, vrep);
+            const uint8x8_t codes = vand_u8(vshl_u8(rep, vsh), vmask);
+            vst1_u8(out + i, vtbl2_u8(vc2s, codes));
+            i += 8;
+        }
     } else if (D == 5) {
-        /* Same window scheme as D=3; c2s has 32 entries (VTBL4). 5 source bytes. */
+        // Same window scheme as D=3; c2s has 32 entries (VTBL4). 5 source bytes.
+        // Register by register: see D == 4.
         uint8x8x4_t vc2s;
         vc2s.val[0] = vld1_u8(c2s);
         vc2s.val[1] = vld1_u8(c2s + 8);
@@ -1869,9 +1894,9 @@ static void zxc_pivco_unpack_flat(uint8_t* RESTRICT out, const size_t n, const i
             i += 8;
         }
     } else if (D == 6) {
-        /* Same window scheme; c2s has 64 entries: two VTBL4 halves, select by
-         * code bit 5. 6 source bytes. */
-        uint8x8x4_t lo, hi;
+        // Same window scheme; c2s has 64 entries: two VTBL4 halves, select by
+        // code bit 5. 6 source bytes.
+        uint8x8x4_t lo, hi;  // register by register: see D == 4
         lo.val[0] = vld1_u8(c2s);
         lo.val[1] = vld1_u8(c2s + 8);
         lo.val[2] = vld1_u8(c2s + 16);
@@ -1904,12 +1929,112 @@ static void zxc_pivco_unpack_flat(uint8_t* RESTRICT out, const size_t n, const i
     }
 #elif defined(ZXC_USE_AVX512) || defined(ZXC_USE_AVX2) || \
     (defined(ZXC_USE_SSE2) && defined(__SSE4_1__))
+#if defined(ZXC_USE_AVX512) && defined(__AVX512VBMI__)
+    /* vpmultishiftqb reads an 8-bit field at an arbitrary bit offset: the
+     * unaligned D-bit read, in one instruction. Two facts carry the rest -
+     * 64 codes are exactly 8*D bytes and byte-aligned, so the tables are the
+     * same every step; and only the low D bits of a field survive, so bytes
+     * past 8*D are irrelevant and both accesses can be clamped to the run.
+     * Clamping the store also ends the run, hence nothing narrower below. */
+    if (D >= 2 && D <= 6) {
+        uint8_t arr[64];
+        uint8_t shf[64];
+        for (int k = 0; k < 8; k++) {
+            for (int j = 0; j < 8; j++) {
+                arr[k * 8 + j] = (uint8_t)(k * D + j);
+                shf[k * 8 + j] = (uint8_t)(j * D);
+            }
+        }
+        const __m512i varr = _mm512_loadu_si512((const void*)arr);
+        const __m512i vshf = _mm512_loadu_si512((const void*)shf);
+        const __m512i vand = _mm512_set1_epi8((char)((1 << D) - 1));
+        /* c2s holds 2^D entries and nothing is guaranteed past them. */
+        const __mmask64 tm = (D == 6) ? ~(__mmask64)0 : (((__mmask64)1 << (1 << D)) - 1);
+        const __m512i vc2s = _mm512_maskz_loadu_epi8(tm, (const void*)c2s);
+        const size_t nbytes = zxc_pivco_run_bytes((uint32_t)n, (uint8_t)D);
+        while (i < n) {
+            const size_t off = ((size_t)i * (size_t)D) >> 3;
+            const size_t avail = nbytes - off;
+            const size_t left = n - i;
+            const __mmask64 lm = (avail >= 64) ? ~(__mmask64)0 : (((__mmask64)1 << avail) - 1);
+            const __mmask64 sm = (left >= 64) ? ~(__mmask64)0 : (((__mmask64)1 << left) - 1);
+            const __m512i raw = _mm512_maskz_loadu_epi8(lm, (const void*)(bits + off));
+            const __m512i q = _mm512_permutexvar_epi8(varr, raw);
+            const __m512i codes = _mm512_and_si512(_mm512_multishift_epi64_epi8(vshf, q), vand);
+            _mm512_mask_storeu_epi8((void*)(out + i), sm, _mm512_permutexvar_epi8(codes, vc2s));
+            i += 64;
+        }
+        if (i > n) i = n;
+    }
+#else
+#if defined(ZXC_USE_AVX2)
+    /* Codes 16..31 start exactly 2*D bytes in, so the upper half runs the same
+     * pattern over a shifted source: one shuffle vector serves both, and packus
+     * leaves each half's codes in order in its own lane - no cross-lane fixup.
+     * The bound keeps both 16-byte reads inside the run; the exact-length
+     * 16-wide loops below take the tail. */
+    if (D >= 2 && D <= 6) {
+        uint8_t sa[16];
+        uint8_t sb[16];
+        uint16_t mu[8];
+        for (int q = 0; q < 8; q++) {
+            const int ba = (q * D) >> 3;
+            sa[2 * q] = (uint8_t)ba;
+            sa[2 * q + 1] = (uint8_t)(ba + 1);
+            sb[2 * q] = (uint8_t)(ba + D); /* code q+8 sits D bytes further */
+            sb[2 * q + 1] = (uint8_t)(ba + D + 1);
+            mu[q] = (uint16_t)(1U << (16 - D - ((q * D) & 7)));
+        }
+        const __m256i vsa = _mm256_broadcastsi128_si256(_mm_loadu_si128((const __m128i*)(void*)sa));
+        const __m256i vsb = _mm256_broadcastsi128_si256(_mm_loadu_si128((const __m128i*)(void*)sb));
+        const __m256i vmu = _mm256_broadcastsi128_si256(_mm_loadu_si128((const __m128i*)(void*)mu));
+        const __m256i vand = _mm256_set1_epi8((char)((1 << D) - 1));
+        uint8_t tab[64];
+        for (int e = 0; e < 64; e++) tab[e] = c2s[e & ((1 << D) - 1)];
+        const __m256i t0 = _mm256_broadcastsi128_si256(_mm_loadu_si128((const __m128i*)(void*)tab));
+        const __m256i t1 =
+            _mm256_broadcastsi128_si256(_mm_loadu_si128((const __m128i*)(void*)(tab + 16)));
+        const __m256i t2 =
+            _mm256_broadcastsi128_si256(_mm_loadu_si128((const __m128i*)(void*)(tab + 32)));
+        const __m256i t3 =
+            _mm256_broadcastsi128_si256(_mm_loadu_si128((const __m128i*)(void*)(tab + 48)));
+        const size_t nbytes = zxc_pivco_run_bytes((uint32_t)n, (uint8_t)D);
+        while (i + 32 <= n && ((size_t)i * (size_t)D >> 3) + (size_t)(2 * D) + 16 <= nbytes) {
+            const uint8_t* src = bits + ((size_t)i * (size_t)D >> 3);
+            const __m256i raw = _mm256_inserti128_si256(
+                _mm256_castsi128_si256(_mm_loadu_si128((const __m128i*)(const void*)src)),
+                _mm_loadu_si128((const __m128i*)(const void*)(src + 2 * D)), 1);
+            const __m256i ca =
+                _mm256_srli_epi16(_mm256_mullo_epi16(_mm256_shuffle_epi8(raw, vsa), vmu), 16 - D);
+            const __m256i cb =
+                _mm256_srli_epi16(_mm256_mullo_epi16(_mm256_shuffle_epi8(raw, vsb), vmu), 16 - D);
+            const __m256i codes = _mm256_and_si256(_mm256_packus_epi16(ca, cb), vand);
+            __m256i sym;
+            if (D <= 4) {
+                sym = _mm256_shuffle_epi8(t0, codes);
+            } else {
+                const __m256i b4 = _mm256_slli_epi16(codes, 3); /* code bit 4 -> sign */
+                const __m256i lo = _mm256_blendv_epi8(_mm256_shuffle_epi8(t0, codes),
+                                                      _mm256_shuffle_epi8(t1, codes), b4);
+                if (D == 5) {
+                    sym = lo;
+                } else {
+                    const __m256i hi = _mm256_blendv_epi8(_mm256_shuffle_epi8(t2, codes),
+                                                          _mm256_shuffle_epi8(t3, codes), b4);
+                    sym = _mm256_blendv_epi8(lo, hi, _mm256_slli_epi16(codes, 2));
+                }
+            }
+            _mm256_storeu_si256((__m256i*)(void*)(out + i), sym);
+            i += 32;
+        }
+    }
+#endif
     if (D == 4) {
         const __m128i vc2s = _mm_loadu_si128((const __m128i*)(const void*)c2s);
         const __m128i vrep = _mm_setr_epi8(0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7);
         const __m128i vmask = _mm_set1_epi8(0x0F);
-        /* even lanes keep low nibble, odd lanes take the high nibble: shift the
-         * replicated bytes right by 4 via a 16-bit shift + odd-lane select. */
+        // even lanes keep low nibble, odd lanes take the high nibble: shift the
+        // replicated bytes right by 4 via a 16-bit shift + odd-lane select.
         const __m128i vodd = _mm_set1_epi16(0x0F00 - 0x0F00 + (short)0xFF00);
         while (i + 16 <= n) {
             const __m128i raw =
@@ -1922,9 +2047,9 @@ static void zxc_pivco_unpack_flat(uint8_t* RESTRICT out, const size_t n, const i
             i += 16;
         }
     } else if (D == 2) {
-        /* 16 codes from 4 bytes. SSE has no per-lane byte shift, so shift by
-         * multiply: (b << (6 - 2j)) >> 6 keeps bits [2j+1:2j]. Bytes spread to
-         * u16 lanes, times {64,16,4,1}, shifted, then packed back. */
+        // 16 codes from 4 bytes. SSE has no per-lane byte shift, so shift by
+        // multiply: (b << (6 - 2j)) >> 6 keeps bits [2j+1:2j]. Bytes spread to
+        // u16 lanes, times {64,16,4,1}, shifted, then packed back.
         uint8_t c2s16[16];
         for (int k = 0; k < 16; k++) c2s16[k] = c2s[k & 3];
         const __m128i vc2s = _mm_loadu_si128((const __m128i*)(const void*)c2s16);
@@ -1949,9 +2074,9 @@ static void zxc_pivco_unpack_flat(uint8_t* RESTRICT out, const size_t n, const i
             i += 16;
         }
     } else if (D == 3) {
-        /* 16-bit window {byte_j,byte_j+1} per lane (byte_j = Di>>3); SSE has no
-         * per-lane u16 shift, so extract bits [s,s+D) of window w by w*2^(16-D-s)
-         * (field lands in the top D bits) then >>(16-D); s_j = Dj&7. D=3: 6 bytes. */
+        // 16-bit window {byte_j,byte_j+1} per lane (byte_j = Di>>3); SSE has no
+        // per-lane u16 shift, so extract bits [s,s+D) of window w by w*2^(16-D-s)
+        // (field lands in the top D bits) then >>(16-D); s_j = Dj&7. D=3: 6 bytes.
         uint8_t c2s16[16];
         for (int k = 0; k < 16; k++) c2s16[k] = c2s[k & 7];
         const __m128i vc2s = _mm_loadu_si128((const __m128i*)(const void*)c2s16);
@@ -1974,7 +2099,7 @@ static void zxc_pivco_unpack_flat(uint8_t* RESTRICT out, const size_t n, const i
             i += 16;
         }
     } else if (D == 5) {
-        /* c2s has 32 entries: pshufb does 16, so select lo/hi by code bit 4. */
+        // c2s has 32 entries: pshufb does 16, so select lo/hi by code bit 4.
         const __m128i vlo = _mm_loadu_si128((const __m128i*)(const void*)c2s);
         const __m128i vhi = _mm_loadu_si128((const __m128i*)(const void*)(c2s + 16));
         const __m128i shufA = _mm_setr_epi8(0, 1, 0, 1, 1, 2, 1, 2, 2, 3, 3, 4, 3, 4, 4, 5);
@@ -1998,7 +2123,7 @@ static void zxc_pivco_unpack_flat(uint8_t* RESTRICT out, const size_t n, const i
             i += 16;
         }
     } else if (D == 6) {
-        /* c2s has 64 entries: 4 pshufb sub-tables, select by code bits 4-5. */
+        // c2s has 64 entries: 4 pshufb sub-tables, select by code bits 4-5.
         const __m128i t0 = _mm_loadu_si128((const __m128i*)(const void*)c2s);
         const __m128i t1 = _mm_loadu_si128((const __m128i*)(const void*)(c2s + 16));
         const __m128i t2 = _mm_loadu_si128((const __m128i*)(const void*)(c2s + 32));
@@ -2027,8 +2152,9 @@ static void zxc_pivco_unpack_flat(uint8_t* RESTRICT out, const size_t n, const i
             i += 16;
         }
     }
+#endif /* AVX-512 VBMI, else AVX2 + SSE */
 #endif
-    /* Generic scalar bit-reader (any D). */
+    // Generic scalar bit-reader (any D).
     {
         uint64_t bitpos = i * (uint64_t)D;
         const uint32_t m = (1U << D) - 1U;
@@ -2084,6 +2210,47 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_emit_leaf_pair(uint8_t* RESTRICT out, co
     }
 #elif defined(ZXC_USE_AVX512) || defined(ZXC_USE_AVX2) || \
     (defined(ZXC_USE_SSE2) && defined(__SSSE3__))
+#if defined(ZXC_USE_AVX512)
+    /* The control word is already the blend mask; the masked store takes the
+     * tail, hence nothing narrower below. */
+    {
+        const __m512i z0 = _mm512_set1_epi8((char)sym0);
+        const __m512i z1 = _mm512_set1_epi8((char)sym1);
+        while (i < n) {
+            const size_t left = n - i;
+            const size_t cb = (left + 7) >> 3;
+            uint64_t ctrl = 0;
+            ZXC_MEMCPY(&ctrl, bits + (i >> 3), cb < 8 ? cb : 8); /* not past the run */
+            const __mmask64 sm = (left >= 64) ? ~(__mmask64)0 : (((__mmask64)1 << left) - 1);
+            _mm512_mask_storeu_epi8((void*)(out + i), sm,
+                                    _mm512_mask_blend_epi8((__mmask64)ctrl, z0, z1));
+            i += 64;
+        }
+        if (i > n) i = n;
+    }
+#else
+#if defined(ZXC_USE_AVX2)
+    /* Broadcasting the control dword lets each 128-bit half pick its own two
+     * bytes out of it. */
+    {
+        const __m256i y0 = _mm256_set1_epi8((char)sym0);
+        const __m256i ydelta = _mm256_set1_epi8((char)(uint8_t)(sym0 ^ sym1));
+        const __m256i yrep = _mm256_setr_epi8(0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2,
+                                              2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3);
+        const __m256i ysel =
+            _mm256_setr_epi8(1, 2, 4, 8, 16, 32, 64, (char)128, 1, 2, 4, 8, 16, 32, 64, (char)128,
+                             1, 2, 4, 8, 16, 32, 64, (char)128, 1, 2, 4, 8, 16, 32, 64, (char)128);
+        while (i + 32 <= n) {
+            uint32_t c4;
+            ZXC_MEMCPY(&c4, bits + (i >> 3), 4);
+            const __m256i rep = _mm256_shuffle_epi8(_mm256_set1_epi32((int)c4), yrep);
+            const __m256i mask = _mm256_cmpeq_epi8(_mm256_and_si256(rep, ysel), ysel);
+            _mm256_storeu_si256((__m256i*)(void*)(out + i),
+                                _mm256_xor_si256(y0, _mm256_and_si256(ydelta, mask)));
+            i += 32;
+        }
+    }
+#endif
     const __m128i vsym0 = _mm_set1_epi8((char)sym0);
     const __m128i vdelta = _mm_set1_epi8((char)(uint8_t)(sym0 ^ sym1));
     const __m128i vrep = _mm_setr_epi8(0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1);
@@ -2092,12 +2259,13 @@ static ZXC_ALWAYS_INLINE void zxc_pivco_emit_leaf_pair(uint8_t* RESTRICT out, co
     while (i + 16 <= n) {
         const __m128i ctrl = _mm_cvtsi32_si128(bits[i >> 3] | ((int)bits[(i >> 3) + 1] << 8));
         const __m128i rep = _mm_shuffle_epi8(ctrl, vrep);
-        /* lanes where the selected bit is set -> 0xFF */
+        // lanes where the selected bit is set -> 0xFF
         const __m128i mask = _mm_cmpeq_epi8(_mm_and_si128(rep, vsel), vsel);
         _mm_storeu_si128((__m128i*)(void*)(out + i),
                          _mm_xor_si128(vsym0, _mm_and_si128(vdelta, mask)));
         i += 16;
     }
+#endif /* AVX-512, else AVX2 + SSE */
 #endif
     while (i < n) {
         const int bit = (bits[i >> 3] >> (i & 7)) & 1;
@@ -2125,7 +2293,7 @@ static int zxc_pivco_decode_core(const uint8_t* RESTRICT payload, const size_t p
                                  uint8_t* RESTRICT scratch) {
     if (UNLIKELY(n == 0)) return ZXC_ERROR_CORRUPT_DATA;
 
-    /* Pass 1: node counts + bit-run pointers, straight from the wire order. */
+    // Pass 1: node counts + bit-run pointers, straight from the wire order.
     uint32_t count[ZXC_PIVCO_MAX_NODES];
     const uint8_t* bit_ptr[ZXC_PIVCO_MAX_NODES];
     count[0] = (uint32_t)n;
@@ -2137,7 +2305,7 @@ static int zxc_pivco_decode_core(const uint8_t* RESTRICT payload, const size_t p
         if (t->covered[nid] || nd->sym >= 0) continue;
         const uint32_t c = count[nid];
         if (t->flat_d[nid]) {
-            /* Packed-code run: no partition below, nothing to popcount. */
+            // Packed-code run: no partition below, nothing to popcount.
             const size_t fbytes = zxc_pivco_run_bytes(c, t->flat_d[nid]);
             if (UNLIKELY((size_t)(pend - p) < fbytes)) return ZXC_ERROR_CORRUPT_DATA;
             bit_ptr[nid] = p;
@@ -2147,9 +2315,9 @@ static int zxc_pivco_decode_core(const uint8_t* RESTRICT payload, const size_t p
         const size_t nbytes = zxc_pivco_run_bytes(c, 0); /* merge node: c partition bits */
         if (UNLIKELY((size_t)(pend - p) < nbytes)) return ZXC_ERROR_CORRUPT_DATA;
         bit_ptr[nid] = p;
-        /* popcount of the c valid bits = the right child's count. All but the
-         * last byte counted fast, the last one with its padding masked - if the
-         * 8-byte loop swallowed it unmasked, padding bits would inflate `ones`. */
+        // popcount of the c valid bits = the right child's count. All but the
+        // last byte counted fast, the last one with its padding masked - if the
+        // 8-byte loop swallowed it unmasked, padding bits would inflate `ones`.
         uint32_t ones = 0;
         if (nbytes) {
             const size_t full = nbytes - 1;
@@ -2178,7 +2346,7 @@ static int zxc_pivco_decode_core(const uint8_t* RESTRICT payload, const size_t p
             return ZXC_ERROR_CORRUPT_DATA;
     }
 
-    /* Per-level sequence offsets (BFS order => children contiguous). */
+    // Per-level sequence offsets (BFS order => children contiguous).
     uint32_t seq_off[ZXC_PIVCO_MAX_NODES];
     for (int d = 0; d <= t->max_depth; d++) {
         uint32_t off = 0;
@@ -2190,29 +2358,19 @@ static int zxc_pivco_decode_core(const uint8_t* RESTRICT payload, const size_t p
         }
     }
 
-    /* Leaf-pair parents emit both runs directly from their bits (XOR-blend),
-     * so their children never need materialising: flag them for skipping.
-     * A dictionary tree carries these flags precomputed in aux. */
+    // Leaf-pair parents emit both runs directly from their bits (XOR-blend),
+    // so their children never need materialising: flag them for skipping.
+    // A dictionary tree carries these flags precomputed in aux.
     uint8_t skip_local[ZXC_PIVCO_MAX_NODES];
     const uint8_t* skip;
     if (aux) {
         skip = aux->skip;
     } else {
-        ZXC_MEMSET(skip_local, 0, sizeof(skip_local));
-        for (int i = 0; i < t->n_nodes; i++) {
-            const zxc_pivco_node_t* nd = &t->nd[t->bfs[i]];
-            if (nd->sym >= 0) continue;
-            const int ch0 = nd->child[0];
-            const int ch1 = nd->child[1];
-            if (ch0 >= 0 && ch1 >= 0 && t->nd[ch0].sym >= 0 && t->nd[ch1].sym >= 0) {
-                skip_local[ch0] = 1;
-                skip_local[ch1] = 1;
-            }
-        }
+        zxc_pivco_mark_leaf_pairs(t, skip_local);
         skip = skip_local;
     }
 
-    /* Pass 2: bottom-up level reconstruction. */
+    // Pass 2: bottom-up level reconstruction.
     for (int d = t->max_depth; d >= 0; d--) {
         uint8_t* const buf_d = (d & 1) ? scratch : dst;
         const uint8_t* const buf_c = (d & 1) ? dst : scratch; /* children at d+1 (read-only) */
@@ -2225,54 +2383,31 @@ static int zxc_pivco_decode_core(const uint8_t* RESTRICT payload, const size_t p
             if (nd->sym >= 0) {
                 ZXC_MEMSET(buf_d + seq_off[nid], (uint8_t)nd->sym, c);
             } else if (t->flat_d[nid]) {
-                /* Packed-path -> symbol table (complete subtree of depth D:
-                 * 2^D leaves): precomputed at attach for a dictionary tree,
-                 * else built here, then unpack the code run directly. */
+                // Packed-path -> symbol table (complete subtree of depth D:
+                // 2^D leaves): precomputed at attach for a dictionary tree,
+                // else built here, then unpack the code run directly.
                 const int D = t->flat_d[nid];
                 uint8_t c2s_local[1U << ZXC_HUF_MAX_CODE_LEN_ULTRA];
                 const uint8_t* c2s;
                 if (aux) {
                     c2s = aux->c2s_pool + aux->c2s_off[nid];
                 } else {
-                    int16_t stk_n[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
-                    uint16_t stk_p[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
-                    uint8_t stk_l[ZXC_HUF_MAX_CODE_LEN_ULTRA + 1];
-                    int sp = 0;
-                    stk_n[0] = (int16_t)nid;
-                    stk_p[0] = 0;
-                    stk_l[0] = 0;
-                    while (sp >= 0) {
-                        const int cn = stk_n[sp];
-                        const uint32_t cp = stk_p[sp];
-                        const int cl = stk_l[sp];
-                        sp--;
-                        if (t->nd[cn].sym >= 0) {
-                            c2s_local[cp] = (uint8_t)t->nd[cn].sym;
-                            continue;
-                        }
-                        sp++;
-                        stk_n[sp] = t->nd[cn].child[0];
-                        stk_p[sp] = (uint16_t)cp;
-                        stk_l[sp] = (uint8_t)(cl + 1);
-                        sp++;
-                        stk_n[sp] = t->nd[cn].child[1];
-                        stk_p[sp] = (uint16_t)(cp | (1U << cl));
-                        stk_l[sp] = (uint8_t)(cl + 1);
-                    }
+                    zxc_pivco_build_c2s(t, nid, c2s_local);
                     c2s = c2s_local;
                 }
                 zxc_pivco_unpack_flat(buf_d + seq_off[nid], c, D, bit_ptr[nid], c2s);
             } else {
-                const int ch0 = nd->child[0];
-                const int ch1 = nd->child[1];
-                if (ch0 >= 0 && ch1 >= 0 && t->nd[ch0].sym >= 0 && t->nd[ch1].sym >= 0) {
-                    zxc_pivco_emit_leaf_pair(buf_d + seq_off[nid], c, (uint8_t)t->nd[ch0].sym,
-                                             (uint8_t)t->nd[ch1].sym, bit_ptr[nid]);
+                if (UNLIKELY(nd->child[0] < 0)) return ZXC_ERROR_CORRUPT_DATA;
+
+                const zxc_pivco_node_t* const l = &t->nd[nd->child[0]];
+                if (nd->child[1] >= 0 && l->sym >= 0 && t->nd[nd->child[1]].sym >= 0) {
+                    zxc_pivco_emit_leaf_pair(buf_d + seq_off[nid], c, (uint8_t)l->sym,
+                                             (uint8_t)t->nd[nd->child[1]].sym, bit_ptr[nid]);
                     continue;
                 }
-                const uint32_t nl = ch0 >= 0 ? count[ch0] : 0;
-                const uint32_t src_off = ch0 >= 0 ? seq_off[ch0] : seq_off[nd->child[1]];
-                zxc_pivco_merge(buf_d + seq_off[nid], buf_c + src_off, nl, c - nl, bit_ptr[nid]);
+                const uint32_t nl = count[nd->child[0]];
+                zxc_pivco_merge(buf_d + seq_off[nid], buf_c + seq_off[nd->child[0]], nl, c - nl,
+                                bit_ptr[nid]);
             }
         }
     }

--- a/lz/zxc/src/lib/zxc_internal.h
+++ b/lz/zxc/src/lib/zxc_internal.h
@@ -161,12 +161,6 @@ extern "C" {
  */
 #define ZXC_PREFETCH_READ(ptr) __builtin_prefetch((const void*)(ptr), 0, 3)
 
-/** @def ZXC_PREFETCH_WRITE
- * @brief Prefetch data for writing.
- * @param ptr Pointer to data to prefetch.
- */
-#define ZXC_PREFETCH_WRITE(ptr) __builtin_prefetch((const void*)(ptr), 1, 3)
-
 /** @def ZXC_MEMCPY
  * @brief Optimized memory copy using compiler built-in.
  */
@@ -206,10 +200,8 @@ extern "C" {
 #if defined(_M_IX86) || defined(_M_X64) || defined(_M_AMD64)
 #include <xmmintrin.h>
 #define ZXC_PREFETCH_READ(ptr) _mm_prefetch((const char*)(ptr), _MM_HINT_T0)
-#define ZXC_PREFETCH_WRITE(ptr) _mm_prefetch((const char*)(ptr), _MM_HINT_T0)
 #else
 #define ZXC_PREFETCH_READ(ptr) __prefetch((const void*)(ptr))
-#define ZXC_PREFETCH_WRITE(ptr) __prefetch((const void*)(ptr))
 #endif
 #define LIKELY(x) (x)
 #define UNLIKELY(x) (x)
@@ -241,7 +233,6 @@ extern "C" {
 #define UNLIKELY(x) (x)
 #define RESTRICT
 #define ZXC_PREFETCH_READ(ptr)
-#define ZXC_PREFETCH_WRITE(ptr)
 #define ZXC_MEMCPY(dst, src, n) memcpy(dst, src, n)
 #define ZXC_MEMSET(dst, val, n) memset(dst, val, n)
 
@@ -273,9 +264,9 @@ extern "C" {
 #endif
 /** @} */ /* end of Compiler Abstractions */
 
-/* Heap allocator and cache-line-aligned allocator macros are now defined
- * in @c zxc_deps.h (included at the top of this header), so non-libc
- * targets can override them by vendoring that single file. */
+// Heap allocator and cache-line-aligned allocator macros are now defined
+// in @c zxc_deps.h (included at the top of this header), so non-libc
+// targets can override them by vendoring that single file.
 
 /**
  * @name Endianness Detection
@@ -331,10 +322,24 @@ extern "C" {
 #define ZXC_MAGIC_WORD 0x9CB02EF5U
 /** @brief Current on-disk file format version. The decoder accepts only this
  *  version; Older versions are rejected with ZXC_ERROR_BAD_VERSION. */
-#define ZXC_FILE_FORMAT_VERSION 7
+#define ZXC_FILE_FORMAT_VERSION 8
 
 /** @brief Safety padding appended to buffers to tolerate overruns. */
 #define ZXC_PAD_SIZE 32
+/**
+ * @brief Readable bytes a GLO/GHI payload guarantees after its literal section.
+ *
+ * A wire guarantee, not a buffer allowance - hence separate from
+ * @ref ZXC_PAD_SIZE even though the values match. RAW literals point into the
+ * caller's buffer and @ref zxc_decode_copy_literals overshoots by up to 31 B,
+ * so it needs readable bytes behind it.
+ *
+ * The following sections usually supply them for free (tokens + offsets clear
+ * 32 B from 16 sequences on); the encoder pads only the shortfall, inside the
+ * extras section. Extras are read on demand, so an over-long end pointer is
+ * harmless - no wire field, nothing to validate about the padding.
+ */
+#define ZXC_BLOCK_LIT_SLACK 32
 /**
  * @brief Tail padding required on the decompression destination buffer.
  *
@@ -393,32 +398,24 @@ extern "C" {
  *         histogram converges early, so past it slices are strided evenly instead. */
 #define ZXC_DICT_HUF_SAMPLE_BUDGET (8U << 20)
 
-/** @brief Block header size: Type(1)+Flags(1)+Reserved(1)+CRC(1)+CompSize(4). */
+/** @brief Block header size: Type(1)+Flags(1)+Reserved(1)+Checksum(1)+CompSize(4). */
 #define ZXC_BLOCK_HEADER_SIZE 8
 /** @brief Size of the per-block checksum field in bytes. */
 #define ZXC_BLOCK_CHECKSUM_SIZE 4
 /** @brief Binary size of a GLO block sub-header. */
-#define ZXC_GLO_HEADER_BINARY_SIZE 16
+#define ZXC_GLO_HEADER_BINARY_SIZE 12
 /** @brief Binary size of a GHI block sub-header. */
-#define ZXC_GHI_HEADER_BINARY_SIZE 16
+#define ZXC_GHI_HEADER_BINARY_SIZE 12
 
 /** @brief Worst-case format overhead inside a single block beyond the outer
  *  8-byte block header and the optional 4-byte checksum.
  *
- *  Covers the inner GLO/GHI sub-header (16 B) plus four section descriptors
- *  (4 x 8 = 32 B) = 48 B, with a 16 B safety margin for future format
- *  evolution. Used by zxc_compress_block_bound() and zxc_compress_bound()
- *  to size the destination buffer in the worst (incompressible) case. */
-#define ZXC_BLOCK_FORMAT_OVERHEAD 64
-
-/** @brief Binary size of a section descriptor (comp_size + raw_size). */
-#define ZXC_SECTION_DESC_BINARY_SIZE 8
-/** @brief 32-bit mask for extracting sizes from a section descriptor. */
-#define ZXC_SECTION_SIZE_MASK 0xFFFFFFFFU
-/** @brief Number of sections in a GLO block. */
-#define ZXC_GLO_SECTIONS 4
-/** @brief Number of sections in a GHI block. */
-#define ZXC_GHI_SECTIONS 3
+ *  Sub-header (12 B) + widest GLO section descriptors (8 B) + widest slack padding
+ *  (@ref ZXC_BLOCK_LIT_SLACK) = 52 B, plus the customary 16 B of margin for
+ *  future format evolution. Used by zxc_compress_block_bound() and
+ *  zxc_compress_bound().
+ */
+#define ZXC_BLOCK_FORMAT_OVERHEAD 68
 
 /** @brief Checksum algorithm id for RapidHash (default, sole implementation). */
 #define ZXC_CHECKSUM_RAPIDHASH 0
@@ -515,18 +512,49 @@ extern "C" {
  * the encoder refuses to emit values above this bound. Together they bound the
  * varint surface to exactly the format-defined block size limit. */
 #define ZXC_MAX_VARINT_VALUE ((uint32_t)(ZXC_BLOCK_SIZE_MAX - 1U))
-/** @brief Maximum decoded output of a single sequence with INLINE ll/ml
- *         (non-varint). Used by 4x decoder bounds checks to reserve space for
- *         subsequent inline sequences in the same batch when the current
- *         sequence has a varint-extended ml. */
-#define ZXC_GLO_MAX_INLINE_OUT_PER_SEQ \
-    ((ZXC_TOKEN_LL_MASK - 1U) + (ZXC_TOKEN_ML_MASK - 1U) + ZXC_LZ_MIN_MATCH_LEN) /* 33 */
+/** @brief Maximum decoded output of one sequence with inline ll/ml, used by the
+ *         4x bounds checks to reserve the rest of a batch.
+ *
+ *         Keep it small - the loop margins scale with it. Widening it to 543
+ *         once cost 2 percent of decode on silesia. */
+#define ZXC_GLO_MAX_INLINE_OUT_PER_SEQ ((ZXC_TOKEN_LL_MASK - 1U) + ZXC_GLO_MAX_INLINE_ML) /* 33 */
+/** @brief Longest match a GLO sequence carries without a varint extension.
+ *
+ * Below @ref ZXC_PAD_SIZE, so the inline path needs no length ladder: one
+ * 32-byte store covers it. The escape path always yields more, so comparing
+ * against this recovers "was the ml nibble inline". */
+#define ZXC_GLO_MAX_INLINE_ML ((ZXC_TOKEN_ML_MASK - 1U) + ZXC_LZ_MIN_MATCH_LEN) /* 19 */
 #define ZXC_GHI_MAX_INLINE_OUT_PER_SEQ \
     ((ZXC_SEQ_LL_MASK - 1U) + (ZXC_SEQ_ML_MASK - 1U) + ZXC_LZ_MIN_MATCH_LEN) /* 513 */
 /** @brief Base bias added to encoded offsets (stored = actual - bias). */
 #define ZXC_LZ_OFFSET_BIAS 1
 /** @brief Maximum allowed offset distance. */
 #define ZXC_LZ_MAX_DIST (ZXC_LZ_WINDOW_SIZE - 1)
+
+/** @brief Match distance floor the encoder holds to at levels 1 to 5, sized to
+ *         the decoder's widest match-copy arm.
+ *
+ *  Applied per block, and only where @ref ZXC_LZ_MINDIST_MAX_SHORT_PCT clears
+ *  it; levels 6 and 7 keep every distance. Encoder policy: no format bit moves,
+ *  so any decoder of the same format version still reads the result. */
+#define ZXC_LZ_MINDIST 32
+
+/** @brief Probe sampling: one position per KB, clamped.
+ *
+ *  Proportional on purpose: a fixed count costs the same on a 4 KB block as on
+ *  a 512 KB one, which measured as a third of the compression time on small,
+ *  highly compressible inputs. */
+#define ZXC_LZ_MINDIST_PROBE_PER_KB 1024
+#define ZXC_LZ_MINDIST_PROBE_MIN 16
+#define ZXC_LZ_MINDIST_PROBE_MAX 64
+
+/** @brief Short-distance hit rate, in percent, above which a block keeps its
+ *         short match distances.
+ *
+ *  Measured: natural text 2-5 %, XML around 25 %, JSON 50-60 %, periodic data
+ *  100 %. Decode gains follow the same order, so the cut sits just above text
+ *  and below everything that measured neutral or worse. */
+#define ZXC_LZ_MINDIST_MAX_SHORT_PCT 20
 /** @brief Bytes at the block end where match search stops (left as literals).
  *  Equals the 8-byte word the finder reads at each probe, so @c ip+8<=iend. */
 #define ZXC_LZ_SEARCH_MARGIN (sizeof(uint64_t))
@@ -611,12 +639,12 @@ typedef struct {
     int16_t lvl_start[ZXC_HUF_MAX_CODE_LEN_ULTRA + 2];
     int n_nodes;
     int max_depth;
-    /* Flat-subtree fast path: flat_d[nid] = D (>= 2) when nid roots a MAXIMAL
-     * complete subtree with all leaves exactly D levels down. Its wire run is
-     * the symbols' packed D-bit residuals instead of D partition bitmaps (same
-     * bits, decode = unpack+lookup), and covered[nid] marks its strict
-     * descendants, absent from the wire. Both sides derive this from the code
-     * lengths, so nothing is signalled. */
+    // Flat-subtree fast path: flat_d[nid] = D (>= 2) when nid roots a MAXIMAL
+    // complete subtree with all leaves exactly D levels down. Its wire run is
+    // the symbols' packed D-bit residuals instead of D partition bitmaps (same
+    // bits, decode = unpack+lookup), and covered[nid] marks its strict
+    // descendants, absent from the wire. Both sides derive this from the code
+    // lengths, so nothing is signalled.
     uint8_t flat_d[ZXC_PIVCO_MAX_NODES];
     uint8_t covered[ZXC_PIVCO_MAX_NODES];
 } zxc_pivco_tree_t;
@@ -801,6 +829,20 @@ static inline int zxc_level_clamp(const int level) {
     return (level > ZXC_LEVEL_ULTRA) ? ZXC_LEVEL_ULTRA : level;
 }
 
+/** @brief Dictionary length from a (possibly NULL) options struct.
+ *
+ *  Gated on @c dict itself: no dictionary pointer means no dictionary, whatever
+ *  the sibling fields hold. Macros rather than functions because the compression
+ *  and decompression option structs carry these fields without sharing a type. */
+#define ZXC_OPTS_DICT_SIZE(o) (((o) && (o)->dict) ? (o)->dict_size : (size_t)0)
+/** @brief Shared literal Huffman table, gated on @c dict the same way. */
+#define ZXC_OPTS_DICT_HUF(o) (((o) && (o)->dict) ? (const uint8_t*)(o)->dict_huf : NULL)
+/** @brief Compression level, 0 meaning the default, clamped to the highest level
+ *         the encoder implements. */
+#define ZXC_OPTS_LEVEL(o, dflt) zxc_level_clamp(((o) && (o)->level > 0) ? (o)->level : (dflt))
+/** @brief Block size, 0 meaning the default. */
+#define ZXC_OPTS_BLOCK_SIZE(o, dflt) (((o) && (o)->block_size > 0) ? (o)->block_size : (dflt))
+
 /** @brief Encoder Huffman code-length cap for a compression @p level: levels below
  *         ::ZXC_LEVEL_ULTRA use ::ZXC_HUF_MAX_CODE_LEN_DENSITY, ::ZXC_LEVEL_ULTRA uses
  *         the full ::ZXC_HUF_MAX_CODE_LEN_ULTRA ceiling (denser codes, slower decode).
@@ -843,6 +885,21 @@ typedef struct {
      8U + (size_t)ZXC_HUF_MAX_CODE_LEN_ULTRA * sizeof(int) + 8U +          \
      (size_t)ZXC_HUF_MAX_CODE_LEN_ULTRA * (size_t)ZXC_HUF_PM_LEVEL_BOUND * \
          sizeof(zxc_huf_pm_frame_t))
+
+/**
+ * @brief The four DP partitions the optimal parser carves out of opt_scratch.
+ *
+ * One definition shared by compute_cctx_layout(), which reserves the region,
+ * and zxc_lz77_optimal_parse_glo(), which carves it: the two cannot drift.
+ */
+static ZXC_ALWAYS_INLINE void zxc_opt_dp_sizes(const size_t chunk_size, size_t* RESTRICT sz_dp,
+                                               size_t* RESTRICT sz_pl, size_t* RESTRICT sz_po,
+                                               size_t* RESTRICT sz_bm) {
+    *sz_dp = ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint32_t));
+    *sz_pl = ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint16_t));
+    *sz_po = ZXC_ALIGN_CL((chunk_size + 1) * sizeof(uint16_t));
+    *sz_bm = ZXC_ALIGN_CL(ZXC_BITMAP_WORDS(chunk_size + 1) * sizeof(uint64_t));
+}
 
 /** @name Block Size Helpers
  *  @brief Runtime helpers for variable block sizes.
@@ -936,6 +993,11 @@ typedef struct {
      *  A larger value keeps the step conservative (grows slowly with distance);
      *  a smaller value ramps up quickly, skipping more in long literal runs. */
     uint32_t step_shift;
+
+    /** Shortest match distance the parser may emit; 1 = unconstrained. Skipped
+     *  candidates do not end the chain walk, which continues to a legal one
+     *  further back. See @ref ZXC_LZ_MINDIST. */
+    uint32_t min_offset;
 } zxc_lz77_params_t;
 
 /**
@@ -944,41 +1006,42 @@ typedef struct {
  * This inline function returns the appropriate LZ77 parameters configuration
  * for the given compression level.
  *
- * @param[in] level The compression level to use for determining LZ77 parameters.
- * @return zxc_lz77_params_t The LZ77 parameters structure corresponding to the specified level.
+ * @param[in] level Compression level; out-of-range values clamp to level 1.
+ * @return The tuning tuple for that level.
  */
 static ZXC_ALWAYS_INLINE zxc_lz77_params_t zxc_get_lz77_params(const int level) {
-    if (level >= ZXC_LEVEL_ULTRA) return (zxc_lz77_params_t){128, 256, 0, 0, 0, 1, 8};
+    // The distance floor stops at level 5: the slow levels keep every distance.
     // search_depth, sufficient_len, use_lazy, lazy_attempts, lazy_len_threshold, step_base,
-    // step_shift
+    // step_shift, min_offset
     static const zxc_lz77_params_t table[7] = {
-        {3, 16, 0, 0, 0, 4, 4},       // fallback
-        {3, 16, 0, 0, 0, 4, 4},       // level 1
-        {3, 18, 0, 0, 0, 3, 6},       // level 2
-        {3, 16, 1, 4, 128, 1, 4},     // level 3
-        {3, 18, 1, 4, 128, 1, 5},     // level 4
-        {64, 256, 1, 16, 128, 1, 8},  // level 5
-        {64, 256, 0, 0, 0, 1, 8}      // level 6
+        {3, 16, 0, 0, 0, 4, 4, ZXC_LZ_MINDIST},       // fallback
+        {3, 16, 0, 0, 0, 4, 4, ZXC_LZ_MINDIST},       // level 1
+        {3, 18, 0, 0, 0, 3, 6, ZXC_LZ_MINDIST},       // level 2
+        {3, 16, 1, 4, 128, 1, 4, ZXC_LZ_MINDIST},     // level 3
+        {3, 18, 1, 4, 128, 1, 5, ZXC_LZ_MINDIST},     // level 4
+        {64, 256, 1, 16, 128, 1, 8, ZXC_LZ_MINDIST},  // level 5
+        {64, 256, 0, 0, 0, 1, 8, 1}                   // level 6
     };
-    return table[level < ZXC_LEVEL_FASTEST ? ZXC_LEVEL_FASTEST : level];
+    return (level >= ZXC_LEVEL_ULTRA)
+               ? (zxc_lz77_params_t){128, 256, 0, 0, 0, 1, 8, 1}
+               : table[level < ZXC_LEVEL_FASTEST ? ZXC_LEVEL_FASTEST : level];
 }
 
 /**
  * @enum zxc_block_type_t
- * @brief Defines the different types of data blocks supported by the ZXC
- * format.
+ * @brief Block types, i.e. which encoder produced a block's payload.
  *
- * This enumeration categorizes blocks based on the compression strategy
- * applied:
- * - `ZXC_BLOCK_RAW` (0): No compression. Used when data is incompressible (high
- * entropy) or when compression would expand the data size.
- * - `ZXC_BLOCK_GLO` (1): General-purpose compression (LZ77 + Bitpacking). This
- * is the default for most data (text, binaries, JSON, etc.). Includes 4 sections descriptors.
- * - `ZXC_BLOCK_GHI` (2): General-purpose high-velocity mode using LZ77 with advanced
- * techniques (lazy matching, step skipping) for maximum ratio. Includes 3 sections descriptors.
- * - `ZXC_BLOCK_SEK` (254): Seek table block. Contains per-block compressed/decompressed sizes
- *   for random-access decompression. Placed between EOF block and file footer.
- * - `ZXC_BLOCK_EOF` (255): End of file marker.
+ * - `ZXC_BLOCK_RAW` (0): stored as-is. Used when the data is incompressible or
+ *   when compressing it would make the block bigger.
+ * - `ZXC_BLOCK_GLO` (1): the general path, LZ77 plus bitpacked sequences,
+ *   levels 3 and up. Carries 0, 4 or 8 bytes of section descriptors depending
+ *   on which streams need an explicit compressed size.
+ * - `ZXC_BLOCK_GHI` (2): the speed path, levels 1 and 2. Fixed 4-byte sequence
+ *   records and always-RAW literals make every section size derivable from the
+ *   header, so it carries no descriptor at all.
+ * - `ZXC_BLOCK_SEK` (254): seek table, holding per-block compressed and
+ *   decompressed sizes. Sits between the EOF block and the file footer.
+ * - `ZXC_BLOCK_EOF` (255): end-of-file marker.
  */
 typedef enum {
     ZXC_BLOCK_RAW = 0,
@@ -999,7 +1062,7 @@ typedef enum {
  * - `ZXC_SECTION_ENCODING_HUFFMAN`: canonical Huffman in the PivCo layout
  *   (level-ordered branch runs, max 11-bit codes -- FORMAT.md section 5.2.1).
  *   Valid for the literal stream (`enc_lit`, level >= 6) and the token
- *   stream (`enc_litlen`, level 7) of GLO blocks.
+ *   stream (`enc_tok`, level 7) of GLO blocks.
  * - `ZXC_SECTION_ENCODING_HUFFMAN_DICT`: same payload as HUFFMAN but the
  *   128-byte code-lengths header is omitted: codes come from the shared
  *   table carried by the dictionary (.zxd). Only valid for `enc_lit` of GLO
@@ -1026,10 +1089,12 @@ typedef enum {
  * The total count of literal bytes.
  * @var zxc_gnr_header_t::enc_lit
  * Encoding method used for the literal stream.
- * @var zxc_gnr_header_t::enc_litlen
- * Encoding method used for the literal lengths stream.
+ * @var zxc_gnr_header_t::enc_tok
+ * GLO only: encoding of the token section, whose bytes each pack a literal
+ * length and a match length nibble. Only RAW and HUFFMAN (level 7) occur.
  * @var zxc_gnr_header_t::enc_mlen
- * Encoding method used for the match lengths stream.
+ * Reserved, written 0 and ignored on decode. Match lengths have no stream of
+ * their own: they share the token byte and spill into the extras.
  * @var zxc_gnr_header_t::enc_off
  * GLO only: width of the offset stream (1 = 1-byte, 0 = 2-byte). GHI has no
  * offset stream, so it writes 0 and ignores the field on decode.
@@ -1037,22 +1102,11 @@ typedef enum {
 typedef struct {
     uint32_t n_sequences;  // Number of sequences
     uint32_t n_literals;   // Number of literals
-    uint8_t enc_lit;       // Literal encoding
-    uint8_t enc_litlen;    // Literal lengths encoding
-    uint8_t enc_mlen;      // Match lengths encoding
+    uint8_t enc_lit;       // Literal stream encoding
+    uint8_t enc_tok;       // Token section encoding (GLO only)
+    uint8_t enc_mlen;      // Reserved (see above)
     uint8_t enc_off;       // Offset stream width (GLO only; ignored on decode in GHI)
 } zxc_gnr_header_t;
-
-/**
- * @struct zxc_section_desc_t
- * @brief Describes the size attributes of a specific data section.
- *
- * Used to track the compressed and uncompressed sizes of sub-components
- * (e.g., a literal stream or offset stream) within a block.
- */
-typedef struct {
-    uint64_t sizes; /**< Packed sizes: compressed size (low 32 bits) | raw size (high 32 bits). */
-} zxc_section_desc_t;
 
 /**
  * ============================================================================
@@ -1062,14 +1116,13 @@ typedef struct {
  */
 
 /**
- * @brief Reads a 16-bit unsigned integer from memory in little-endian format.
+ * @brief Reads a little-endian 16-bit value from a possibly unaligned address.
  *
- * This function interprets the bytes at the given memory address as a
- * little-endian 16-bit integer, regardless of the host system's endianness.
- * It is marked as always inline for performance critical paths.
+ * The memcpy is what makes the unaligned read defined; compilers fold it into
+ * a single load. Byte-swapped on big-endian hosts, so the wire stays LE.
  *
- * @param[in] p Pointer to the memory location to read from.
- * @return The 16-bit unsigned integer value read from memory.
+ * @param[in] p Address to read from.
+ * @return The value, in host order.
  */
 static ZXC_ALWAYS_INLINE uint16_t zxc_le16(const void* p) {
     uint16_t v;
@@ -1082,14 +1135,13 @@ static ZXC_ALWAYS_INLINE uint16_t zxc_le16(const void* p) {
 }
 
 /**
- * @brief Reads a 32-bit unsigned integer from memory in little-endian format.
+ * @brief Reads a little-endian 32-bit value from a possibly unaligned address.
  *
- * This function interprets the bytes at the given pointer address as a
- * little-endian 32-bit integer, regardless of the host system's endianness.
- * It is marked as always inline for performance critical paths.
+ * The memcpy is what makes the unaligned read defined; compilers fold it into
+ * a single load. Byte-swapped on big-endian hosts, so the wire stays LE.
  *
- * @param[in] p Pointer to the memory location to read from.
- * @return The 32-bit unsigned integer value read from memory.
+ * @param[in] p Address to read from.
+ * @return The value, in host order.
  */
 static ZXC_ALWAYS_INLINE uint32_t zxc_le32(const void* p) {
     uint32_t v;
@@ -1102,14 +1154,57 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_le32(const void* p) {
 }
 
 /**
- * @brief Reads a 64-bit unsigned integer from memory in little-endian format.
+ * @brief Reports whether a block leans on back-references shorter than
+ *        @ref ZXC_LZ_MINDIST.
  *
- * This function interprets the bytes at the given memory address as a
- * little-endian 64-bit integer, regardless of the host system's endianness.
- * It is marked as always inline for performance critical paths.
+ * Asks one question per sampled position: is there a 4-byte repeat inside the
+ * distance the floor would forbid? Blocks that answer yes often -- periodic
+ * runs, JSON keys, XML tags -- lose size and decode time under it.
  *
- * @param[in] p Pointer to the memory location to read from.
- * @return The 64-bit unsigned integer value read from memory.
+ * @param[in] blk  Block payload, past any dictionary prefix.
+ * @param[in] size Payload size in bytes.
+ * @return 1 when the block must keep its short distances, 0 when the floor is safe.
+ */
+static ZXC_ALWAYS_INLINE int zxc_block_is_short_dist_bound(const uint8_t* const blk,
+                                                           const size_t size) {
+    const size_t d_max = ZXC_LZ_MINDIST;
+    // Too small to sample, and too small to gain: keep every distance.
+    if (size < d_max + sizeof(uint32_t)) return 1;
+
+    size_t want = size / ZXC_LZ_MINDIST_PROBE_PER_KB;
+    if (want < ZXC_LZ_MINDIST_PROBE_MIN) want = ZXC_LZ_MINDIST_PROBE_MIN;
+    if (want > ZXC_LZ_MINDIST_PROBE_MAX) want = ZXC_LZ_MINDIST_PROBE_MAX;
+    size_t stride = size / want;
+    if (stride < d_max) stride = d_max;
+
+    const size_t planned = (size - sizeof(uint32_t) - d_max) / stride + 1;
+    const size_t bar = (size_t)ZXC_LZ_MINDIST_MAX_SHORT_PCT * planned;
+
+    size_t samples = 0;
+    size_t hits = 0;
+    for (size_t i = d_max; i + sizeof(uint32_t) <= size; i += stride) {
+        const uint32_t cur = zxc_le32(blk + i);
+        samples++;
+        for (size_t d = 1; d < d_max; d++) {
+            if (zxc_le32(blk + i - d) == cur) {
+                hits++;
+                break;
+            }
+        }
+        if (hits * 100U > bar) return 1;                           // can only rise
+        if ((hits + (planned - samples)) * 100U <= bar) return 0;  // out of reach
+    }
+    return hits * 100U > bar;
+}
+
+/**
+ * @brief Reads a little-endian 64-bit value from a possibly unaligned address.
+ *
+ * The memcpy is what makes the unaligned read defined; compilers fold it into
+ * a single load. Byte-swapped on big-endian hosts, so the wire stays LE.
+ *
+ * @param[in] p Address to read from.
+ * @return The value, in host order.
  */
 static ZXC_ALWAYS_INLINE uint64_t zxc_le64(const void* p) {
     uint64_t v;
@@ -1122,19 +1217,13 @@ static ZXC_ALWAYS_INLINE uint64_t zxc_le64(const void* p) {
 }
 
 /**
- * @brief Stores a 16-bit integer in memory using little-endian byte order.
+ * @brief Writes a 16-bit value little-endian to a possibly unaligned address.
  *
- * This function copies the value of a 16-bit unsigned integer to the specified
- * memory location. It uses memcpy to avoid strict aliasing violations and
- * potential unaligned access issues.
+ * Mirror of zxc_le16(): the memcpy makes the unaligned store defined, and the
+ * value is byte-swapped on big-endian hosts so the wire stays LE.
  *
- * @note This function assumes the system is little-endian or that the compiler
- * optimizes the memcpy to a store instruction that handles endianness if necessary
- * (though the implementation shown is a direct copy).
- *
- * @param[out] p Pointer to the destination memory where the value will be stored.
- *          Must point to a valid memory region of at least 2 bytes.
- * @param[in] v The 16-bit unsigned integer value to store.
+ * @param[out] p Address to write to, at least 2 bytes.
+ * @param[in]  v Value, in host order.
  */
 static ZXC_ALWAYS_INLINE void zxc_store_le16(void* p, const uint16_t v) {
 #ifdef ZXC_BIG_ENDIAN
@@ -1146,16 +1235,13 @@ static ZXC_ALWAYS_INLINE void zxc_store_le16(void* p, const uint16_t v) {
 }
 
 /**
- * @brief Stores a 32-bit unsigned integer in little-endian format at the specified memory location.
+ * @brief Writes a 32-bit value little-endian to a possibly unaligned address.
  *
- * This function writes the 32-bit value `v` to the memory pointed to by `p`.
- * It uses `ZXC_MEMCPY` to ensure safe memory access, avoiding potential alignment issues
- * that could occur with direct pointer casting on some architectures.
+ * Mirror of zxc_le32(); see zxc_store_le16() for the memcpy and endianness
+ * rationale.
  *
- * @note This function is marked as `ZXC_ALWAYS_INLINE` to minimize function call overhead.
- *
- * @param[out] p Pointer to the destination memory where the value will be stored.
- * @param[in] v The 32-bit unsigned integer value to store.
+ * @param[out] p Address to write to, at least 4 bytes.
+ * @param[in]  v Value, in host order.
  */
 static ZXC_ALWAYS_INLINE void zxc_store_le32(void* p, const uint32_t v) {
 #ifdef ZXC_BIG_ENDIAN
@@ -1167,18 +1253,13 @@ static ZXC_ALWAYS_INLINE void zxc_store_le32(void* p, const uint32_t v) {
 }
 
 /**
- * @brief Stores a 64-bit unsigned integer in little-endian format at the specified memory location.
+ * @brief Writes a 64-bit value little-endian to a possibly unaligned address.
  *
- * This function copies the 64-bit value `v` to the memory pointed to by `p`.
- * It uses `ZXC_MEMCPY` to ensure safe memory access, avoiding potential alignment issues
- * that might occur with direct pointer dereferencing on some architectures.
+ * Mirror of zxc_le64(); see zxc_store_le16() for the memcpy and endianness
+ * rationale.
  *
- * @note This function assumes the system is little-endian or that the compiler optimizes
- * the memcpy to a store instruction that handles endianness correctly if `ZXC_MEMCPY`
- * is defined appropriately.
- *
- * @param[out] p Pointer to the destination memory where the value will be stored.
- * @param[in] v The 64-bit unsigned integer value to store.
+ * @param[out] p Address to write to, at least 8 bytes.
+ * @param[in]  v Value, in host order.
  */
 static ZXC_ALWAYS_INLINE void zxc_store_le64(void* p, const uint64_t v) {
 #ifdef ZXC_BIG_ENDIAN
@@ -1194,8 +1275,8 @@ static ZXC_ALWAYS_INLINE void zxc_store_le64(void* p, const uint64_t v) {
  *
  * Implementation based on Marsaglia's Xorshift (PRNG) principles.
  *
- * @param[in] p Pointer to the input data to be hashed (8 bytes)
- * @return uint8_t The computed hash value.
+ * @param[in] p The 8 header bytes to hash.
+ * @return The checksum byte.
  */
 static ZXC_ALWAYS_INLINE uint8_t zxc_hash8(const uint8_t* p) {
     const uint64_t v = zxc_le64(p);
@@ -1209,12 +1290,10 @@ static ZXC_ALWAYS_INLINE uint8_t zxc_hash8(const uint8_t* p) {
 /**
  * @brief Computes the 2-byte checksum for file headers.
  *
- * This function generates a hash value by reading data from the given pointer.
- * The result is a 16-bit hash.
  * Implementation based on Marsaglia's Xorshift (PRNG) principles.
  *
- * @param[in] p Pointer to the input data to be hashed (16 bytes)
- * @return uint16_t The computed hash value.
+ * @param[in] p The 16 header bytes to hash.
+ * @return The checksum halfword.
  */
 static ZXC_ALWAYS_INLINE uint16_t zxc_hash16(const uint8_t* p) {
     const uint64_t v1 = zxc_le64(p);
@@ -1228,10 +1307,10 @@ static ZXC_ALWAYS_INLINE uint16_t zxc_hash16(const uint8_t* p) {
 }
 
 /**
- * @brief Copies 16 bytes from the source memory location to the destination memory location.
+ * @brief Copies exactly 16 bytes as one vector move where the ISA has one.
  *
- * This function is forced to be inlined and uses SIMD intrinsics when available.
- * SSE2 on x86/x64, NEON on ARM, or memcpy as fallback.
+ * SSE2 on x86, NEON on ARM, memcpy elsewhere. Fixed width: the caller must
+ * have 16 readable and 16 writable bytes.
  *
  * @param[out] dst Pointer to the destination memory block.
  * @param[in] src Pointer to the source memory block.
@@ -1274,17 +1353,13 @@ static ZXC_ALWAYS_INLINE void zxc_copy32(void* dst, const void* src) {
 }
 
 /**
- * @brief Counts trailing zeros in a 32-bit unsigned integer.
+ * @brief Counts trailing zeros, returning 32 for a zero input.
  *
- * This function returns the number of contiguous zero bits starting from the
- * least significant bit (LSB). If the input is 0, it returns 32.
+ * The zero case is the reason for the guard: both `__builtin_ctz` and
+ * `_BitScanForward` leave the result undefined there.
  *
- * It utilizes compiler-specific built-ins for GCC/Clang (`__builtin_ctz`) and
- * MSVC (`_BitScanForward`) for optimal performance. If no supported compiler
- * is detected, it falls back to a portable De Bruijn sequence implementation.
- *
- * @param[in] x The 32-bit unsigned integer to scan.
- * @return The number of trailing zeros (0-32).
+ * @param[in] x Value to scan.
+ * @return Trailing zero count, in [0, 32].
  */
 static ZXC_ALWAYS_INLINE int zxc_ctz32(const uint32_t x) {
     if (x == 0) return 32;
@@ -1304,17 +1379,13 @@ static ZXC_ALWAYS_INLINE int zxc_ctz32(const uint32_t x) {
 }
 
 /**
- * @brief Counts the number of trailing zeros in a 64-bit unsigned integer.
+ * @brief Counts trailing zeros, returning 64 for a zero input.
  *
- * This function determines the number of zero bits following the least significant
- * one bit in the binary representation of `x`.
+ * The zero case is the reason for the guard: both `__builtin_ctzll` and
+ * `_BitScanForward64` leave the result undefined there.
  *
- * @param[in] x The 64-bit unsigned integer to scan.
- * @return The number of trailing zeros. Returns 64 if `x` is 0.
- *
- * @note This implementation uses compiler built-ins for GCC/Clang (`__builtin_ctzll`)
- *       and MSVC (`_BitScanForward64`) when available for optimal performance.
- *       It falls back to a De Bruijn sequence multiplication method for other compilers.
+ * @param[in] x Value to scan.
+ * @return Trailing zero count, in [0, 64].
  */
 static ZXC_ALWAYS_INLINE int zxc_ctz64(const uint64_t x) {
     if (x == 0) return 64;
@@ -1342,42 +1413,28 @@ static ZXC_ALWAYS_INLINE int zxc_ctz64(const uint64_t x) {
 }
 
 /**
- * @brief Allocates aligned memory in a cross-platform manner.
+ * @brief Allocates aligned memory (`_aligned_malloc` on Windows, else `posix_memalign`).
  *
- * This function provides a unified interface for allocating memory with a specific
- * alignment requirement. It wraps `_aligned_malloc` for Windows
- * environments and `posix_memalign` for POSIX-compliant systems.
- *
- * @param[in] size The size of the memory block to allocate, in bytes.
- * @param[in] alignment The alignment value, which must be a power of two and a multiple
- *                  of `sizeof(void *)`.
- * @return A pointer to the allocated memory block, or NULL if the allocation fails.
- *         The returned pointer must be freed using the corresponding aligned free function.
+ * @param[in] size      Bytes to allocate.
+ * @param[in] alignment Power of two, and a multiple of `sizeof(void*)`.
+ * @return The block, or NULL on failure. Free it with zxc_aligned_free(), not
+ *         `free()`: the Windows allocator is a separate one.
  */
 void* zxc_aligned_malloc(const size_t size, const size_t alignment);
 
 /**
- * @brief Frees memory previously allocated with an aligned allocation function.
+ * @brief Frees a zxc_aligned_malloc() block (`_aligned_free` on Windows, else `free`).
  *
- * This function provides a cross-platform wrapper for freeing aligned memory.
- * On Windows, it calls `_aligned_free`.
- * On other platforms, it falls back to the standard `free` function.
- *
- * @param[in] ptr A pointer to the memory block to be freed. If ptr is NULL, no operation is
- * performed.
+ * @param[in] ptr Block to free; NULL is a no-op.
  */
 void zxc_aligned_free(void* ptr);
 
-/*
- * ============================================================================
- * COMPRESSION CONTEXT & STRUCTS
- * ============================================================================
- */
+// ============================================================================
+// COMPRESSION CONTEXT & STRUCTS
+// ============================================================================
 
-/*
- * INTERNAL API
- * ------------
- */
+// INTERNAL API
+// ------------
 
 /**
  * @brief Calculates a 32-bit hash for a given input buffer.
@@ -1414,13 +1471,10 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_checksum_seed(const void* RESTRICT input, 
 }
 
 /**
- * @brief Combines a running hash with a new block hash using rotate-left and XOR.
+ * @brief Folds a block hash into the running global checksum.
  *
- * This function updates a global checksum by rotating the current hash left by 1 bit
- * (with wraparound) and XORing with the new block hash. This provides a simple but
- * effective rolling hash that depends on the order of blocks.
- *
- * Formula: result = ((hash << 1) | (hash >> 31)) ^ block_hash
+ * `result = rotl32(hash, 1) ^ block_hash`. The rotate is what makes the result
+ * depend on block order, so a reordered archive fails the global check.
  *
  * @param[in] hash The current running hash value.
  * @param[in] block_hash The hash of the new block to combine.
@@ -1432,79 +1486,69 @@ static ZXC_ALWAYS_INLINE uint32_t zxc_hash_combine_rotate(const uint32_t hash,
 }
 
 /**
- * @brief Writes a generic header and section descriptors to a destination
- * buffer.
+ * @brief Writes a GLO sub-header followed by its section descriptors.
  *
- * Serializes the `zxc_gnr_header_t` and an array of 4 section descriptors.
+ * They hold only the two sizes the header cannot imply, and are 0, 4 or 8 bytes
+ * wide accordingly.
  *
- * @param[out] dst Pointer to the destination buffer.
- * @param[in] rem The remaining space in the destination buffer.
- * @param[in] gh Pointer to the generic header structure to write.
- * @param[in] desc Array of 4 section descriptors to write.
- * @return int The number of bytes written, or a negative error code if the buffer
- * is too small.
+ * @param[out] dst      Pointer to the destination buffer.
+ * @param[in]  rem      The remaining space in the destination buffer.
+ * @param[in]  gh       Pointer to the generic header structure to write.
+ * @param[in]  lit_comp Compressed size of the literal section.
+ * @param[in]  tok_comp Compressed size of the token section.
+ * @return The number of bytes written, or a negative error code if the buffer
+ *         is too small.
  */
 int zxc_write_glo_header_and_desc(uint8_t* RESTRICT dst, const size_t rem,
-                                  const zxc_gnr_header_t* RESTRICT gh,
-                                  const zxc_section_desc_t desc[ZXC_GLO_SECTIONS]);
+                                  const zxc_gnr_header_t* RESTRICT gh, const uint32_t lit_comp,
+                                  const uint32_t tok_comp);
 
 /**
- * @brief Reads a generic header and section descriptors from a source buffer.
+ * @brief Reads a GLO sub-header and its section descriptors from a source buffer.
  *
- * Deserializes data into a `zxc_gnr_header_t` and an array of 4 section
- * descriptors.
+ * Sizes absent from the descriptors are reconstructed from the header, so both
+ * outputs are always populated.
  *
- * @param[in] src Pointer to the source buffer.
- * @param[in] len The length of the source buffer available for reading.
- * @param[out] gh Pointer to the generic header structure to populate.
- * @param[out] desc Array of 4 section descriptors to populate.
- *
- * @return int Returns ZXC_OK on success, or a negative zxc_error_t code on failure.
+ * @param[in]  src      Pointer to the source buffer.
+ * @param[in]  len      The length of the source buffer available for reading.
+ * @param[out] gh       Pointer to the generic header structure to populate.
+ * @param[out] lit_comp Receives the literal section's compressed size.
+ * @param[out] tok_comp Receives the token section's compressed size.
+ * @return Bytes consumed (header + table), or a negative zxc_error_t code.
  */
 int zxc_read_glo_header_and_desc(const uint8_t* RESTRICT src, const size_t len,
-                                 zxc_gnr_header_t* RESTRICT gh,
-                                 zxc_section_desc_t desc[ZXC_GLO_SECTIONS]);
+                                 zxc_gnr_header_t* RESTRICT gh, uint32_t* RESTRICT lit_comp,
+                                 uint32_t* RESTRICT tok_comp);
 
 /**
- * @brief Writes a record header and description to the destination buffer.
+ * @brief Writes a GHI sub-header. GHI carries no section descriptors.
  *
- * @param dst Pointer to the destination buffer where the header and description will be written.
- * @param rem Remaining size available in the destination buffer.
- * @param gh Pointer to the GNR header structure containing header information.
- * @param desc Array of 3 section descriptors to be written along with the header.
- *
- * @return int Returns the number of bytes written on success, or a negative error code on failure.
+ * @param[out] dst Pointer to the destination buffer.
+ * @param[in]  rem Remaining size available in the destination buffer.
+ * @param[in]  gh  Pointer to the GNR header structure containing header information.
+ * @return The number of bytes written, or a negative error code on failure.
  */
-int zxc_write_ghi_header_and_desc(uint8_t* RESTRICT dst, const size_t rem,
-                                  const zxc_gnr_header_t* RESTRICT gh,
-                                  const zxc_section_desc_t desc[ZXC_GHI_SECTIONS]);
+int zxc_write_ghi_header(uint8_t* RESTRICT dst, const size_t rem,
+                         const zxc_gnr_header_t* RESTRICT gh);
 
 /**
- * @brief Reads a record header and section descriptors from a buffer.
+ * @brief Reads a GHI sub-header from a buffer.
  *
- * This function parses the source buffer to extract a general header and
- * up to three section descriptors from a ZXC record.
- *
- * @param[in] src Pointer to the source buffer containing the record data.
- * @param[in] len Length of the source buffer in bytes.
- * @param[out] gh Pointer to a zxc_gnr_header_t structure to store the parsed header.
- * @param[out] desc Array of 3 zxc_section_desc_t structures to store the parsed section
- * descriptors.
- *
- * @return int Returns ZXC_OK on success, or a negative zxc_error_t code on failure.
+ * @param[in]  src Pointer to the source buffer containing the record data.
+ * @param[in]  len Length of the source buffer in bytes.
+ * @param[out] gh  Pointer to a zxc_gnr_header_t structure to store the parsed header.
+ * @return ZXC_OK on success, or a negative zxc_error_t code on failure.
  */
-int zxc_read_ghi_header_and_desc(const uint8_t* RESTRICT src, const size_t len,
-                                 zxc_gnr_header_t* RESTRICT gh,
-                                 zxc_section_desc_t desc[ZXC_GHI_SECTIONS]);
+int zxc_read_ghi_header(const uint8_t* RESTRICT src, const size_t len,
+                        zxc_gnr_header_t* RESTRICT gh);
 
-/* ============================================================================
- * Huffman codec for the GLO literal stream (level >= 6).
- *
- * On-disk layout, decoder geometry and tunables: see
- * @ref ZXC_HUF_MAX_CODE_LEN_ULTRA and the surrounding "Huffman Codec Constants"
- * group above.
- * ============================================================================
- */
+// ============================================================================
+// Huffman codec for the GLO literal stream (level >= 6).
+//
+// On-disk layout, decoder geometry and tunables: see
+// @ref ZXC_HUF_MAX_CODE_LEN_ULTRA and the surrounding "Huffman Codec Constants"
+// group above.
+// ============================================================================
 
 /**
  * @brief Build length-limited canonical Huffman code lengths from a frequency table.
@@ -1571,28 +1615,43 @@ void zxc_huf_nudge_cost(const uint8_t* RESTRICT code_len, const uint32_t* RESTRI
 
 /**
  * @brief Pack per-symbol code lengths into the 128-byte (4-bit nibble) header.
+ *
+ * Nibble order follows the byte: `code_len[2*i]` low, `code_len[2*i + 1]` high.
+ * Lengths above 15 are silently truncated, so the caller must have capped at
+ * `ZXC_HUF_MAX_CODE_LEN_ULTRA` (<= 15) first.
+ *
+ * @param[in]  code_len Per-symbol lengths, `ZXC_HUF_NUM_SYMBOLS` entries.
+ * @param[out] out      `ZXC_HUF_TABLE_SIZE` bytes of packed header.
  */
 void zxc_huf_pack_lengths(const uint8_t* RESTRICT code_len, uint8_t* RESTRICT out);
 
 /**
  * @brief Unpack and structurally validate a 128-byte packed lengths header.
- * @return `ZXC_OK` on success, `ZXC_ERROR_CORRUPT_DATA` on invalid lengths.
+ *
+ * Inverts ::zxc_huf_pack_lengths and checks the two structural invariants: no
+ * length above `ZXC_HUF_MAX_CODE_LEN_ULTRA`, and at least one symbol present.
+ * Kraft consistency is not checked here; the tree build does that later.
+ *
+ * @param[in]  in       128-byte packed header.
+ * @param[out] code_len Per-symbol lengths, `ZXC_HUF_NUM_SYMBOLS` entries.
+ * @return `ZXC_OK`, or `ZXC_ERROR_CORRUPT_DATA` if a length is too large or the
+ *         table is empty.
  */
 int zxc_huf_unpack_lengths(const uint8_t* RESTRICT in, uint8_t* RESTRICT code_len);
 
-/* --------------------------------------------------------------------------
- * PivCo-Huffman section codec (enc 2/3)
- *
- * Layout from PivCo-Huffman by Marcin Zukowski
- * (https://github.com/MarcinZukowski/pivco-huffman); implemented
- * independently here. See zxc_huffman.c for the codec.
- *
- * Same code bits as canonical Huffman, reordered by tree LEVEL: for each
- * internal node in BFS order, its branch bits (one per symbol routed through
- * it, LSB-first, byte-aligned). No size fields - the decoder derives every run
- * length from the root count and popcounts. Decoding is bottom-up level merges,
- * shuffle-parallel and gather-free.
- * -------------------------------------------------------------------------- */
+// --------------------------------------------------------------------------
+// PivCo-Huffman section codec (enc 2/3)
+//
+// Layout from PivCo-Huffman by Marcin Zukowski
+// (https://github.com/MarcinZukowski/pivco-huffman); implemented
+// independently here. See zxc_huffman.c for the codec.
+//
+// Same code bits as canonical Huffman, reordered by tree LEVEL: for each
+// internal node in BFS order, its branch bits (one per symbol routed through
+// it, LSB-first, byte-aligned). No size fields - the decoder derives every run
+// length from the root count and popcounts. Decoding is bottom-up level merges,
+// shuffle-parallel and gather-free.
+// --------------------------------------------------------------------------
 
 /** @brief Extra scratch slack required past `n` by the PivCo decoder. */
 #define ZXC_PIVCO_SCRATCH_PAD 32
@@ -1639,14 +1698,14 @@ int zxc_huf_decode_section_dict(const uint8_t* RESTRICT payload, size_t payload_
                                 const zxc_pivco_decode_aux_t* RESTRICT aux,
                                 uint8_t* RESTRICT scratch);
 
-/* ---------------------------------------------------------------------------
- * Compression / decompression context.
- *
- * The context owns the working buffers (hash table, sequence buffers, scratch)
- * that encoder and decoder reuse across blocks. It stays private - the public
- * APIs already wrap it opaquely - so the layout can evolve (cache-line
- * placement, extra scratch arenas) without breaking the ABI.
- * --------------------------------------------------------------------------- */
+// ---------------------------------------------------------------------------
+// Compression / decompression context.
+//
+// The context owns the working buffers (hash table, sequence buffers, scratch)
+// that encoder and decoder reuse across blocks. It stays private - the public
+// APIs already wrap it opaquely - so the layout can evolve (cache-line
+// placement, extra scratch arenas) without breaking the ABI.
+// ---------------------------------------------------------------------------
 
 /**
  * @struct zxc_cctx_t
@@ -1665,28 +1724,28 @@ int zxc_huf_decode_section_dict(const uint8_t* RESTRICT payload, size_t payload_
  *   entry whose stored epoch differs from `ctx->epoch` is treated as empty.
  */
 typedef struct {
-    /* Hot zone: random access / high frequency.
-     * Kept at the start to ensure they reside in the first cache line (64 bytes). */
+    // Hot zone: random access / high frequency.
+    // Kept at the start to ensure they reside in the first cache line (64 bytes).
     uint32_t* hash_table;  /**< Hash table for LZ77 match positions (epoch|pos). */
     uint8_t* hash_tags;    /**< Split tag table for fast match rejection (8-bit tags). */
     uint16_t* chain_table; /**< Chain table for collision resolution. */
     void* memory_block;    /**< Single allocation block owner. */
     uint32_t epoch;        /**< Current epoch for lazy hash table invalidation. */
 
-    /* Warm zone: sequential access per sequence. */
+    // Warm zone: sequential access per sequence.
     uint32_t* buf_sequences; /**< Buffer for sequence records (packed: LL(8)|ML(8)|Offset(16)). */
     uint8_t* buf_tokens;     /**< Buffer for token sequences. */
     uint16_t* buf_offsets;   /**< Buffer for offsets. */
     uint8_t* buf_extras;     /**< Buffer for extra lengths (vbytes for LL/ML). */
     uint8_t* literals;       /**< Buffer for literal bytes. */
 
-    /* Cold zone: configuration / scratch / resizeable. */
+    // Cold zone: configuration / scratch / resizeable.
     uint8_t* lit_buffer;            /**< Scratch buffer for literals (RLE / Huffman). */
     size_t lit_buffer_cap;          /**< Current capacity of the scratch buffer. */
     uint8_t* work_buf;              /**< Padded scratch buffer for buffer-API decompression. */
     size_t work_buf_cap;            /**< Capacity of the work buffer. */
     uint8_t* tok_buffer;            /**< Decode scratch for a Huffman-coded GLO token
-                                         section (enc_litlen == HUFFMAN); NULL on compress.
+                                         section (enc_tok == HUFFMAN); NULL on compress.
                                          Heap decode contexts defer it (with pivco_scratch)
                                          to the first entropy section, see entropy_block. */
     size_t tok_buffer_cap;          /**< Capacity of tok_buffer in bytes. */
@@ -1716,7 +1775,7 @@ typedef struct {
                                          accumulates post-LZ literal byte frequencies here
                                          (256 entries). NULL outside dictionary training. */
 
-    /* Block-size derived parameters (computed once at init). */
+    // Block-size derived parameters (computed once at init).
     size_t chunk_size;    /**< Effective block size in bytes. */
     uint32_t offset_bits; /**< log2(chunk_size) - governs epoch_mark shift. */
     uint32_t offset_mask; /**< (1U << offset_bits) - 1 */
@@ -1836,24 +1895,18 @@ int zxc_cctx_alloc_entropy_scratch(zxc_cctx_t* ctx);
 void zxc_cctx_free(zxc_cctx_t* ctx);
 
 /**
- * @brief Internal wrapper function to decompress a single chunk of data.
+ * @brief Decompresses one chunk through the runtime ISA dispatch.
  *
- * This function handles the decompression of a specific chunk from the source
- * buffer into the destination buffer using the provided compression context. It
- * serves as an abstraction layer over the core decompression logic.
+ * Un-suffixed entry point: it loads the resolved variant pointer (`_default`,
+ * `_avx2`, `_avx512`, ...), running the one-time CPU detection on the first
+ * call, and routes to the dict variant when the context carries a dictionary.
  *
- * @param[in,out] ctx     Pointer to the ZXC compression context structure containing
- *                internal state and configuration.
- * @param[in] src     Pointer to the source buffer containing compressed data.
- * @param[in] src_sz  Size of the compressed data in the source buffer (in bytes).
- * @param[out] dst     Pointer to the destination buffer where decompressed data will
- * be written.
- * @param[in] dst_cap Capacity of the destination buffer (maximum bytes that can be
- * written).
- *
- * @return int    Returns ZXC_OK on success, or a negative zxc_error_t code on failure.
- *                Specific error codes depend on the underlying ZXC
- * implementation.
+ * @param[in]  ctx     Context holding the decode state and dictionary, if any.
+ * @param[in]  src     Compressed chunk.
+ * @param[in]  src_sz  Size of @p src in bytes.
+ * @param[out] dst     Destination buffer.
+ * @param[in]  dst_cap Capacity of @p dst.
+ * @return Bytes decoded (> 0), or a negative @ref zxc_error_t.
  */
 int zxc_decompress_chunk_wrapper(const zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                  const size_t src_sz, uint8_t* RESTRICT dst, const size_t dst_cap);
@@ -1862,34 +1915,28 @@ int zxc_decompress_chunk_wrapper_dict(const zxc_cctx_t* RESTRICT ctx, const uint
                                       const size_t dst_cap);
 
 /**
- * @brief Wraps the internal chunk compression logic.
+ * @brief Compresses one chunk through the runtime ISA dispatch.
  *
- * This function acts as a wrapper to compress a single chunk of data using the
- * provided compression context. It handles the interaction with the underlying
- * compression algorithm for a specific block of memory.
+ * Counterpart of zxc_decompress_chunk_wrapper(): same lazily-resolved variant
+ * pointer, same one-time CPU detection on the first call.
  *
- * @param[in,out] ctx   Pointer to the ZXC compression context containing configuration
- *              and state.
- * @param[in] chunk Pointer to the source buffer containing the raw data to
- * compress.
- * @param[in] src_sz    The size of the source chunk in bytes.
- * @param[out] dst   Pointer to the destination buffer where compressed data will be
- * written.
- * @param[in] dst_cap   The capacity of the destination buffer (maximum bytes to write).
- *
- * @return int      The number of bytes written to the destination buffer on success,
- *                  or a negative error code on failure.
+ * @param[in,out] ctx     Compression context: configuration and working buffers.
+ * @param[in]     src     Raw data to compress.
+ * @param[in]     src_sz  Size of @p src in bytes.
+ * @param[out]    dst     Destination buffer.
+ * @param[in]     dst_cap Capacity of @p dst.
+ * @return Bytes written (> 0), or a negative @ref zxc_error_t.
  */
-int zxc_compress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT chunk,
+int zxc_compress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT src,
                                const size_t src_sz, uint8_t* RESTRICT dst, const size_t dst_cap);
 
-/* ---------------------------------------------------------------------------
- * Internal frame primitives.
- *
- * Read/write the ZXC file header, block header and footer. Kept internal:
- * exposing them would freeze on-disk details (block_flags layout, footer
- * composition) that stay free to evolve until the format is declared stable.
- * --------------------------------------------------------------------------- */
+// ---------------------------------------------------------------------------
+// Internal frame primitives.
+//
+// Read/write the ZXC file header, block header and footer. Kept internal:
+// exposing them would freeze on-disk details (block_flags layout, footer
+// composition) that stay free to evolve until the format is declared stable.
+// ---------------------------------------------------------------------------
 
 /**
  * @brief On-disk header structure for a ZXC block (8 bytes, little-endian).
@@ -1898,11 +1945,11 @@ int zxc_compress_chunk_wrapper(zxc_cctx_t* RESTRICT ctx, const uint8_t* RESTRICT
  * Descriptors within the compressed payload.
  */
 typedef struct {
-    uint8_t block_type;  /**< Block type (see @ref zxc_block_type_t). */
-    uint8_t block_flags; /**< Flags (e.g., checksum presence). */
-    uint8_t reserved;    /**< Reserved for future protocol extensions. */
-    uint8_t header_crc;  /**< Header integrity checksum (1 byte). */
-    uint32_t comp_size;  /**< Compressed size excluding this header. */
+    uint8_t block_type;      /**< Block type (see @ref zxc_block_type_t). */
+    uint8_t block_flags;     /**< Flags (e.g., checksum presence). */
+    uint8_t reserved;        /**< Reserved for future protocol extensions. */
+    uint8_t header_checksum; /**< Header integrity checksum (1 byte). */
+    uint32_t comp_size;      /**< Compressed size excluding this header. */
 } zxc_block_header_t;
 
 /**
@@ -1998,10 +2045,10 @@ int zxc_read_block_header(const uint8_t* RESTRICT src, const size_t src_size,
 int zxc_write_file_footer(uint8_t* RESTRICT dst, const size_t dst_capacity, const uint64_t src_size,
                           const uint32_t global_hash, const int checksum_enabled);
 
-/* ---------------------------------------------------------------------------
- * Seekable cross-TU hooks (defined in zxc_seekable.c, consumed by the
- * FILE*-flavored open helper in zxc_driver.c).
- * ------------------------------------------------------------------------- */
+// ---------------------------------------------------------------------------
+// Seekable cross-TU hooks (defined in zxc_seekable.c, consumed by the
+// FILE*-flavored open helper in zxc_driver.c).
+// -------------------------------------------------------------------------
 
 /**
  * @brief Hands ownership of a heap-allocated reader context to a seekable

--- a/lz/zxc/src/lib/zxc_pivco_tables.h
+++ b/lz/zxc/src/lib/zxc_pivco_tables.h
@@ -34,9 +34,9 @@
 
 #include <stdint.h>
 
-/* ELF/Mach-O visibility only: Windows PE/COFF targets (MinGW/MSYS2 GCC,
- * clang-on-Windows) do not support it and warn -Wattributes, so gate on
- * !_WIN32 exactly like ZXC_NO_EXPORT in zxc_export.h. */
+// ELF/Mach-O visibility only: Windows PE/COFF targets (MinGW/MSYS2 GCC,
+// clang-on-Windows) do not support it and warn -Wattributes, so gate on
+// !_WIN32 exactly like ZXC_NO_EXPORT in zxc_export.h.
 #if (defined(__GNUC__) || defined(__clang__)) && !defined(_WIN32)
 #define ZXC_HIDDEN __attribute__((visibility("hidden")))
 #else

--- a/lz/zxc/src/lib/zxc_pstream.c
+++ b/lz/zxc/src/lib/zxc_pstream.c
@@ -29,9 +29,9 @@
 #include "../../include/zxc_error.h"
 #include "zxc_internal.h"
 
-/* ===================================================================== */
-/*  Compression                                                          */
-/* ===================================================================== */
+// =====================================================================
+// Compression
+// =====================================================================
 
 /**
  * @enum cstream_state_t
@@ -195,8 +195,8 @@ static int cs_compress_block_from(zxc_cstream* cs, const uint8_t* RESTRICT src, 
     cs->pending_pos = 0;
     cs->total_in += len;
 
-    /* If checksums are on, the block trailer is the last ZXC_BLOCK_CHECKSUM_SIZE
-     * bytes of pending; fold it into the rolling global hash. */
+    // If checksums are on, the block trailer is the last ZXC_BLOCK_CHECKSUM_SIZE
+    // bytes of pending; fold it into the rolling global hash.
     if (cs->opts.checksum_enabled && cs->pending_len >= ZXC_BLOCK_CHECKSUM_SIZE) {
         const uint32_t bh = zxc_le32(cs->pending + cs->pending_len - ZXC_BLOCK_CHECKSUM_SIZE);
         cs->global_hash = zxc_hash_combine_rotate(cs->global_hash, bh);
@@ -224,26 +224,27 @@ static int cs_compress_one_block(zxc_cstream* cs) {
 }
 
 /**
- * @brief Drains staged output bytes into the caller's output buffer.
+ * @brief Copies what fits of a staged buffer into the caller's output.
  *
- * Copies as many bytes as possible from
- * @c cs->pending[pending_pos..pending_len) into
- * @c out->dst[pos..size), advancing both cursors.
- *
- * @param[in,out] cs  Compression stream.
- * @param[in,out] out Caller output buffer.
- * @return Non-zero once the @c pending buffer has been fully drained
- *         (@c pending_pos == @c pending_len), zero otherwise.
+ * The single output pump: the compressor's pending buffer and the
+ * decompressor's decoded block both drain through it. Returns the byte count.
  */
-static int cs_drain_pending(zxc_cstream* cs, zxc_outbuf_t* out) {
+static size_t zxc_outbuf_push(zxc_outbuf_t* out, const uint8_t* RESTRICT src, size_t* RESTRICT pos,
+                              const size_t len) {
     const size_t avail_out = out->size - out->pos;
-    const size_t avail_pen = cs->pending_len - cs->pending_pos;
-    const size_t n = avail_out < avail_pen ? avail_out : avail_pen;
+    const size_t avail_src = len - *pos;
+    const size_t n = avail_out < avail_src ? avail_out : avail_src;
     if (n) {
-        ZXC_MEMCPY((uint8_t*)out->dst + out->pos, cs->pending + cs->pending_pos, n);
+        ZXC_MEMCPY((uint8_t*)out->dst + out->pos, src + *pos, n);
         out->pos += n;
-        cs->pending_pos += n;
+        *pos += n;
     }
+    return n;
+}
+
+/** @brief Flushes the pending staging buffer; 1 once fully drained. */
+static int cs_drain_pending(zxc_cstream* cs, zxc_outbuf_t* out) {
+    zxc_outbuf_push(out, cs->pending, &cs->pending_pos, cs->pending_len);
     return cs->pending_pos == cs->pending_len;
 }
 
@@ -261,10 +262,6 @@ static int cs_drain_pending(zxc_cstream* cs, zxc_outbuf_t* out) {
  * returns @c NULL rather than silently dropping them.  Pre-sizes the
  * @c pending buffer so that the file header / footer paths never need a
  * realloc.
- *
- * @param[in] opts Compression options, or @c NULL for full defaults.
- * @return New stream owned by the caller, or @c NULL on allocation
- *         failure / invalid option values (including dictionary options).
  */
 zxc_cstream* zxc_cstream_create(const zxc_compress_opts_t* opts) {
     zxc_cstream* cs = (zxc_cstream*)ZXC_CALLOC(1, sizeof(*cs));
@@ -272,17 +269,16 @@ zxc_cstream* zxc_cstream_create(const zxc_compress_opts_t* opts) {
 
     if (opts) cs->opts = *opts;
 
-    /* The push-stream format carries no dict_id, so a dictionary here would
-     * produce archives that decode wrong (or not at all) elsewhere. */
+    // The push-stream format carries no dict_id, so a dictionary here would
+    // produce archives that decode wrong (or not at all) elsewhere.
     if (UNLIKELY(cs->opts.dict || cs->opts.dict_size || cs->opts.dict_huf)) {
         ZXC_FREE(cs);
         return NULL;
     }
 
-    if (cs->opts.level == 0) cs->opts.level = ZXC_LEVEL_DEFAULT;
-    cs->opts.level = zxc_level_clamp(cs->opts.level);
-    if (cs->opts.block_size == 0) cs->opts.block_size = ZXC_BLOCK_SIZE_DEFAULT;
-    /* n_threads is ignored on this single-threaded path. */
+    cs->opts.level = ZXC_OPTS_LEVEL(&cs->opts, ZXC_LEVEL_DEFAULT);
+    cs->opts.block_size = ZXC_OPTS_BLOCK_SIZE(&cs->opts, ZXC_BLOCK_SIZE_DEFAULT);
+    // n_threads is ignored on this single-threaded path.
     cs->opts.n_threads = 0;
     cs->opts.progress_cb = NULL;
     cs->opts.user_data = NULL;
@@ -302,7 +298,7 @@ zxc_cstream* zxc_cstream_create(const zxc_compress_opts_t* opts) {
         return NULL;
     }
     // LCOV_EXCL_STOP
-    /* Pre-size pending so the file header path never needs realloc. */
+    // Pre-size pending so the file header path never needs realloc.
     cs->pending_cap =
         ZXC_FILE_HEADER_SIZE > ZXC_FILE_FOOTER_SIZE ? ZXC_FILE_HEADER_SIZE : ZXC_FILE_FOOTER_SIZE;
     cs->pending = (uint8_t*)ZXC_MALLOC(cs->pending_cap);
@@ -337,7 +333,7 @@ static int cs_stage_file_header(zxc_cstream* cs) {
  * @brief Stages the 8-byte EOF block into the @c pending buffer.
  *
  * The EOF block is a regular block header with @c block_type set to
- * @ref ZXC_BLOCK_EOF and @c comp_size = 0; it carries no payload.
+ * `ZXC_BLOCK_EOF` and @c comp_size = 0; it carries no payload.
  *
  * @param[in,out] cs Compression stream.
  * @return @ref ZXC_OK on success, negative @ref zxc_error_t on failure.
@@ -355,7 +351,7 @@ static int cs_stage_eof(zxc_cstream* cs) {
         .block_type = (uint8_t)ZXC_BLOCK_EOF,
         .block_flags = 0,
         .reserved = 0,
-        .header_crc = 0,
+        .header_checksum = 0,
         .comp_size = 0,
     };
     const int w = zxc_write_block_header(cs->pending, cs->pending_cap, &eof);
@@ -391,13 +387,6 @@ static int cs_stage_footer(zxc_cstream* cs) {
     return ZXC_OK;
 }
 
-/**
- * @brief Releases a compression stream and all internal buffers.
- *
- * Safe to call with @c NULL.
- *
- * @param[in,out] cs Stream returned by @ref zxc_cstream_create.
- */
 void zxc_cstream_free(zxc_cstream* cs) {
     if (!cs) return;
     ZXC_FREE(cs->pending);
@@ -408,9 +397,6 @@ void zxc_cstream_free(zxc_cstream* cs) {
 
 /**
  * @brief Returns the suggested input chunk size (configured block size).
- *
- * @param[in] cs Compression stream.
- * @return Block size in bytes, or 0 if @p cs is @c NULL.
  */
 size_t zxc_cstream_in_size(const zxc_cstream* cs) { return cs ? cs->block_size : 0; }
 
@@ -420,9 +406,6 @@ size_t zxc_cstream_in_size(const zxc_cstream* cs) { return cs ? cs->block_size :
  * Sized to hold one full compressed block plus framing overhead, i.e.
  * @ref zxc_compress_block_bound applied to the configured block size.
  * Falls back to @c block_size when the bound overflows @c size_t.
- *
- * @param[in] cs Compression stream.
- * @return Suggested output buffer capacity in bytes, or 0 if @p cs is @c NULL.
  */
 size_t zxc_cstream_out_size(const zxc_cstream* cs) {
     if (UNLIKELY(!cs)) return 0;  // LCOV_EXCL_LINE
@@ -442,13 +425,6 @@ size_t zxc_cstream_out_size(const zxc_cstream* cs) {
  * The terminal states (@c CS_DRAIN_LAST, @c CS_DRAIN_EOF, @c CS_DRAIN_FOOTER,
  * @c CS_DONE, @c CS_ERRORED) are owned by @ref zxc_cstream_end; reaching
  * them here yields @ref ZXC_ERROR_NULL_INPUT.
- *
- * @param[in,out] cs  Compression stream.
- * @param[in,out] out Caller output buffer.
- * @param[in,out] in  Caller input buffer.
- * @return @c 0 if @p in fully consumed and nothing pending,
- *         @c >0 number of bytes still pending (drain @p out then call again),
- *         @c <0 a @ref zxc_error_t code.
  */
 int64_t zxc_cstream_compress(zxc_cstream* cs, zxc_outbuf_t* out, zxc_inbuf_t* in) {
     if (UNLIKELY(!cs || !out || !in || in->pos > in->size || out->pos > out->size ||
@@ -499,7 +475,7 @@ int64_t zxc_cstream_compress(zxc_cstream* cs, zxc_outbuf_t* out, zxc_inbuf_t* in
                     cs->state = CS_DRAIN_BLOCK;
                     break;
                 }
-                /* Block not yet full either in is empty or we made no progress. */
+                // Block not yet full either in is empty or we made no progress.
                 return 0;
             }
 
@@ -508,7 +484,7 @@ int64_t zxc_cstream_compress(zxc_cstream* cs, zxc_outbuf_t* out, zxc_inbuf_t* in
             case CS_DRAIN_FOOTER:
             case CS_DONE:
             case CS_ERRORED:
-                /* These states are owned by _end(). */
+                // These states are owned by _end().
                 return ZXC_ERROR_NULL_INPUT;
         }
     }
@@ -522,12 +498,6 @@ int64_t zxc_cstream_compress(zxc_cstream* cs, zxc_outbuf_t* out, zxc_inbuf_t* in
  * -> @c CS_DONE).  Reentrant: when @p out fills mid-drain, returns the
  * number of bytes still pending and resumes from where it left off on the
  * next call.  See the public contract in @ref zxc_cstream_end.
- *
- * @param[in,out] cs  Compression stream.
- * @param[in,out] out Caller output buffer.
- * @return @c 0 once finalisation is complete (stream is now in DONE state),
- *         @c >0 number of bytes still pending (drain and call again),
- *         @c <0 a @ref zxc_error_t code.
  */
 int64_t zxc_cstream_end(zxc_cstream* cs, zxc_outbuf_t* out) {
     if (UNLIKELY(!cs || !out || cs->state == CS_DONE)) return ZXC_ERROR_NULL_INPUT;
@@ -536,7 +506,7 @@ int64_t zxc_cstream_end(zxc_cstream* cs, zxc_outbuf_t* out) {
     for (;;) {
         switch (cs->state) {
             case CS_INIT: {
-                /* _end before any input, still need to emit file header. */
+                // _end before any input, still need to emit file header.
                 const int rc = cs_stage_file_header(cs);
                 if (UNLIKELY(rc < 0)) return cs_set_error(cs, rc);  // LCOV_EXCL_LINE
                 cs->state = CS_DRAIN_HEADER;
@@ -551,14 +521,14 @@ int64_t zxc_cstream_end(zxc_cstream* cs, zxc_outbuf_t* out) {
             }
 
             case CS_ACCUMULATE: {
-                /* Compress the residual partial block (if any), then EOF + footer. */
+                // Compress the residual partial block (if any), then EOF + footer.
                 if (cs->in_used > 0) {
                     const int rc = cs_compress_one_block(cs);
                     if (UNLIKELY(rc < 0)) return cs_set_error(cs, rc);  // LCOV_EXCL_LINE
                     cs->state = CS_DRAIN_LAST;
                     break;
                 }
-                /* No residual data: go straight to EOF. */
+                // No residual data: go straight to EOF.
                 {
                     const int rc = cs_stage_eof(cs);
                     if (UNLIKELY(rc < 0)) return cs_set_error(cs, rc);  // LCOV_EXCL_LINE
@@ -569,7 +539,7 @@ int64_t zxc_cstream_end(zxc_cstream* cs, zxc_outbuf_t* out) {
 
             case CS_DRAIN_LAST: {
                 if (!cs_drain_pending(cs, out)) return (int64_t)(cs->pending_len - cs->pending_pos);
-                /* After last data block -> EOF. */
+                // After last data block -> EOF.
                 const int rc = cs_stage_eof(cs);
                 if (UNLIKELY(rc < 0)) return cs_set_error(cs, rc);  // LCOV_EXCL_LINE
                 cs->state = CS_DRAIN_EOF;
@@ -597,9 +567,9 @@ int64_t zxc_cstream_end(zxc_cstream* cs, zxc_outbuf_t* out) {
     }
 }
 
-/* ===================================================================== */
-/*  Decompression                                                        */
-/* ===================================================================== */
+// =====================================================================
+// Decompression
+// =====================================================================
 
 /**
  * @enum dstream_state_t
@@ -766,49 +736,23 @@ static int ds_set_error(zxc_dstream* ds, const int code) {
 }
 
 /**
- * @brief Pulls up to @c (scratch_need - scratch_used) bytes from @p in.
+ * @brief Accumulates caller input into a buffer until it holds the wanted size.
  *
- * Used to accumulate fixed-size frames (file header, block header, footer,
- * EOF tail peek) into the inline @c scratch buffer.
- *
- * @param[in,out] ds Decompression stream.
- * @param[in,out] in Caller input buffer; @c pos is advanced.
- * @return @c 1 once @c scratch holds exactly @c scratch_need bytes,
- *         @c 0 otherwise (need more input).
+ * The single input pump: the fixed-size frame accumulator (headers, footer, EOF
+ * peek) and the variable-size block payload differ only in the buffer they
+ * fill. Returns 1 once the target size is reached, 0 if more input is needed.
  */
-static int ds_pull_scratch(zxc_dstream* ds, zxc_inbuf_t* in) {
-    const size_t want = ds->scratch_need - ds->scratch_used;
+static int ds_pull(uint8_t* RESTRICT dst, size_t* RESTRICT used, const size_t need,
+                   zxc_inbuf_t* in) {
+    const size_t want = need - *used;
     const size_t avail = in->size - in->pos;
     const size_t n = want < avail ? want : avail;
     if (n) {
-        ZXC_MEMCPY(ds->scratch + ds->scratch_used, (const uint8_t*)in->src + in->pos, n);
+        ZXC_MEMCPY(dst + *used, (const uint8_t*)in->src + in->pos, n);
         in->pos += n;
-        ds->scratch_used += n;
+        *used += n;
     }
-    return ds->scratch_used == ds->scratch_need;
-}
-
-/**
- * @brief Same as @ref ds_pull_scratch but pulls into the heap @c payload buffer.
- *
- * Used to accumulate the variable-size compressed block payload
- * (header + comp_size [+ checksum]).
- *
- * @param[in,out] ds Decompression stream.
- * @param[in,out] in Caller input buffer; @c pos is advanced.
- * @return @c 1 once @c payload holds exactly @c payload_need bytes,
- *         @c 0 otherwise (need more input).
- */
-static int ds_pull_payload(zxc_dstream* ds, zxc_inbuf_t* in) {
-    const size_t want = ds->payload_need - ds->payload_used;
-    const size_t avail = in->size - in->pos;
-    const size_t n = want < avail ? want : avail;
-    if (n) {
-        ZXC_MEMCPY(ds->payload + ds->payload_used, (const uint8_t*)in->src + in->pos, n);
-        in->pos += n;
-        ds->payload_used += n;
-    }
-    return ds->payload_used == ds->payload_need;
+    return *used == need;
 }
 
 /**
@@ -819,9 +763,6 @@ static int ds_pull_payload(zxc_dstream* ds, zxc_inbuf_t* in) {
  * to the @c FILE*-based pipeline).  @c block_size, @c file_has_checksum,
  * and the @c payload / @c decoded buffers are filled in lazily once the
  * file header is parsed.
- *
- * @param[in] opts Decompression options, or @c NULL for full defaults.
- * @return New stream owned by the caller, or @c NULL on allocation failure.
  */
 zxc_dstream* zxc_dstream_create(const zxc_decompress_opts_t* opts) {
     zxc_dstream* ds = (zxc_dstream*)ZXC_CALLOC(1, sizeof(*ds));
@@ -843,8 +784,6 @@ zxc_dstream* zxc_dstream_create(const zxc_decompress_opts_t* opts) {
  * @brief Releases a decompression stream and all internal buffers.
  *
  * Safe to call with @c NULL.
- *
- * @param[in,out] ds Stream returned by @ref zxc_dstream_create.
  */
 void zxc_dstream_free(zxc_dstream* ds) {
     if (UNLIKELY(!ds)) return;  // LCOV_EXCL_LINE
@@ -856,9 +795,6 @@ void zxc_dstream_free(zxc_dstream* ds) {
 
 /**
  * @brief Returns 1 iff the stream has reached @c DS_DONE.
- *
- * @param[in] ds Decompression stream.
- * @return @c 1 if DONE, @c 0 otherwise (including errored).
  */
 int zxc_dstream_finished(const zxc_dstream* ds) { return (ds && ds->state == DS_DONE) ? 1 : 0; }
 
@@ -868,9 +804,6 @@ int zxc_dstream_finished(const zxc_dstream* ds) { return (ds && ds->state == DS_
  * Before the file header is parsed the call returns
  * @ref ZXC_BLOCK_SIZE_DEFAULT; afterwards it returns the maximal compressed
  * block size derived from the negotiated @c block_size.
- *
- * @param[in] ds Decompression stream.
- * @return Suggested input buffer capacity in bytes, or 0 if @p ds is @c NULL.
  */
 size_t zxc_dstream_in_size(const zxc_dstream* ds) {
     if (UNLIKELY(!ds)) return 0;  // LCOV_EXCL_LINE
@@ -884,38 +817,17 @@ size_t zxc_dstream_in_size(const zxc_dstream* ds) {
  *
  * Equals the negotiated @c block_size; before the file header is parsed,
  * returns @ref ZXC_BLOCK_SIZE_DEFAULT.
- *
- * @param[in] ds Decompression stream.
- * @return Suggested output buffer capacity in bytes, or 0 if @p ds is @c NULL.
  */
 size_t zxc_dstream_out_size(const zxc_dstream* ds) {
     if (UNLIKELY(!ds)) return 0;  // LCOV_EXCL_LINE
     return ds->block_size == 0 ? ZXC_BLOCK_SIZE_DEFAULT : ds->block_size;
 }
 
-/**
- * @brief Drains @c ds->decoded[decoded_pos..decoded_size) into @p out.
- *
- * Updates @c ds->total_out by the number of bytes copied and, when
- * @p produced is non-NULL, accumulates the same count into @c *produced
- * (used by the outer state machine to compute the per-call return value).
- *
- * @param[in,out] ds       Decompression stream.
- * @param[in,out] out      Caller output buffer.
- * @param[in,out] produced Optional running count of bytes produced this call.
- * @return @c 1 once @c decoded is fully drained, @c 0 otherwise.
- */
+/** @brief Flushes the decoded block; 1 once fully drained. `produced` is optional. */
 static int ds_drain_decoded(zxc_dstream* ds, zxc_outbuf_t* out, size_t* produced) {
-    const size_t avail_out = out->size - out->pos;
-    const size_t avail_dec = ds->decoded_size - ds->decoded_pos;
-    const size_t n = avail_out < avail_dec ? avail_out : avail_dec;
-    if (n) {
-        ZXC_MEMCPY((uint8_t*)out->dst + out->pos, ds->decoded + ds->decoded_pos, n);
-        out->pos += n;
-        ds->decoded_pos += n;
-        ds->total_out += n;
-        if (produced) *produced += n;
-    }
+    const size_t n = zxc_outbuf_push(out, ds->decoded, &ds->decoded_pos, ds->decoded_size);
+    ds->total_out += n;
+    if (produced) *produced += n;
     return ds->decoded_pos == ds->decoded_size;
 }
 
@@ -936,7 +848,7 @@ static int ds_drain_decoded(zxc_dstream* ds, zxc_outbuf_t* out, size_t* produced
  *         negative @ref zxc_error_t on validation/allocation failure.
  */
 static int ds_handle_need_file_header(zxc_dstream* ds, zxc_inbuf_t* in) {
-    if (!ds_pull_scratch(ds, in)) return 1;
+    if (!ds_pull(ds->scratch, &ds->scratch_used, ds->scratch_need, in)) return 1;
 
     size_t bs = 0;
     int has_csum = 0;
@@ -945,7 +857,7 @@ static int ds_handle_need_file_header(zxc_dstream* ds, zxc_inbuf_t* in) {
     ds->block_size = bs;
     ds->file_has_checksum = has_csum;
 
-    /* Allocate payload + decoded buffers now that block_size is known. */
+    // Allocate payload + decoded buffers now that block_size is known.
     const uint64_t pb = zxc_compress_block_bound(ds->block_size);
     // LCOV_EXCL_START
     if (UNLIKELY(pb == 0 || pb > SIZE_MAX)) return ds_set_error(ds, ZXC_ERROR_OVERFLOW);
@@ -988,13 +900,13 @@ static int ds_handle_need_file_header(zxc_dstream* ds, zxc_inbuf_t* in) {
  *         negative @ref zxc_error_t on validation/allocation failure.
  */
 static int ds_handle_need_block_header(zxc_dstream* ds, zxc_inbuf_t* in) {
-    if (!ds_pull_scratch(ds, in)) return 1;
+    if (!ds_pull(ds->scratch, &ds->scratch_used, ds->scratch_need, in)) return 1;
 
     const int rc = zxc_read_block_header(ds->scratch, ds->scratch_used, &ds->cur_bh);
     if (UNLIKELY(rc != ZXC_OK)) return ds_set_error(ds, rc);  // LCOV_EXCL_LINE
 
     if (ds->cur_bh.block_type == (uint8_t)ZXC_BLOCK_EOF) {
-        /* EOF block: comp_size must be 0; no payload, no checksum. */
+        // EOF block: comp_size must be 0; no payload, no checksum.
         if (UNLIKELY(ds->cur_bh.comp_size != 0)) return ds_set_error(ds, ZXC_ERROR_BAD_BLOCK_SIZE);
         ds->state = DS_PEEK_TAIL;
         ds->scratch_used = 0;
@@ -1002,19 +914,19 @@ static int ds_handle_need_block_header(zxc_dstream* ds, zxc_inbuf_t* in) {
         return 0;
     }
 
-    /* Normal data block: read comp_size [+ ZXC_BLOCK_CHECKSUM_SIZE if file-level checksums]. */
+    // Normal data block: read comp_size [+ ZXC_BLOCK_CHECKSUM_SIZE if file-level checksums].
     const uint64_t need = (uint64_t)ds->cur_bh.comp_size +
-                          (ds->file_has_checksum ? (uint64_t)ZXC_BLOCK_CHECKSUM_SIZE : 0u);
+                          (ds->file_has_checksum ? (uint64_t)ZXC_BLOCK_CHECKSUM_SIZE : 0U);
     if (UNLIKELY(need > ds->payload_cap)) return ds_set_error(ds, ZXC_ERROR_BAD_BLOCK_SIZE);
 
-    /* Feed the full block (header + payload + opt csum) to zxc_decompress_block,
-     * so prefix with the 8-byte header we just parsed. */
+    // Feed the full block (header + payload + opt csum) to zxc_decompress_block,
+    // so prefix with the 8-byte header we just parsed.
     ZXC_MEMCPY(ds->payload, ds->scratch, ZXC_BLOCK_HEADER_SIZE);
     ds->payload_used = ZXC_BLOCK_HEADER_SIZE;
     ds->payload_need = (size_t)need + ZXC_BLOCK_HEADER_SIZE;
     // LCOV_EXCL_START
     if (UNLIKELY(ds->payload_need > ds->payload_cap)) {
-        /* grow */
+        // grow
         uint8_t* nb = (uint8_t*)ZXC_REALLOC(ds->payload, ds->payload_need);
         if (UNLIKELY(!nb)) return ds_set_error(ds, ZXC_ERROR_MEMORY);
         ds->payload = nb;
@@ -1042,13 +954,6 @@ static int ds_handle_need_block_header(zxc_dstream* ds, zxc_inbuf_t* in) {
  * @par Errors
  * On any negative return the stream becomes errored (sticky); subsequent
  * calls keep returning the same code until @ref zxc_dstream_free.
- *
- * @param[in,out] ds  Decompression stream.
- * @param[in,out] out Caller output buffer.
- * @param[in,out] in  Caller input buffer.
- * @return @c >0 number of decompressed bytes written into @p out this call,
- *         @c 0 stream complete (DONE) or no progress possible,
- *         @c <0 a @ref zxc_error_t code.
  */
 int64_t zxc_dstream_decompress(zxc_dstream* ds, zxc_outbuf_t* out, zxc_inbuf_t* in) {
     if (UNLIKELY(!ds || !out || !in || in->pos > in->size || out->pos > out->size ||
@@ -1077,7 +982,8 @@ int64_t zxc_dstream_decompress(zxc_dstream* ds, zxc_outbuf_t* out, zxc_inbuf_t* 
             }
 
             case DS_NEED_BLOCK_PAYLOAD: {
-                if (!ds_pull_payload(ds, in)) return (int64_t)produced;
+                if (!ds_pull(ds->payload, &ds->payload_used, ds->payload_need, in))
+                    return (int64_t)produced;
                 ds->state = DS_DECODE_BLOCK;
                 break;
             }
@@ -1089,9 +995,9 @@ int64_t zxc_dstream_decompress(zxc_dstream* ds, zxc_outbuf_t* out, zxc_inbuf_t* 
                     &ds->inner, ds->payload, ds->payload_used, ddst, ds->decoded_cap);
                 if (UNLIKELY(dsz < 0)) return ds_set_error(ds, dsz);
 
-                /* If file-level checksum verification is enabled, fold this
-                 * block's trailer into the rolling global hash (last
-                 * ZXC_BLOCK_CHECKSUM_SIZE bytes of the *raw* block). */
+                // If file-level checksum verification is enabled, fold this
+                // block's trailer into the rolling global hash (last
+                // ZXC_BLOCK_CHECKSUM_SIZE bytes of the *raw* block).
                 if (ds->opts.checksum_enabled && ds->file_has_checksum &&
                     ds->payload_used >= ZXC_BLOCK_CHECKSUM_SIZE) {
                     const uint32_t bh =
@@ -1127,17 +1033,18 @@ int64_t zxc_dstream_decompress(zxc_dstream* ds, zxc_outbuf_t* out, zxc_inbuf_t* 
             }
 
             case DS_PEEK_TAIL: {
-                if (!ds_pull_scratch(ds, in)) return (int64_t)produced;
-                /* Try to interpret as a block header (SEK). */
+                if (!ds_pull(ds->scratch, &ds->scratch_used, ds->scratch_need, in))
+                    return (int64_t)produced;
+                // Try to interpret as a block header (SEK).
                 zxc_block_header_t peek;
                 const int sek_rc = zxc_read_block_header(ds->scratch, ds->scratch_used, &peek);
                 if (sek_rc == ZXC_OK && peek.block_type == (uint8_t)ZXC_BLOCK_SEK) {
-                    /* SEK block: skip its payload (peek.comp_size bytes). */
+                    // SEK block: skip its payload (peek.comp_size bytes).
                     ds->sek_remaining = (size_t)peek.comp_size;
                     ds->state = DS_DRAIN_SEK_PAYLOAD;
                     break;
                 }
-                /* Not SEK -> these 8 bytes are the first 8 of the 12-byte footer. */
+                // Not SEK -> these 8 bytes are the first 8 of the 12-byte footer.
                 ds->state = DS_NEED_FOOTER_REST;
                 ds->scratch_need = ZXC_FILE_FOOTER_SIZE; /* keep first 8, want 4 more */
                 break;
@@ -1157,7 +1064,8 @@ int64_t zxc_dstream_decompress(zxc_dstream* ds, zxc_outbuf_t* out, zxc_inbuf_t* 
 
             case DS_NEED_FOOTER_REST:
             case DS_NEED_FOOTER_FULL: {
-                if (!ds_pull_scratch(ds, in)) return (int64_t)produced;
+                if (!ds_pull(ds->scratch, &ds->scratch_used, ds->scratch_need, in))
+                    return (int64_t)produced;
                 ds->state = DS_VALIDATE_FOOTER;
                 break;
             }

--- a/lz/zxc/src/lib/zxc_seekable.c
+++ b/lz/zxc/src/lib/zxc_seekable.c
@@ -32,132 +32,11 @@
 #include "../../include/zxc_dict.h"
 #include "../../include/zxc_error.h"
 #include "zxc_internal.h"
+#include "zxc_threads.h"
 
-/* ========================================================================= */
-/*  Platform Threading Layer                                                 */
-/* ========================================================================= */
-
-// LCOV_EXCL_START - Windows platform layer, not reachable on POSIX CI
-#if defined(_WIN32)
-#include <process.h> /* _beginthreadex */
-#include <windows.h>
-
-/* Map POSIX threading primitives to Windows equivalents */
-typedef HANDLE zxc_thread_t;
-
-/**
- * @brief Trampoline payload bridging the POSIX-style @c void*(*)(void*) worker
- *        signature to the Win32 @c _beginthreadex entry point.
- *
- * Heap-allocated by @ref zxc_seek_thread_create and freed by
- * @ref zxc_seek_thread_entry once the captured callback has started.
- */
-typedef struct {
-    void* (*func)(void*); /* worker to invoke */
-    void* arg;            /* argument forwarded to @c func */
-} zxc_seek_thread_arg_t;
-
-/**
- * @brief @c _beginthreadex entry point: unpacks the trampoline payload, frees
- *        it, then runs the captured POSIX-style worker.
- *
- * @param[in] p  Heap @ref zxc_seek_thread_arg_t handed over by the creator;
- *               ownership transfers to this function.
- * @return Always 0 (the worker's @c void* result is discarded, matching the
- *         POSIX path which also ignores it).
- */
-static unsigned __stdcall zxc_seek_thread_entry(void* p) {
-    zxc_seek_thread_arg_t* a = (zxc_seek_thread_arg_t*)p;
-    void* (*f)(void*) = a->func;
-    void* arg = a->arg;
-    ZXC_FREE(a);
-    f(arg);
-    return 0;
-}
-
-/**
- * @brief Spawns a thread running @p fn(@p arg), abstracting @c _beginthreadex.
- *
- * Allocates a @ref zxc_seek_thread_arg_t trampoline so the Win32 entry-point
- * signature can carry a POSIX-style worker; the trampoline is freed by the
- * thread itself (or here, on a launch failure).
- *
- * @param[out] t    Receives the created thread handle on success.
- * @param[in]  fn   Worker to run on the new thread.
- * @param[in]  arg  Opaque argument forwarded to @p fn.
- * @return 0 on success, @ref ZXC_ERROR_MEMORY on allocation or spawn failure.
- */
-static int zxc_seek_thread_create(zxc_thread_t* t, void* (*fn)(void*), void* arg) {
-    zxc_seek_thread_arg_t* wrapper = ZXC_MALLOC(sizeof(zxc_seek_thread_arg_t));
-    if (UNLIKELY(!wrapper)) return ZXC_ERROR_MEMORY;
-    wrapper->func = fn;
-    wrapper->arg = arg;
-    uintptr_t handle = _beginthreadex(NULL, 0, zxc_seek_thread_entry, wrapper, 0, NULL);
-    if (UNLIKELY(handle == 0)) {
-        ZXC_FREE(wrapper);
-        return ZXC_ERROR_MEMORY;
-    }
-    *t = (HANDLE)handle;
-    return 0;
-}
-
-/**
- * @brief Blocks until thread @p t finishes, then releases its handle.
- * @param[in] t  Handle from a successful @ref zxc_seek_thread_create.
- */
-static void zxc_seek_thread_join(zxc_thread_t t) {
-    WaitForSingleObject(t, INFINITE);
-    CloseHandle(t);
-}
-
-/**
- * @brief Returns the number of logical processors reported by the OS.
- * @return Online processor count (always >= 1 in practice).
- */
-static int zxc_seek_get_num_procs(void) {
-    SYSTEM_INFO si;
-    GetSystemInfo(&si);
-    return (int)si.dwNumberOfProcessors;
-}
-// LCOV_EXCL_STOP
-
-#else /* POSIX */
-#include <pthread.h>
-#include <unistd.h>
-
-typedef pthread_t zxc_thread_t;
-
-/**
- * @brief Spawns a thread running @p fn(@p arg) via @c pthread_create.
- * @param[out] t    Receives the created thread handle on success.
- * @param[in]  fn   Worker to run on the new thread.
- * @param[in]  arg  Opaque argument forwarded to @p fn.
- * @return 0 on success, @ref ZXC_ERROR_MEMORY if the thread cannot be created.
- */
-static int zxc_seek_thread_create(zxc_thread_t* t, void* (*fn)(void*), void* arg) {
-    return pthread_create(t, NULL, fn, arg) == 0 ? 0 : ZXC_ERROR_MEMORY;
-}
-
-/**
- * @brief Blocks until thread @p t finishes (its @c void* result is discarded).
- * @param[in] t  Handle from a successful @ref zxc_seek_thread_create.
- */
-static void zxc_seek_thread_join(zxc_thread_t t) { pthread_join(t, NULL); }
-
-/**
- * @brief Returns the number of online logical processors.
- * @return @c _SC_NPROCESSORS_ONLN, clamped to a minimum of 1 if the query fails.
- */
-static int zxc_seek_get_num_procs(void) {
-    const long n = sysconf(_SC_NPROCESSORS_ONLN);
-    return (n > 0) ? (int)n : 1;
-}
-
-#endif /* _WIN32 */
-
-/* ========================================================================= */
-/*  Seek Table Writer                                                        */
-/* ========================================================================= */
+// =========================================================================
+// Seek Table Writer
+// =========================================================================
 
 /**
  * @brief Byte size of a seek table holding @p num_blocks entries.
@@ -165,9 +44,6 @@ static int zxc_seek_get_num_procs(void) {
  * Public API (declared in @c zxc_seekable.h): one block header plus
  * @p num_blocks fixed-size entries. Use it to size the destination buffer
  * before @ref zxc_write_seek_table.
- *
- * @param[in] num_blocks  Number of block entries the table will hold.
- * @return Total table size in bytes (block header + entries).
  */
 size_t zxc_seek_table_size(const uint32_t num_blocks) {
     return ZXC_BLOCK_HEADER_SIZE + (size_t)num_blocks * ZXC_SEEK_ENTRY_SIZE;
@@ -178,14 +54,6 @@ size_t zxc_seek_table_size(const uint32_t num_blocks) {
  *
  * Public API; full contract in @c zxc_seekable.h. Emits the standard ZXC block
  * header followed by one little-endian @c u32 compressed-size entry per block.
- *
- * @param[out] dst           Destination buffer.
- * @param[in]  dst_capacity  Capacity of @p dst in bytes.
- * @param[in]  comp_sizes    Array of @p num_blocks compressed block sizes.
- * @param[in]  num_blocks    Number of blocks (and entries) to write.
- * @return Bytes written on success, or a negative @ref zxc_error_t
- *         (@ref ZXC_ERROR_OVERFLOW, @ref ZXC_ERROR_DST_TOO_SMALL,
- *         @ref ZXC_ERROR_NULL_INPUT).
  */
 int64_t zxc_write_seek_table(uint8_t* dst, const size_t dst_capacity, const uint32_t* comp_sizes,
                              const uint32_t num_blocks) {
@@ -197,14 +65,14 @@ int64_t zxc_write_seek_table(uint8_t* dst, const size_t dst_capacity, const uint
 
     const uint32_t payload_size = num_blocks * ZXC_SEEK_ENTRY_SIZE;
 
-    /* Write standard ZXC block header */
+    // Write standard ZXC block header
     const zxc_block_header_t bh = {
         .block_type = ZXC_BLOCK_SEK, .block_flags = 0, .reserved = 0, .comp_size = payload_size};
     const int hdr_res = zxc_write_block_header(dst, dst_capacity, &bh);
     if (UNLIKELY(hdr_res < 0)) return hdr_res;
     uint8_t* p = dst + hdr_res;
 
-    /* Write entries: comp_size(4) only */
+    // Write entries: comp_size(4) only
     for (uint32_t i = 0; i < num_blocks; i++) {
         zxc_store_le32(p, comp_sizes[i]);
         p += sizeof(uint32_t);
@@ -213,186 +81,227 @@ int64_t zxc_write_seek_table(uint8_t* dst, const size_t dst_capacity, const uint
     return (int64_t)(p - dst);
 }
 
-/* ========================================================================= */
-/*  Seekable Reader (Opaque Handle)                                          */
-/* ========================================================================= */
+// =========================================================================
+// Seekable Reader (Opaque Handle)
+// =========================================================================
 
 struct zxc_seekable_s {
-    /* Source - exactly one of {src, reader.read_at} is set. The FILE* variant
-     * wraps pread() in its own reader ctx, indistinguishable from here. */
+    // Source - exactly one of {src, reader.read_at} is set. The FILE* variant
+    // wraps pread() in its own reader ctx, indistinguishable from here.
     const uint8_t* src;
     uint64_t src_size;
     zxc_reader_t reader; /* user-supplied callback reader; read_at == NULL when unused */
 
-    /* Reader context owned by the handle and freed in zxc_seekable_free, set by
-     * the thin wrappers. NULL when the caller owns reader.ctx itself. */
+    // Reader context owned by the handle and freed in zxc_seekable_free, set by
+    // the thin wrappers. NULL when the caller owns reader.ctx itself.
     void* owned_reader_ctx;
 
-    /* Parsed seek table */
+    // Parsed seek table
     uint32_t num_blocks;
     uint32_t* comp_sizes;   /* array[num_blocks] */
     uint64_t* comp_offsets; /* prefix-sum: byte offset in compressed file per block */
     uint64_t total_decomp;  /* total decompressed size (from footer) */
+    uint32_t max_comp_size; /* largest entry of comp_sizes, from the same walk */
 
-    /* File header info - block_size is always a power of 2 in [4KB, 2MB],
-     * fits in 21 bits. */
+    // File header info - block_size is always a power of 2 in [4KB, 2MB],
+    // fits in 21 bits.
     uint32_t block_size;
     int file_has_checksums;
     uint32_t expected_dict_id; /* dict_id from the file header; 0 = no dictionary */
 
-    /* Reusable decompression context (single-threaded path only) */
+    // Reusable decompression context and compressed-block scratch. Both belong
+    // to the single-threaded path, which is already not reentrant per handle;
+    // the multi-threaded path gives each worker its own.
     zxc_cctx_t dctx;
     int dctx_initialized;
+    uint8_t* read_buf;
+    size_t read_buf_cap;
 
-    /* Dictionary (owned copy, freed in zxc_seekable_free). */
+    // Dictionary (owned copy, freed in zxc_seekable_free).
     uint8_t* dict;
     size_t dict_size;
-    /* Shared literal Huffman table (owned copy; meaningful when has_dict_huf). */
+    // Shared literal Huffman table (owned copy; meaningful when has_dict_huf).
     uint8_t dict_huf[ZXC_HUF_TABLE_SIZE];
     int has_dict_huf;
 };
 
 /**
- * @brief Parses the seek table from raw bytes at the end of the archive.
+ * @struct zxc_seek_source_t
+ * @brief Where the archive bytes come from during parsing.
+ *
+ * The two public entry points differ only in this: @ref zxc_seekable_open holds
+ * the whole archive in memory, @ref zxc_seekable_open_reader reaches it through
+ * a positioned callback. Everything after the first read is common, so the
+ * parser below takes a source instead of being written twice.
+ */
+typedef struct {
+    const uint8_t* data;     /* in-memory archive, NULL in callback mode */
+    const zxc_reader_t* rdr; /* callback mode, NULL in buffer mode */
+    uint64_t size;           /* archive size, both modes */
+} zxc_seek_source_t;
+
+/**
+ * @brief Reads a byte range from the archive, whatever backs it.
+ *
+ * Returns 1 on success, 0 if the range falls outside the archive or the
+ * caller's reader came up short: every bounds check on a parsed offset goes
+ * through here.
+ */
+static int zxc_seek_source_read(const zxc_seek_source_t* src, void* dst, const size_t len,
+                                const uint64_t off) {
+    if (UNLIKELY(off > src->size || (uint64_t)len > src->size - off)) return 0;
+    if (src->data) {
+        ZXC_MEMCPY(dst, src->data + off, len);
+        return 1;
+    }
+    return src->rdr->read_at(src->rdr->ctx, dst, len, off) == (int64_t)len;
+}
+
+/**
+ * @brief Parses and validates the seek table at the end of the archive.
  *
  * Detection (backward from end):
  *   1. Read file header => block_size
  *   2. Read file footer => total_decomp_size
  *   3. Derive num_blocks = ceil(total_decomp_size / block_size)
  *   4. Compute expected seek block position, validate block_type == SEK
- *   5. Read comp_sizes; derive decomp_sizes from block_size
+ *   5. Read comp_sizes, build the compressed-offset prefix sums, and check the
+ *      layout lands exactly on the EOF block
  *
- * @param[in] data       Pointer to the whole in-memory archive.
- * @param[in] data_size  Archive size in bytes.
- * @return A newly allocated handle (free via @ref zxc_seekable_free), or NULL
- *         if the buffer is too small or the seek table is missing / malformed.
+ * Returns a handle to free via @ref zxc_seekable_free, or NULL if the archive
+ * is too small or the seek table is missing / malformed.
  */
-static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_size) {
-    /* Minimum: file_header(16) + eof_block(8) + seek_block_header(8)
-     *          + file_footer(12) = 44 */
-    const size_t MIN_SEEKABLE_SIZE =
+static zxc_seekable* zxc_seekable_parse(const zxc_seek_source_t* src) {
+    // Minimum: file_header(16) + eof_block(8) + seek_block_header(8)
+    //          + file_footer(12) = 44
+    const uint64_t MIN_SEEKABLE_SIZE =
         ZXC_FILE_HEADER_SIZE + ZXC_BLOCK_HEADER_SIZE + ZXC_BLOCK_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE;
-    if (UNLIKELY(data_size < MIN_SEEKABLE_SIZE)) return NULL;
+    if (UNLIKELY(src->size < MIN_SEEKABLE_SIZE)) return NULL;
 
-    /* Step 1: validate file header => block_size */
+    // Step 1: validate file header => block_size
+    uint8_t header[ZXC_FILE_HEADER_SIZE];
+    if (UNLIKELY(!zxc_seek_source_read(src, header, sizeof(header), 0))) return NULL;
+
     size_t block_size_sz = 0;
     int file_has_chk = 0;
     uint32_t header_dict_id = 0;
-    if (UNLIKELY(zxc_read_file_header(data, data_size, &block_size_sz, &file_has_chk,
+    if (UNLIKELY(zxc_read_file_header(header, sizeof(header), &block_size_sz, &file_has_chk,
                                       &header_dict_id) != ZXC_OK))
         return NULL;  // LCOV_EXCL_LINE
     const uint32_t block_size = (uint32_t)block_size_sz;
     if (UNLIKELY(block_size == 0)) return NULL;  // LCOV_EXCL_LINE
 
-    /* Step 2: read total decompressed size from the file footer */
-    const uint8_t* const footer_ptr = data + data_size - ZXC_FILE_FOOTER_SIZE;
-    const uint64_t total_decomp = zxc_le64(footer_ptr);
+    // Step 2: read total decompressed size from the file footer
+    uint8_t footer[ZXC_FILE_FOOTER_SIZE];
+    if (UNLIKELY(
+            !zxc_seek_source_read(src, footer, sizeof(footer), src->size - ZXC_FILE_FOOTER_SIZE)))
+        return NULL;
+    const uint64_t total_decomp = zxc_le64(footer);
 
-    /* A value of 0 means empty file - no seek table */
+    // A value of 0 means empty file - no seek table
     if (UNLIKELY(total_decomp == 0)) return NULL;
 
-    /* Step 3: derive num_blocks = ceil(total_decomp / block_size) */
-    const uint64_t num_blocks_64 = (total_decomp + block_size - 1) / block_size;
+    // Step 3: derive num_blocks = ceil(total_decomp / block_size)
+    const uint64_t num_blocks_64 = total_decomp / block_size + (total_decomp % block_size != 0);
     if (UNLIKELY(num_blocks_64 > UINT32_MAX)) return NULL;
     const uint32_t num_blocks = (uint32_t)num_blocks_64;
 
-    /* Step 4: compute seek block position and validate. */
-    const uint64_t entries_total_64 = num_blocks_64 * ZXC_SEEK_ENTRY_SIZE;
-    if (UNLIKELY(entries_total_64 > SIZE_MAX - ZXC_BLOCK_HEADER_SIZE)) return NULL;
-    const size_t entries_total = (size_t)entries_total_64;
-    const size_t seek_block_total = ZXC_BLOCK_HEADER_SIZE + entries_total;
-    if (UNLIKELY(seek_block_total + ZXC_FILE_FOOTER_SIZE > data_size)) return NULL;
-    const uint8_t* const seek_block_start =
-        data + data_size - ZXC_FILE_FOOTER_SIZE - seek_block_total;
-    if (UNLIKELY(seek_block_start < data)) return NULL;
+    // Step 4: locate and validate the seek block. Two headers of margin, not one:
+    // the tail read below spans the EOF block, so tail_total could wrap on 32 bits.
+    const uint64_t entries_total = num_blocks_64 * ZXC_SEEK_ENTRY_SIZE;
+    if (UNLIKELY(entries_total > SIZE_MAX - 2 * ZXC_BLOCK_HEADER_SIZE)) return NULL;
 
-    /* Read and validate SEK block header */
+    const size_t seek_block_total = ZXC_BLOCK_HEADER_SIZE + (size_t)entries_total;
+    if (UNLIKELY((uint64_t)seek_block_total + ZXC_FILE_FOOTER_SIZE > src->size)) return NULL;
+
+    const uint64_t seek_off = src->size - ZXC_FILE_FOOTER_SIZE - (uint64_t)seek_block_total;
+    if (UNLIKELY(seek_off < ZXC_BLOCK_HEADER_SIZE)) return NULL;
+
+    // The EOF block sits immediately before the seek block, so one read covers
+    // both: [EOF 8][SEK header 8][entries]. Keeps a reader-backed open at three
+    // reads (header, footer, tail) while validating the same layout the
+    // in-memory path does.
+    const size_t tail_total = ZXC_BLOCK_HEADER_SIZE + seek_block_total;
+    const uint64_t tail_off = seek_off - ZXC_BLOCK_HEADER_SIZE;
+
+    uint8_t* tail = NULL;
+    const uint8_t* tail_view;
+    zxc_seekable* s = NULL;
+    if (src->data) {
+        tail_view = src->data + tail_off;
+    } else {
+        tail = (uint8_t*)ZXC_MALLOC(tail_total);
+        if (UNLIKELY(!tail)) return NULL;  // LCOV_EXCL_LINE
+        if (UNLIKELY(!zxc_seek_source_read(src, tail, tail_total, tail_off))) goto fail;
+        tail_view = tail;
+    }
+
+    const uint8_t* const eof_hdr = tail_view;
+    const uint8_t* const seek_blk = tail_view + ZXC_BLOCK_HEADER_SIZE;
+
     zxc_block_header_t bh;
-    if (UNLIKELY(zxc_read_block_header(seek_block_start, seek_block_total, &bh) != ZXC_OK))
-        return NULL;
-    if (UNLIKELY(bh.block_type != ZXC_BLOCK_SEK)) return NULL;
-    if (UNLIKELY(bh.comp_size != (uint32_t)entries_total)) return NULL;
+    // The SEK header stores the table size in a 32-bit field, so reject any larger value before
+    // reading it.
+    if (UNLIKELY(entries_total > UINT32_MAX)) goto fail;
+    if (UNLIKELY(zxc_read_block_header(seek_blk, seek_block_total, &bh) != ZXC_OK ||
+                 bh.block_type != ZXC_BLOCK_SEK || bh.comp_size != entries_total))
+        goto fail;
 
-    /* Step 5: allocate handle and parse entries */
-    zxc_seekable* const s = (zxc_seekable*)ZXC_CALLOC(1, sizeof(zxc_seekable));
-    // LCOV_EXCL_START
-    if (UNLIKELY(!s)) return NULL;
-    // LCOV_EXCL_STOP
+    // Step 5: allocate the handle and parse the entries
+    s = (zxc_seekable*)ZXC_CALLOC(1, sizeof(zxc_seekable));
+    if (UNLIKELY(!s)) goto fail;  // LCOV_EXCL_LINE
 
+    if (src->rdr) s->reader = *src->rdr;
+    s->src = src->data;
+    s->src_size = src->size;
     s->num_blocks = num_blocks;
     s->block_size = block_size;
     s->file_has_checksums = file_has_chk;
     s->expected_dict_id = header_dict_id;
-    s->src = data;
-    s->src_size = (uint64_t)data_size;
-
-    /* Allocate arrays */
-    s->comp_sizes = (uint32_t*)ZXC_CALLOC(num_blocks, sizeof(uint32_t));
-    s->comp_offsets = (uint64_t*)ZXC_CALLOC((size_t)num_blocks + 1, sizeof(uint64_t));
-    // LCOV_EXCL_START
-    if (UNLIKELY(!s->comp_sizes || !s->comp_offsets)) {
-        zxc_seekable_free(s);
-        return NULL;
-    }
-    // LCOV_EXCL_STOP
     s->total_decomp = total_decomp;
 
-    /* Parse comp_sizes and build compressed prefix sums.
-     * Validate each comp_size against data_size to prevent prefix-sum overflow
-     * and out-of-bounds reads during decompression. */
-    const uint8_t* ep = seek_block_start + ZXC_BLOCK_HEADER_SIZE;
-    uint64_t comp_acc = ZXC_FILE_HEADER_SIZE; /* blocks start after file header */
-    for (uint32_t i = 0; i < num_blocks; i++) {
-        s->comp_sizes[i] = zxc_le32(ep);
-        ep += sizeof(uint32_t);
+    s->comp_sizes = (uint32_t*)ZXC_CALLOC(num_blocks, sizeof(uint32_t));
+    s->comp_offsets = (uint64_t*)ZXC_CALLOC((size_t)num_blocks + 1, sizeof(uint64_t));
+    if (UNLIKELY(!s->comp_sizes || !s->comp_offsets)) goto fail;  // LCOV_EXCL_LINE
 
-        /* Reject entries below minimum (block header) or larger than the file */
-        if (UNLIKELY(s->comp_sizes[i] < ZXC_BLOCK_HEADER_SIZE ||
-                     s->comp_sizes[i] > (uint64_t)data_size)) {
-            zxc_seekable_free(s);
-            return NULL;
+    // Parse comp_sizes and build compressed prefix sums. Every entry is checked
+    // against the archive size, so the prefix sum can neither overflow nor
+    // point a later read out of bounds.
+    {
+        const uint8_t* ep = seek_blk + ZXC_BLOCK_HEADER_SIZE;
+        uint64_t comp_acc = ZXC_FILE_HEADER_SIZE; /* blocks start after file header */
+        for (uint32_t i = 0; i < num_blocks; i++) {
+            s->comp_sizes[i] = zxc_le32(ep);
+            ep += sizeof(uint32_t);
+
+            // Reject entries below minimum (block header) or larger than the file
+            if (UNLIKELY(s->comp_sizes[i] < ZXC_BLOCK_HEADER_SIZE || s->comp_sizes[i] > src->size))
+                goto fail;
+            if (s->comp_sizes[i] > s->max_comp_size) s->max_comp_size = s->comp_sizes[i];
+            s->comp_offsets[i] = comp_acc;
+            comp_acc += s->comp_sizes[i];
+            // Reject if cumulative offset exceeds file size (inconsistent table)
+            if (UNLIKELY(comp_acc > src->size)) goto fail;  // LCOV_EXCL_LINE
         }
-        s->comp_offsets[i] = comp_acc;
-        comp_acc += s->comp_sizes[i];
-        /* Reject if cumulative offset exceeds file size (inconsistent table) */
-        if (UNLIKELY(comp_acc > (uint64_t)data_size)) {
-            // LCOV_EXCL_START
-            zxc_seekable_free(s);
-            return NULL;
-            // LCOV_EXCL_STOP
-        }
-    }
-    s->comp_offsets[num_blocks] = comp_acc;
+        s->comp_offsets[num_blocks] = comp_acc;
 
-    /* Verify prefix-sum lands exactly at the EOF block position.
-     * Expected layout: [header 16][data blocks][EOF 8][SEK block][footer 12]
-     * So comp_acc (end of data blocks) + EOF(8) == seek_block_start. */
-    const uint64_t expected_eof_offset =
-        (uint64_t)(seek_block_start - data) - ZXC_BLOCK_HEADER_SIZE;
-    if (UNLIKELY(comp_acc != expected_eof_offset)) {
-        // LCOV_EXCL_START
-        zxc_seekable_free(s);
-        return NULL;
-        // LCOV_EXCL_STOP
+        // Verify the prefix sum lands exactly on the EOF block, and that an EOF
+        // block really sits there. Expected layout:
+        // [header 16][data blocks][EOF 8][SEK block][footer 12]
+        zxc_block_header_t eof_bh;
+        if (UNLIKELY(comp_acc != seek_off - ZXC_BLOCK_HEADER_SIZE ||
+                     zxc_read_block_header(eof_hdr, ZXC_BLOCK_HEADER_SIZE, &eof_bh) != ZXC_OK ||
+                     eof_bh.block_type != ZXC_BLOCK_EOF))
+            goto fail;
     }
 
-    /* Validate that an actual EOF block header exists at the computed offset */
-    if (UNLIKELY(comp_acc + ZXC_BLOCK_HEADER_SIZE > data_size)) {
-        // LCOV_EXCL_START
-        zxc_seekable_free(s);
-        return NULL;
-        // LCOV_EXCL_STOP
-    }
-    zxc_block_header_t eof_bh;
-    if (UNLIKELY(zxc_read_block_header(data + comp_acc, ZXC_BLOCK_HEADER_SIZE, &eof_bh) != ZXC_OK ||
-                 eof_bh.block_type != ZXC_BLOCK_EOF)) {
-        // LCOV_EXCL_START
-        zxc_seekable_free(s);
-        return NULL;
-        // LCOV_EXCL_STOP
-    }
-
+    ZXC_FREE(tail);
     return s;
+
+fail:
+    ZXC_FREE(tail);
+    zxc_seekable_free(s);
+    return NULL;
 }
 
 /**
@@ -400,19 +309,15 @@ static zxc_seekable* zxc_seekable_parse(const uint8_t* data, const size_t data_s
  *
  * Public API; see @c zxc_seekable.h. Thin guard around
  * @ref zxc_seekable_parse, which detects and validates the trailing seek table.
- *
- * @param[in] src       Pointer to the whole compressed archive.
- * @param[in] src_size  Archive size in bytes.
- * @return A handle to release with @ref zxc_seekable_free, or NULL on bad input
- *         or a missing / malformed seek table.
  */
 zxc_seekable* zxc_seekable_open(const void* src, const size_t src_size) {
     if (UNLIKELY(!src || src_size == 0)) return NULL;
-    return zxc_seekable_parse((const uint8_t*)src, src_size);
+    const zxc_seek_source_t source = {(const uint8_t*)src, NULL, (uint64_t)src_size};
+    return zxc_seekable_parse(&source);
 }
 
-/* zxc_seekable_open_file lives elsewhere: it builds a zxc_reader_t over pread()
- * and delegates below, keeping this TU free of <stdio.h>. */
+// zxc_seekable_open_file lives elsewhere: it builds a zxc_reader_t over pread()
+// and delegates below, keeping this TU free of <stdio.h>.
 
 /**
  * @brief Opens a seekable archive over a caller-supplied random-access reader.
@@ -422,148 +327,20 @@ zxc_seekable* zxc_seekable_open(const void* src, const size_t src_size) {
  * validates the SEK block, and builds the per-block compressed-offset prefix
  * sums. Unlike @ref zxc_seekable_open the archive is never mapped whole; only
  * the metadata is read up front.
- *
- * @param[in] r  Reader descriptor (@c read_at and @c size must be set).
- * @return A handle to release with @ref zxc_seekable_free, or NULL on bad input,
- *         a short read, or a malformed seek table.
  */
 zxc_seekable* zxc_seekable_open_reader(const zxc_reader_t* r) {
     if (UNLIKELY(!r || !r->read_at || r->size == 0)) return NULL;
-
-    /* Minimum: file_header(16) + eof_block(8) + seek_block_header(8)
-     *          + file_footer(12) = 44 */
-    const uint64_t MIN_SEEKABLE_SIZE =
-        ZXC_FILE_HEADER_SIZE + ZXC_BLOCK_HEADER_SIZE + ZXC_BLOCK_HEADER_SIZE + ZXC_FILE_FOOTER_SIZE;
-    if (UNLIKELY(r->size < MIN_SEEKABLE_SIZE)) return NULL;
-
-    /* Read file header => block_size */
-    uint8_t header[ZXC_FILE_HEADER_SIZE];
-    if (UNLIKELY(r->read_at(r->ctx, header, ZXC_FILE_HEADER_SIZE, 0) !=
-                 (int64_t)ZXC_FILE_HEADER_SIZE))
-        return NULL;
-
-    size_t bs_sz = 0;
-    int fhc = 0;
-    uint32_t header_dict_id = 0;
-    if (UNLIKELY(zxc_read_file_header(header, ZXC_FILE_HEADER_SIZE, &bs_sz, &fhc,
-                                      &header_dict_id) != ZXC_OK))
-        return NULL;  // LCOV_EXCL_LINE
-    const uint32_t bs = (uint32_t)bs_sz;
-    if (UNLIKELY(bs == 0)) return NULL;
-
-    /* Read footer => total_decomp_size */
-    uint8_t footer_buf[ZXC_FILE_FOOTER_SIZE];
-    if (UNLIKELY(r->read_at(r->ctx, footer_buf, ZXC_FILE_FOOTER_SIZE,
-                            r->size - ZXC_FILE_FOOTER_SIZE) != (int64_t)ZXC_FILE_FOOTER_SIZE))
-        return NULL;
-
-    const uint64_t total_decomp = zxc_le64(footer_buf);
-    if (UNLIKELY(total_decomp == 0)) return NULL;
-
-    /* Derive num_blocks = ceil(total_decomp / block_size) */
-    const uint64_t num_blocks_64 = (total_decomp + bs - 1) / bs;
-    if (UNLIKELY(num_blocks_64 > UINT32_MAX)) return NULL;
-    const uint32_t num_blocks = (uint32_t)num_blocks_64;
-
-    /* Guard against size_t multiplication overflow */
-    const uint64_t entries_total_64 = (uint64_t)num_blocks * ZXC_SEEK_ENTRY_SIZE;
-    if (UNLIKELY(entries_total_64 > SIZE_MAX - ZXC_BLOCK_HEADER_SIZE)) return NULL;
-
-    /* Read the full seek block */
-    const size_t seek_block_total = ZXC_BLOCK_HEADER_SIZE + (size_t)entries_total_64;
-    if (UNLIKELY(seek_block_total + ZXC_FILE_FOOTER_SIZE > r->size)) return NULL;
-
-    uint8_t* const seek_buf = (uint8_t*)ZXC_MALLOC(seek_block_total);
-    if (UNLIKELY(!seek_buf)) return NULL;
-
-    const uint64_t seek_offset = r->size - ZXC_FILE_FOOTER_SIZE - (uint64_t)seek_block_total;
-    if (UNLIKELY(r->read_at(r->ctx, seek_buf, seek_block_total, seek_offset) !=
-                 (int64_t)seek_block_total)) {
-        // LCOV_EXCL_START
-        ZXC_FREE(seek_buf);
-        return NULL;
-        // LCOV_EXCL_STOP
-    }
-
-    /* Validate SEK block header */
-    zxc_block_header_t bh;
-    if (UNLIKELY(zxc_read_block_header(seek_buf, seek_block_total, &bh) != ZXC_OK) ||
-        bh.block_type != ZXC_BLOCK_SEK || bh.comp_size != (uint32_t)entries_total_64) {
-        // LCOV_EXCL_START
-        ZXC_FREE(seek_buf);
-        return NULL;
-        // LCOV_EXCL_STOP
-    }
-
-    /* Build seekable handle */
-    zxc_seekable* const s = (zxc_seekable*)ZXC_CALLOC(1, sizeof(zxc_seekable));
-    if (UNLIKELY(!s)) {
-        // LCOV_EXCL_START
-        ZXC_FREE(seek_buf);
-        return NULL;
-        // LCOV_EXCL_STOP
-    }
-
-    s->reader = *r;
-    s->src = NULL;
-    s->src_size = r->size;
-    s->num_blocks = num_blocks;
-    s->block_size = bs;
-    s->file_has_checksums = fhc;
-    s->expected_dict_id = header_dict_id;
-
-    s->comp_sizes = (uint32_t*)ZXC_CALLOC(num_blocks, sizeof(uint32_t));
-    s->comp_offsets = (uint64_t*)ZXC_CALLOC((size_t)num_blocks + 1, sizeof(uint64_t));
-    if (UNLIKELY(!s->comp_sizes || !s->comp_offsets)) {
-        // LCOV_EXCL_START
-        ZXC_FREE(seek_buf);
-        zxc_seekable_free(s);
-        return NULL;
-        // LCOV_EXCL_STOP
-    }
-    s->total_decomp = total_decomp;
-
-    /* Parse comp_sizes and build prefix sums; validate against archive size. */
-    const uint8_t* ep = seek_buf + ZXC_BLOCK_HEADER_SIZE;
-    uint64_t comp_acc = ZXC_FILE_HEADER_SIZE;
-    for (uint32_t i = 0; i < num_blocks; i++) {
-        s->comp_sizes[i] = zxc_le32(ep);
-        ep += sizeof(uint32_t);
-
-        if (UNLIKELY(s->comp_sizes[i] < ZXC_BLOCK_HEADER_SIZE || s->comp_sizes[i] > r->size)) {
-            // LCOV_EXCL_START
-            ZXC_FREE(seek_buf);
-            zxc_seekable_free(s);
-            return NULL;
-            // LCOV_EXCL_STOP
-        }
-        s->comp_offsets[i] = comp_acc;
-        comp_acc += s->comp_sizes[i];
-        if (UNLIKELY(comp_acc > r->size)) {
-            // LCOV_EXCL_START
-            ZXC_FREE(seek_buf);
-            zxc_seekable_free(s);
-            return NULL;
-            // LCOV_EXCL_STOP
-        }
-    }
-    s->comp_offsets[num_blocks] = comp_acc;
-
-    ZXC_FREE(seek_buf);
-    return s;
+    const zxc_seek_source_t source = {NULL, r, r->size};
+    return zxc_seekable_parse(&source);
 }
 
 /**
  * @brief Number of blocks in the archive.
- * @param[in] s  Seekable handle (may be NULL).
- * @return Block count, or 0 if @p s is NULL.
  */
 uint32_t zxc_seekable_get_num_blocks(const zxc_seekable* s) { return s ? s->num_blocks : 0; }
 
 /**
  * @brief Total decompressed size of the archive.
- * @param[in] s  Seekable handle (may be NULL).
- * @return Decompressed size in bytes, or 0 if @p s is NULL.
  */
 uint64_t zxc_seekable_get_decompressed_size(const zxc_seekable* s) {
     return s ? s->total_decomp : 0;
@@ -571,10 +348,6 @@ uint64_t zxc_seekable_get_decompressed_size(const zxc_seekable* s) {
 
 /**
  * @brief Compressed byte size of a given block.
- * @param[in] s          Seekable handle (may be NULL).
- * @param[in] block_idx  Zero-based block index.
- * @return Compressed size in bytes, or 0 if @p s is NULL or @p block_idx is
- *         out of range.
  */
 uint32_t zxc_seekable_get_block_comp_size(const zxc_seekable* s, const uint32_t block_idx) {
     if (UNLIKELY(!s || block_idx >= s->num_blocks)) return 0;
@@ -586,11 +359,6 @@ uint32_t zxc_seekable_get_block_comp_size(const zxc_seekable* s, const uint32_t 
  *
  * Every block decompresses to @c block_size except the last, which holds the
  * remainder of @c total_decomp.
- *
- * @param[in] s          Seekable handle (may be NULL).
- * @param[in] block_idx  Zero-based block index.
- * @return Decompressed size in bytes, or 0 if @p s is NULL or @p block_idx is
- *         out of range.
  */
 uint32_t zxc_seekable_get_block_decomp_size(const zxc_seekable* s, const uint32_t block_idx) {
     if (UNLIKELY(!s || block_idx >= s->num_blocks)) return 0;
@@ -599,9 +367,9 @@ uint32_t zxc_seekable_get_block_decomp_size(const zxc_seekable* s, const uint32_
     return (remaining >= (uint64_t)s->block_size) ? s->block_size : (uint32_t)remaining;
 }
 
-/* ========================================================================= */
-/*  Random-Access Decompression                                              */
-/* ========================================================================= */
+// =========================================================================
+// Random-Access Decompression
+// =========================================================================
 
 /**
  * @brief Maps a decompressed @p offset to its containing block index (O(1)).
@@ -644,8 +412,8 @@ static uint32_t zxc_seek_decomp_size(const uint32_t block_size, const uint64_t t
 /**
  * @brief Reads a compressed block into @p buf from the memory buffer or reader.
  *
- * Single-threaded path: copies from @c s->src in buffer mode, otherwise calls
- * @c s->reader.read_at (which also backs the FILE* variant).
+ * Copies from @c s->src in buffer mode, otherwise calls @c s->reader.read_at
+ * (which also backs the FILE* variant).
  *
  * @param[in]  s          Seekable handle.
  * @param[in]  block_idx  Zero-based block index to read.
@@ -662,12 +430,12 @@ static int zxc_seek_read_block(const zxc_seekable* s, const uint32_t block_idx, 
     if (UNLIKELY(csz > buf_cap)) return ZXC_ERROR_DST_TOO_SMALL;
 
     if (s->src) {
-        /* Buffer mode */
+        // Buffer mode
         if (UNLIKELY(off + csz > s->src_size)) return ZXC_ERROR_SRC_TOO_SMALL;
         ZXC_MEMCPY(buf, s->src + off, csz);
     } else if (s->reader.read_at) {
-        /* Caller-supplied reader (also covers the FILE* variant, which
-         * provides a pread-backed callback from zxc_seekable_file.c). */
+        // Caller-supplied reader (also covers the FILE* variant, which
+        // provides a pread-backed callback from zxc_seekable_file.c).
         const int64_t r = s->reader.read_at(s->reader.ctx, buf, csz, off);
         if (UNLIKELY(r != (int64_t)csz)) return (r < 0) ? (int)r : ZXC_ERROR_IO;
     } else {
@@ -684,13 +452,6 @@ static int zxc_seek_read_block(const zxc_seekable* s, const uint32_t block_idx, 
  * lazily-initialised, dictionary-aware context, and copies out only the
  * requested sub-range. Single-threaded; see @ref zxc_seekable_decompress_range_mt
  * for the parallel variant.
- *
- * @param[in,out] s             Seekable handle (carries the reusable context).
- * @param[out]    dst           Destination buffer.
- * @param[in]     dst_capacity  Capacity of @p dst (must be >= @p len).
- * @param[in]     offset        Absolute decompressed start offset.
- * @param[in]     len           Number of decompressed bytes to produce.
- * @return @p len on success, or a negative @ref zxc_error_t.
  */
 int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t dst_capacity,
                                       const uint64_t offset, const size_t len) {
@@ -701,7 +462,7 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
     if (UNLIKELY(s->expected_dict_id != 0 && (!s->dict || s->dict_size == 0)))
         return ZXC_ERROR_DICT_REQUIRED;
 
-    /* Initialize decompression context on first use */
+    // Initialize decompression context on first use
     if (!s->dctx_initialized) {
         // LCOV_EXCL_START
         if (UNLIKELY(zxc_cctx_init(&s->dctx, (size_t)s->block_size, 0, 0, 0, s->dict_size) !=
@@ -720,58 +481,46 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
     }
     s->dctx.dict_size = s->dict_size;
 
-    /* work_buf is pre-sized to block_size + ZXC_DECOMPRESS_TAIL_PAD by the
-     * matching zxc_cctx_init above. */
+    // work_buf is pre-sized to block_size + ZXC_DECOMPRESS_TAIL_PAD by the
+    // matching zxc_cctx_init above.
     const size_t work_sz = (size_t)s->block_size + ZXC_DECOMPRESS_TAIL_PAD;
 
-    /* Find block range - O(1) division */
+    // Find block range - O(1) division
     const uint32_t blk_start = zxc_seek_find_block(s->block_size, offset);
     const uint32_t blk_end = zxc_seek_find_block(s->block_size, offset + len - 1);
 
     uint8_t* out = (uint8_t*)dst;
     size_t remaining = len;
 
-    /* Allocate read buffer for compressed blocks */
-    size_t max_comp = 0;
-    for (uint32_t bi = blk_start; bi <= blk_end; bi++) {
-        if (s->comp_sizes[bi] > max_comp) max_comp = s->comp_sizes[bi];
+    // Compressed-block scratch, sized once for the largest block of the archive
+    // and kept on the handle: a range read is often one of many.
+    const size_t read_cap = (size_t)s->max_comp_size + ZXC_PAD_SIZE;
+    if (s->read_buf_cap < read_cap) {
+        uint8_t* const nb = (uint8_t*)ZXC_REALLOC(s->read_buf, read_cap);
+        if (UNLIKELY(!nb)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
+        s->read_buf = nb;
+        s->read_buf_cap = read_cap;
     }
-    uint8_t* const read_buf = (uint8_t*)ZXC_MALLOC(max_comp + ZXC_PAD_SIZE);
-    if (UNLIKELY(!read_buf)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
+    uint8_t* const read_buf = s->read_buf;
 
     for (uint32_t bi = blk_start; bi <= blk_end; bi++) {
-        /* Read compressed block data */
-        const int read_res = zxc_seek_read_block(s, bi, read_buf, max_comp + ZXC_PAD_SIZE);
-        if (UNLIKELY(read_res < 0)) {
-            // LCOV_EXCL_START
-            ZXC_FREE(read_buf);
-            return read_res;
-            // LCOV_EXCL_STOP
-        }
+        // Read compressed block data
+        const int read_res = zxc_seek_read_block(s, bi, read_buf, read_cap);
+        if (UNLIKELY(read_res < 0)) return read_res;  // LCOV_EXCL_LINE
 
-        /* Decompress the block: when a dictionary is active, decode into the
-         * cctx-owned dict_buffer (which has dict content prepended) so that
-         * match copies referencing dictionary bytes resolve naturally. */
+        // Decompress the block: when a dictionary is active, decode into the
+        // cctx-owned dict_buffer (which has dict content prepended) so that
+        // match copies referencing dictionary bytes resolve naturally.
         uint8_t* dec_dst =
             s->dctx.dict_buffer ? s->dctx.dict_buffer + s->dict_size : s->dctx.work_buf;
         const int dec_res =
             zxc_decompress_chunk_wrapper(&s->dctx, read_buf, (size_t)read_res, dec_dst, work_sz);
-        if (UNLIKELY(dec_res < 0)) {
-            // LCOV_EXCL_START
-            ZXC_FREE(read_buf);
-            return dec_res;
-            // LCOV_EXCL_STOP
-        }
+        if (UNLIKELY(dec_res < 0)) return dec_res;  // LCOV_EXCL_LINE
 
-        /* Calculate which portion of this block's decompressed data we need */
+        // Calculate which portion of this block's decompressed data we need
         const uint64_t blk_decomp_start = zxc_seek_decomp_offset(s->block_size, bi);
         const size_t skip = (offset > blk_decomp_start) ? (size_t)(offset - blk_decomp_start) : 0;
-        if (UNLIKELY((size_t)dec_res < skip)) {
-            // LCOV_EXCL_START
-            ZXC_FREE(read_buf);
-            return ZXC_ERROR_CORRUPT_DATA;
-            // LCOV_EXCL_STOP
-        }
+        if (UNLIKELY((size_t)dec_res < skip)) return ZXC_ERROR_CORRUPT_DATA;  // LCOV_EXCL_LINE
         const size_t avail = (size_t)dec_res - skip;
         const size_t copy = (avail < remaining) ? avail : remaining;
 
@@ -780,13 +529,12 @@ int64_t zxc_seekable_decompress_range(zxc_seekable* s, void* dst, const size_t d
         remaining -= copy;
     }
 
-    ZXC_FREE(read_buf);
     return (int64_t)len;
 }
 
-/* ========================================================================= */
-/*  Multi-Threaded Random-Access Decompression (Fork-Join)                   */
-/* ========================================================================= */
+// =========================================================================
+// Multi-Threaded Random-Access Decompression (Fork-Join)
+// =========================================================================
 
 /**
  * @brief Per-block job descriptor for multi-threaded decompression.
@@ -803,42 +551,6 @@ typedef struct {
     size_t copy_len;       /* bytes to copy into dst */
     int result;            /* 0 = OK, < 0 = error */
 } zxc_seek_mt_job_t;
-
-/**
- * @brief Thread-safe block read backing the multi-threaded path.
- *
- * Like @ref zxc_seek_read_block but safe to call concurrently: buffer mode uses
- * @c memcpy on const data, reader mode relies on a positioned (pread-style)
- * callback that carries its own offset.
- *
- * @param[in]  s          Seekable handle (read-only).
- * @param[in]  block_idx  Zero-based block index to read.
- * @param[out] buf        Destination buffer.
- * @param[in]  buf_cap    Capacity of @p buf in bytes.
- * @return The block's compressed byte count on success, or a negative
- *         @ref zxc_error_t.
- */
-static int zxc_seek_read_block_mt(const zxc_seekable* s, const uint32_t block_idx, uint8_t* buf,
-                                  const size_t buf_cap) {
-    const uint64_t off = s->comp_offsets[block_idx];
-    const uint32_t csz = s->comp_sizes[block_idx];
-    if (UNLIKELY(csz > buf_cap)) return ZXC_ERROR_DST_TOO_SMALL;
-
-    if (s->src) {
-        /* Buffer mode - memcpy is inherently thread-safe on const data */
-        if (UNLIKELY(off + csz > s->src_size)) return ZXC_ERROR_SRC_TOO_SMALL;
-        ZXC_MEMCPY(buf, s->src + off, csz);
-    } else if (s->reader.read_at) {
-        /* Reader callback - caller-supplied read_at must be thread-safe.
-         * The FILE* variant (zxc_seekable_file.c) installs a pread-backed
-         * callback that is naturally thread-safe. */
-        const int64_t r = s->reader.read_at(s->reader.ctx, buf, csz, off);
-        if (UNLIKELY(r != (int64_t)csz)) return (r < 0) ? (int)r : ZXC_ERROR_IO;
-    } else {
-        return ZXC_ERROR_NULL_INPUT;  // LCOV_EXCL_LINE
-    }
-    return (int)csz;
-}
 
 /**
  * @struct zxc_seek_mt_stripe_t
@@ -896,7 +608,7 @@ static void zxc_seek_mt_fail_stripe(zxc_seek_mt_stripe_t* st, const int code) {
  * Each job's outcome goes into its @c result (read by the main thread after
  * join); on error the worker abandons the rest of its stripe.
  *
- * @param[in,out] arg  Pointer to this worker's @ref zxc_seek_mt_stripe_t.
+ * @param[in,out] arg  Pointer to this worker's `zxc_seek_mt_stripe_t`.
  * @return Always NULL (result codes are reported via the jobs).
  */
 static void* zxc_seek_mt_worker(void* arg) {
@@ -904,7 +616,7 @@ static void* zxc_seek_mt_worker(void* arg) {
     zxc_seek_mt_job_t* const jobs = st->jobs;
     const zxc_seekable* const s = jobs[st->first].s;
 
-    /* Thread-local decompression context (mode=0 for decompress-only) */
+    // Thread-local decompression context (mode=0 for decompress-only)
     zxc_cctx_t dctx;
     if (UNLIKELY(zxc_cctx_init(&dctx, (size_t)s->block_size, 0, 0, 0, s->dict_size) != ZXC_OK)) {
         // LCOV_EXCL_START
@@ -925,7 +637,7 @@ static void* zxc_seek_mt_worker(void* arg) {
     uint8_t* const dict_work = dctx.dict_buffer;
     if (dict_work) ZXC_MEMCPY(dict_work, s->dict, s->dict_size);
 
-    /* Read buffer sized for the largest compressed block of the stripe. */
+    // Read buffer sized for the largest compressed block of the stripe.
     size_t max_csz = 0;
     for (uint32_t i = st->first; i < st->num_jobs; i += st->stride) {
         const uint32_t csz = s->comp_sizes[jobs[i].block_idx];
@@ -944,7 +656,7 @@ static void* zxc_seek_mt_worker(void* arg) {
         zxc_seek_mt_job_t* const job = &jobs[i];
 
         const int read_res =
-            zxc_seek_read_block_mt(s, job->block_idx, read_buf, max_csz + ZXC_PAD_SIZE);
+            zxc_seek_read_block(s, job->block_idx, read_buf, max_csz + ZXC_PAD_SIZE);
         if (UNLIKELY(read_res < 0)) {
             // LCOV_EXCL_START
             job->result = read_res;
@@ -952,7 +664,7 @@ static void* zxc_seek_mt_worker(void* arg) {
             // LCOV_EXCL_STOP
         }
 
-        /* Decompress: use dict bounce buffer when dictionary is active */
+        // Decompress: use dict bounce buffer when dictionary is active
         uint8_t* dec_dst = dict_work ? dict_work + s->dict_size : dctx.work_buf;
         const int dec_res =
             zxc_decompress_chunk_wrapper(&dctx, read_buf, (size_t)read_res, dec_dst, work_sz);
@@ -970,7 +682,7 @@ static void* zxc_seek_mt_worker(void* arg) {
             // LCOV_EXCL_STOP
         }
 
-        /* Copy the requested portion directly into the caller's output buffer */
+        // Copy the requested portion directly into the caller's output buffer
         ZXC_MEMCPY(job->dst, dec_dst + job->skip, job->copy_len);
         job->result = 0;
     }
@@ -987,14 +699,6 @@ static void* zxc_seek_mt_worker(void* arg) {
  * block (each with its own thread-local context and read buffer) and runs them
  * fork-join in waves of up to @p n_threads. Falls back to the single-threaded
  * path for trivial spans. @p n_threads == 0 auto-detects the core count.
- *
- * @param[in,out] s             Seekable handle (read-only during the parallel phase).
- * @param[out]    dst           Destination buffer.
- * @param[in]     dst_capacity  Capacity of @p dst (must be >= @p len).
- * @param[in]     offset        Absolute decompressed start offset.
- * @param[in]     len           Number of decompressed bytes to produce.
- * @param[in]     n_threads     Worker thread count; 0 = auto-detect.
- * @return @p len on success, or the first negative @ref zxc_error_t observed.
  */
 int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_t dst_capacity,
                                          const uint64_t offset, const size_t len, int n_threads) {
@@ -1005,29 +709,29 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
     if (UNLIKELY(s->expected_dict_id != 0 && (!s->dict || s->dict_size == 0)))
         return ZXC_ERROR_DICT_REQUIRED;
 
-    /* Find block range - O(1) division */
+    // Find block range - O(1) division
     const uint32_t blk_start = zxc_seek_find_block(s->block_size, offset);
     const uint32_t blk_end = zxc_seek_find_block(s->block_size, offset + len - 1);
     const uint32_t num_jobs = blk_end - blk_start + 1;
 
-    /* Auto-detect thread count (0 = use all available cores) */
-    if (n_threads == 0) n_threads = zxc_seek_get_num_procs();
+    // Auto-detect thread count (0 = use all available cores)
+    if (n_threads == 0) n_threads = zxc_num_procs();
 
-    /* Fallback to single-threaded path for trivial cases */
+    // Fallback to single-threaded path for trivial cases
     if (n_threads <= 1 || num_jobs <= 1) {
         return zxc_seekable_decompress_range(s, dst, dst_capacity, offset, len);
     }
 
-    /* Cap threads to number of blocks and max limit */
+    // Cap threads to number of blocks and max limit
     if ((uint32_t)n_threads > num_jobs) n_threads = (int)num_jobs;
     if (n_threads > ZXC_MAX_THREADS) n_threads = ZXC_MAX_THREADS;
 
-    /* Allocate job descriptors */
+    // Allocate job descriptors
     zxc_seek_mt_job_t* const jobs =
         (zxc_seek_mt_job_t*)ZXC_CALLOC(num_jobs, sizeof(zxc_seek_mt_job_t));
     if (UNLIKELY(!jobs)) return ZXC_ERROR_MEMORY;  // LCOV_EXCL_LINE
 
-    /* Plan jobs: compute skip, copy_len, and dst pointer for each block */
+    // Plan jobs: compute skip, copy_len, and dst pointer for each block
     uint8_t* out = (uint8_t*)dst;
     size_t remaining = len;
     for (uint32_t i = 0; i < num_jobs; i++) {
@@ -1055,9 +759,8 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
         remaining -= copy;
     }
 
-    /* Launch one persistent worker per thread */
-    zxc_thread_t* const threads =
-        (zxc_thread_t*)ZXC_MALLOC((size_t)n_threads * sizeof(zxc_thread_t));
+    // Launch one persistent worker per thread
+    pthread_t* const threads = (pthread_t*)ZXC_MALLOC((size_t)n_threads * sizeof(pthread_t));
     zxc_seek_mt_stripe_t* const stripes =
         (zxc_seek_mt_stripe_t*)ZXC_MALLOC((size_t)n_threads * sizeof(zxc_seek_mt_stripe_t));
     if (UNLIKELY(!threads || !stripes)) {
@@ -1075,10 +778,10 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
         stripes[t].num_jobs = num_jobs;
         stripes[t].first = (uint32_t)t;
         stripes[t].stride = (uint32_t)n_threads;
-        if (UNLIKELY(zxc_seek_thread_create(&threads[t], zxc_seek_mt_worker, &stripes[t]) != 0)) {
+        if (UNLIKELY(pthread_create(&threads[t], NULL, zxc_seek_mt_worker, &stripes[t]) != 0)) {
             // LCOV_EXCL_START
-            /* Failed to create thread - mark its stripe as errored; already
-             * launched workers keep running and are joined below. */
+            // Failed to create thread - mark its stripe as errored; already
+            // launched workers keep running and are joined below.
             zxc_seek_mt_fail_stripe(&stripes[t], ZXC_ERROR_MEMORY);
             continue;
             // LCOV_EXCL_STOP
@@ -1088,13 +791,13 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
         threads[launched - 1] = threads[t];
     }
 
-    /* Join phase */
-    for (int t = 0; t < launched; t++) zxc_seek_thread_join(threads[t]);
+    // Join phase
+    for (int t = 0; t < launched; t++) pthread_join(threads[t], NULL);
 
     ZXC_FREE(threads);
     ZXC_FREE(stripes);
 
-    /* Report the first error in job order, if any. */
+    // Report the first error in job order, if any.
     int64_t result = (int64_t)len;
     for (uint32_t i = 0; i < num_jobs; i++) {
         if (jobs[i].result < 0) {
@@ -1113,13 +816,12 @@ int64_t zxc_seekable_decompress_range_mt(zxc_seekable* s, void* dst, const size_
  * Public API; see @c zxc_seekable.h. Tears down the reusable context, the seek
  * arrays (comp sizes / offsets), the owned dictionary copy and any attached
  * reader context. NULL-safe.
- *
- * @param[in] s  Seekable handle to release (may be NULL).
  */
 void zxc_seekable_free(zxc_seekable* s) {
     if (UNLIKELY(!s)) return;
     if (s->dctx_initialized) zxc_cctx_free(&s->dctx);
     ZXC_FREE(s->dict);
+    ZXC_FREE(s->read_buf);
     ZXC_FREE(s->comp_sizes);
     ZXC_FREE(s->comp_offsets);
     ZXC_FREE(s->owned_reader_ctx);
@@ -1133,13 +835,6 @@ void zxc_seekable_free(zxc_seekable* s) {
  * the file header, then takes an owned copy of @p dict (and the optional shared
  * literal Huffman table @p dict_huf). Drops any context already built so the
  * [dict | decode] bounce buffer is re-carved on the next decompress.
- *
- * @param[in,out] s          Seekable handle.
- * @param[in]     dict       Dictionary bytes.
- * @param[in]     dict_size  Dictionary length (<= @c ZXC_DICT_SIZE_MAX).
- * @param[in]     dict_huf   Optional shared literal Huffman table, or NULL.
- * @return @ref ZXC_OK, or a negative @ref zxc_error_t
- *         (@ref ZXC_ERROR_DICT_TOO_LARGE, @ref ZXC_ERROR_DICT_MISMATCH, ...).
  */
 int zxc_seekable_set_dict(zxc_seekable* s, const void* dict, const size_t dict_size,
                           const void* dict_huf) {
@@ -1163,9 +858,9 @@ int zxc_seekable_set_dict(zxc_seekable* s, const void* dict, const size_t dict_s
         s->has_dict_huf = 1;
     }
 
-    /* The [dict | decode] bounce buffer is carved into the dctx workspace.
-     * Drop any context built without it (or for a different dict size) so it is
-     * re-carved with the new dict on the next decompress. */
+    // The [dict | decode] bounce buffer is carved into the dctx workspace.
+    // Drop any context built without it (or for a different dict size) so it is
+    // re-carved with the new dict on the next decompress.
     if (s->dctx_initialized) {
         zxc_cctx_free(&s->dctx);
         s->dctx_initialized = 0;
@@ -1180,9 +875,6 @@ int zxc_seekable_set_dict(zxc_seekable* s, const void* dict, const size_t dict_s
  * @c ZXC_FREE when @ref zxc_seekable_free runs. Used by
  * @ref zxc_seekable_open_file so its allocated reader state outlives the open
  * call. NULL-safe on @p s.
- *
- * @param[in,out] s    Seekable handle (may be NULL).
- * @param[in]     ctx  Heap pointer to hand over; freed by @ref zxc_seekable_free.
  */
 void zxc_seekable_attach_owned_ctx(zxc_seekable* s, void* ctx) {
     if (s) s->owned_reader_ctx = ctx;

--- a/lz/zxc/src/lib/zxc_threads.h
+++ b/lz/zxc/src/lib/zxc_threads.h
@@ -1,0 +1,142 @@
+/*
+ * ZXC - High-performance lossless compression
+ *
+ * Copyright (c) 2025-2026 Bertrand Lebonnois and contributors.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file zxc_threads.h
+ * @brief POSIX-shaped threading layer shared by the stream engine
+ *        (zxc_driver.c) and the seekable reader (zxc_seekable.c).
+ *
+ * On POSIX this is @c <pthread.h> verbatim. On Windows it maps the handful of
+ * primitives both engines use onto the Win32 API under their POSIX names, so
+ * one body of threading logic compiles everywhere. Include this instead of
+ * @c <pthread.h>.
+ */
+
+#ifndef ZXC_THREADS_H
+#define ZXC_THREADS_H
+
+#include "zxc_internal.h"
+
+// LCOV_EXCL_START - Windows platform layer, not reachable on POSIX CI
+#if defined(_WIN32)
+
+#include <process.h> /* _beginthreadex */
+#include <windows.h>
+
+typedef CRITICAL_SECTION pthread_mutex_t;
+typedef CONDITION_VARIABLE pthread_cond_t;
+typedef HANDLE pthread_t;
+
+#define pthread_mutex_init(m, a) InitializeCriticalSection(m)
+#define pthread_mutex_destroy(m) DeleteCriticalSection(m)
+#define pthread_mutex_lock(m) EnterCriticalSection(m)
+#define pthread_mutex_unlock(m) LeaveCriticalSection(m)
+
+#define pthread_cond_init(c, a) InitializeConditionVariable(c)
+#define pthread_cond_destroy(c) (void)(0)
+#define pthread_cond_wait(c, m) SleepConditionVariableCS(c, m, INFINITE)
+#define pthread_cond_signal(c) WakeConditionVariable(c)
+#define pthread_cond_broadcast(c) WakeAllConditionVariable(c)
+
+/**
+ * @brief Trampoline payload bridging the POSIX @c void*(*)(void*) worker
+ *        signature to the @c _beginthreadex entry point.
+ *
+ * Heap-allocated by the @c pthread_create shim and freed by
+ * @ref zxc_win_thread_entry once the captured worker has started.
+ */
+typedef struct {
+    void* (*func)(void*); /* worker to invoke */
+    void* arg;            /* argument forwarded to @c func */
+} zxc_win_thread_arg_t;
+
+/**
+ * @brief @c _beginthreadex entry point: unpacks the trampoline payload, frees
+ *        it, then runs the captured POSIX-style worker.
+ *
+ * @param[in] p  Heap @ref zxc_win_thread_arg_t handed over by the creator;
+ *               ownership transfers to this function.
+ * @return Always 0 (the worker's @c void* result is discarded, as on POSIX).
+ */
+static inline unsigned __stdcall zxc_win_thread_entry(void* p) {
+    zxc_win_thread_arg_t* a = (zxc_win_thread_arg_t*)p;
+    void* (*f)(void*) = a->func;
+    void* arg = a->arg;
+    ZXC_FREE(a);
+    f(arg);
+    return 0;
+}
+
+/**
+ * @brief @c pthread_create shim: spawns @p start_routine(@p arg) via
+ *        @c _beginthreadex, matching the POSIX prototype.
+ *
+ * @param[out] thread        Receives the thread handle on success.
+ * @param[in]  attr          Unused (POSIX attribute object); ignored.
+ * @param[in]  start_routine Worker to run on the new thread.
+ * @param[in]  arg           Opaque argument forwarded to @p start_routine.
+ * @return 0 on success, @ref ZXC_ERROR_MEMORY on allocation or spawn failure.
+ */
+static inline int pthread_create(pthread_t* thread, const void* attr, void* (*start_routine)(void*),
+                                 void* arg) {
+    (void)attr;
+    zxc_win_thread_arg_t* wrapper = ZXC_MALLOC(sizeof(zxc_win_thread_arg_t));
+    if (UNLIKELY(!wrapper)) return ZXC_ERROR_MEMORY;
+    wrapper->func = start_routine;
+    wrapper->arg = arg;
+    uintptr_t handle = _beginthreadex(NULL, 0, zxc_win_thread_entry, wrapper, 0, NULL);
+    if (UNLIKELY(handle == 0)) {
+        ZXC_FREE(wrapper);
+        return ZXC_ERROR_MEMORY;
+    }
+    *thread = (HANDLE)handle;
+    return 0;
+}
+
+/**
+ * @brief @c pthread_join shim: blocks until @p thread finishes, then closes its
+ *        handle.
+ *
+ * @param[in] thread  Handle from a successful @c pthread_create.
+ * @param[in] retval  Unused (POSIX exit-value out-param); ignored.
+ * @return Always 0.
+ */
+static inline int pthread_join(pthread_t thread, void** retval) {
+    (void)retval;
+    WaitForSingleObject(thread, INFINITE);
+    CloseHandle(thread);
+    return 0;
+}
+
+/**
+ * @brief Returns the number of logical processors reported by the OS.
+ * @return Processor count from @c GetSystemInfo (always >= 1 in practice).
+ */
+static ZXC_ALWAYS_INLINE int zxc_num_procs(void) {
+    SYSTEM_INFO si;
+    GetSystemInfo(&si);
+    return (int)si.dwNumberOfProcessors;
+}
+
+#else /* POSIX */
+// LCOV_EXCL_STOP
+
+#include <pthread.h>
+#include <unistd.h>
+
+/**
+ * @brief Returns the number of online logical processors.
+ * @return @c _SC_NPROCESSORS_ONLN, clamped to a minimum of 1 if the query fails.
+ */
+static ZXC_ALWAYS_INLINE int zxc_num_procs(void) {
+    const long n = sysconf(_SC_NPROCESSORS_ONLN);
+    return (n > 0) ? (int)n : 1;
+}
+
+#endif /* _WIN32 */
+
+#endif /* ZXC_THREADS_H */


### PR DESCRIPTION
Solid decompression speedup across all hardware architectures.

Decompression Benchmark Results (silesia.tar)
Levels -1/-2 & -6/-7: Consistent gains ranging from +2% to +10%.
Levels -3 to -5: up to +19% on ARM (M2/Neoverse-V2) and +11–13% on x86 (Zen 3/Zen 5).

