### PR TITLE
Enable tornado on RISC-V with fast unaligned access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,21 @@ else
     endif
 
     ifneq (,$(filter riscv%,$(shell uname -m)))
-        DONT_BUILD_TORNADO ?= 1
-        MOREFLAGS += -mno-strict-align
+        # Detect fast unaligned access support using hwprobe syscall
+        RISCV_HAS_FAST_UNALIGNED := $(shell \
+            $(CC) $(SOURCE_PATH)check_riscv_fast_unaligned.c -o /tmp/check_riscv_unaligned 2>/dev/null && \
+            /tmp/check_riscv_unaligned 2>/dev/null && \
+            echo 1 || echo 0; \
+            rm -f /tmp/check_riscv_unaligned)
+
+        ifeq ($(RISCV_HAS_FAST_UNALIGNED),1)
+            $(info RISC-V: fast unaligned access detected)
+            DONT_BUILD_TORNADO ?= 0
+        else
+            $(info RISC-V: adding -mno-strict-align)
+            DONT_BUILD_TORNADO ?= 1
+            MOREFLAGS += -mno-strict-align
+        endif
     endif
 
     # some compressors use dlopen(), which requires linking with -ldl on glibc

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ sources, the Notes column says so.
 | [slz 1.2.2](http://www.libslz.org/) | 2026-04-09 | Compressor only; decompresses via zlib |
 | [snappy 1.2.2](https://github.com/google/snappy) | 2025-03-26 | Patched in lzbench: RISC-V support in `snappy-internal.h` |
 | [tamp 2.2.4](https://github.com/BrianPugh/tamp) | 2026-06-11 | |
-| [tornado 0.6a](https://encode.su/threads/231-FreeArc-compression-suite-%284x4-Tornado-REP-Delta-Dict-%29) | 2014-03-08 | Disabled on RISC-V (unaligned access) |
+| [tornado 0.6a](https://encode.su/threads/231-FreeArc-compression-suite-%284x4-Tornado-REP-Delta-Dict-%29) | 2014-03-08 | Auto-disabled on RISC-V without fast unaligned access support |
 | [ucl 1.03](http://www.oberhumer.com/opensource/ucl/) | 2004-07-20 | |
 | [xz 5.8.3](https://github.com/tukaani-project/xz) | 2026-03-31 | Built in lzbench with a hand-written `config.h` (upstream uses autotools) |
 | [yalz77 2022-07-06](https://github.com/ivan-tkatchev/yalz77) | 2022-07-06 | |

--- a/check_riscv_fast_unaligned.c
+++ b/check_riscv_fast_unaligned.c
@@ -1,0 +1,45 @@
+/* Check if RISC-V hardware supports fast unaligned memory access.
+ * Uses the hwprobe syscall (Linux 6.4+).
+ * Exit code 0: FAST unaligned access supported
+ * Exit code 1: Not FAST (slow/emulated/unsupported/unknown)
+ */
+
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#if defined(__riscv) && defined(__linux__)
+
+#ifdef __has_include
+#  if __has_include(<asm/hwprobe.h>)
+#    include <asm/hwprobe.h>
+#  else
+#    define MANUAL_DEFS
+#  endif
+#else
+#  include <asm/hwprobe.h>
+#endif
+
+#ifdef MANUAL_DEFS
+#define __NR_riscv_hwprobe 258
+struct riscv_hwprobe {
+    long long key;
+    unsigned long long value;
+};
+#define RISCV_HWPROBE_KEY_MISALIGNED_SCALAR_PERF 4
+#define RISCV_HWPROBE_MISALIGNED_FAST 3
+#endif
+
+int main(void) {
+    struct riscv_hwprobe pairs[] = {
+        { .key = RISCV_HWPROBE_KEY_MISALIGNED_SCALAR_PERF, },
+    };
+
+    if (syscall(__NR_riscv_hwprobe, pairs, 1, 0, (void*)0, 0) == 0) {
+        return (pairs[0].value == RISCV_HWPROBE_MISALIGNED_FAST) ? 0 : 1;
+    }
+    return 1;
+}
+
+#else
+int main(void) { return 1; }
+#endif

--- a/lz/tornado/Common.h
+++ b/lz/tornado/Common.h
@@ -15,7 +15,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#if defined(_M_X64) || defined(_M_AMD64) || defined(__x86_64__) || defined(_ARCH_PPC64) || defined(__arm64__) || defined(__aarch64__) || defined(__loongarch64)
+#if defined(_M_X64) || defined(_M_AMD64) || defined(__x86_64__) || defined(_ARCH_PPC64) || defined(__arm64__) || defined(__aarch64__) || defined(__loongarch64) || (defined(__riscv) && (__riscv_xlen == 64))
 #define FREEARC_64BIT
 #endif
 


### PR DESCRIPTION
Tornado is now automatically enabled on RISC-V platforms that support fast unaligned memory access (detected via hwprobe syscall on Linux). On RISC-V without fast unaligned access support, tornado is auto-disabled.

- Add RISC-V 64-bit architecture detection in tornado/Common.h
- Add compile-time detection tool (check_riscv_fast_unaligned.c)
- Auto-disable tornado in Makefile on RISC-V if fast unaligned access unsupported

Tested on SpacemiT K3 with fast unaligned access.