### PR TITLE
aceapex: fix double-free on empty compression streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ sources, the Notes column says so.
 
 | Compressor | Last update | Notes |
 | :--- | :--- | :--- |
-| [aceapex 1.0.1](https://github.com/yasha1971-coder/aceapex) | 2026-07-30 | |
+| [aceapex 1.0.1](https://github.com/yasha1971-coder/aceapex) | 2026-07-30 | Fixed in lzbench: double-free on empty compression streams |
 | [brieflz 1.3.0](https://github.com/jibsen/brieflz) | 2020-02-15 | |
 | [brotli 1.2.0](https://github.com/google/brotli) | 2025-10-27 | |
 | [bsc 3.3.12](https://github.com/IlyaGrebnov/libbsc) | 2025-09-10 | Disabled on 32-bit ARM — multithreaded decompress faults (SIGBUS, lzbench#293) |

--- a/lz/aceapex/aceapex_main.cpp
+++ b/lz/aceapex/aceapex_main.cpp
@@ -516,11 +516,12 @@ static bool encode_file(const uint8_t* src, size_t src_size, int threads, int le
         }
 
         // Realloc raw buffers to fit accumulated data
+        // Clamp realloc size to avoid realloc(ptr, 0) which would free and return NULL
         uint8_t* tmp;
-        tmp=(uint8_t*)realloc(raw_lit,total_lit); if(!tmp){free(results);free(wargs);free(pts);free(raw_lit);free(raw_off);free(raw_len);free(raw_cmd);return false;} raw_lit=tmp;
-        tmp=(uint8_t*)realloc(raw_off,total_off); if(!tmp){free(results);free(wargs);free(pts);free(raw_lit);free(raw_off);free(raw_len);free(raw_cmd);return false;} raw_off=tmp;
-        tmp=(uint8_t*)realloc(raw_len,total_len); if(!tmp){free(results);free(wargs);free(pts);free(raw_lit);free(raw_off);free(raw_len);free(raw_cmd);return false;} raw_len=tmp;
-        tmp=(uint8_t*)realloc(raw_cmd,total_cmd); if(!tmp){free(results);free(wargs);free(pts);free(raw_lit);free(raw_off);free(raw_len);free(raw_cmd);return false;} raw_cmd=tmp;
+        tmp=(uint8_t*)realloc(raw_lit,total_lit?total_lit:1); if(!tmp){free(results);free(wargs);free(pts);free(raw_lit);free(raw_off);free(raw_len);free(raw_cmd);return false;} raw_lit=tmp;
+        tmp=(uint8_t*)realloc(raw_off,total_off?total_off:1); if(!tmp){free(results);free(wargs);free(pts);free(raw_lit);free(raw_off);free(raw_len);free(raw_cmd);return false;} raw_off=tmp;
+        tmp=(uint8_t*)realloc(raw_len,total_len?total_len:1); if(!tmp){free(results);free(wargs);free(pts);free(raw_lit);free(raw_off);free(raw_len);free(raw_cmd);return false;} raw_len=tmp;
+        tmp=(uint8_t*)realloc(raw_cmd,total_cmd?total_cmd:1); if(!tmp){free(results);free(wargs);free(pts);free(raw_lit);free(raw_off);free(raw_len);free(raw_cmd);return false;} raw_cmd=tmp;
 
         // Copy batch results and free block buffers immediately
         size_t li=boffs[batch_start].lit_off;


### PR DESCRIPTION
realloc(ptr, 0) frees ptr and returns NULL in glibc. The code treated NULL as allocation failure and freed ptr again.

Fix: ensure size >= 1 before realloc.